### PR TITLE
Only export the signing secrets that actually exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,29 +74,56 @@ jobs:
 
       - run: npm ci
 
+      # --- Code signing and notarization (both optional) -------------------
+      # Base64-encode the .p12 and store it as CSC_LINK; macOS and Windows read
+      # the same pair. Everything here is absent until a Developer ID exists.
+      #
+      # An absent secret does not leave its variable unset — GitHub Actions
+      # exports it as an empty string. electron-builder's macOS packager only
+      # null-checks CSC_LINK (its Windows one also rejects ""), so the empty
+      # string wins over every other source and is then resolved as a path
+      # relative to the project directory — which is a directory, not a file:
+      #
+      #   • empty password will be used  reason=CSC_KEY_PASSWORD is not defined
+      #   ⨯ /Users/runner/work/<repo>/<repo> not a file
+      #
+      # Exporting through $GITHUB_ENV instead lets the unset case stay unset.
+      # Note that a step-level `env:` would override these, so the build step
+      # below must not name them.
+      - name: Export the signing secrets that exist
+        shell: bash
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          for name in CSC_LINK CSC_KEY_PASSWORD APPLE_ID \
+                      APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
+            value="${!name}"
+            [ -n "$value" ] || continue
+            # Heredoc form: a base64 .p12 may legitimately contain newlines.
+            printf '%s<<CSC_VALUE_EOF\n%s\nCSC_VALUE_EOF\n' "$name" "$value" \
+              >> "$GITHUB_ENV"
+          done
+
+          # Without this, electron-builder hunts the runner keychain for any
+          # usable identity and fails confusingly when it finds none.
+          if [ -n "$CSC_LINK" ]; then
+            echo "CSC_IDENTITY_AUTO_DISCOVERY=true" >> "$GITHUB_ENV"
+          else
+            echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"
+          fi
+
+      # With no certificate the macOS build falls back to the ad-hoc signature
+      # from scripts/adhoc-sign.mjs, and notarization stays inert regardless
+      # while `notarize: false` is set in electron-builder.yml.
       - name: Build and publish
         env:
           # electron-builder uploads to the repo named in the `publish` block
           # of electron-builder.yml using this token.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # --- Code signing (optional) -------------------------------------
-          # macOS and Windows read the same pair. Base64-encode the .p12 and
-          # store it as CSC_LINK. Absent secrets resolve to an empty string,
-          # which electron-builder treats as "unsigned" rather than an error,
-          # so this workflow works before any certificate exists.
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-
-          # Without this, electron-builder hunts the runner keychain for any
-          # usable identity and fails confusingly when it finds none.
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.CSC_LINK != '' }}
-
-          # --- macOS notarization (optional) -------------------------------
-          # Inert until `notarize: true` is set in electron-builder.yml.
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run release
 
       # Kept for the unsigned-build era: if publishing fails, or a build is


### PR DESCRIPTION
The macOS job of the `v0.1.0` release run ([33613599321](https://github.com/klarluft/gitwarren-app/actions/runs/33613599321)) failed after 44s while Windows and Linux passed, so the draft release currently holds installers for two platforms out of three. The run itself reports green because the build matrix is `continue-on-error: true`.

```
• ad-hoc signed             release/0.1.0/mac-arm64/GitWarren.app
• empty password will be used for code signing  reason=CSC_KEY_PASSWORD is not defined
⨯ /Users/runner/work/gitwarren-app/gitwarren-app not a file
```

## Cause

An absent secret does not leave its variable unset — `${{ secrets.CSC_LINK }}` expands to an empty string, and the step's `env:` block exported it. So the runner had `CSC_LINK=""`, not "no `CSC_LINK`".

electron-builder reads it through `chooseNotNull`, which tests `== null` only, so `""` beat every other source:

```js
// platformPackager.js
function chooseNotNull(v1, v2) { return v1 == null ? v2 : v1 }
```

`macPackager` then guards on `cscLink == null` alone and went on to build a keychain from it. `loadCscLink("")` resolved the empty string as a path relative to the project directory, statted a directory, and reported it as not a file. `windowsSignToolManager` guards with `cscLink == null || cscLink === ""` — which is the only reason the Windows job survived the identical value.

## Fix

Route the secrets through `$GITHUB_ENV`, exporting each only when non-empty, so the unset case stays genuinely unset: `getCscLink()` returns null, signing is skipped, and the ad-hoc signature from `afterPack` survives untouched. The heredoc form is used because a base64 `.p12` may contain newlines, and the build step no longer names these variables because a step-level `env:` would take precedence over `$GITHUB_ENV`.

`CSC_IDENTITY_AUTO_DISCOVERY` keeps its old meaning, now derived in the shell. The `APPLE_*` trio is routed the same way — inert today under `notarize: false`, but the same trap is waiting there for whenever it is turned on.

## Verification

The export step was run locally against both branches:

| Secrets | `$GITHUB_ENV` contents |
| --- | --- |
| none configured | `CSC_IDENTITY_AUTO_DISCOVERY=false` only — no `CSC_LINK` at all |
| cert + team id | multi-line `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_TEAM_ID`, `CSC_IDENTITY_AUTO_DISCOVERY=true`; empty `APPLE_ID` omitted |

## Re-running the release

Merging this is not enough on its own — `v0.1.0` is already tagged and the draft is missing its macOS assets. After merge, re-run **Release** via `workflow_dispatch` with tag `v0.1.0`: the workflow definition comes from the selected branch while the checkout comes from the tag, so the fix applies without re-tagging. The `draft` job finds the existing release and leaves it alone, and the macOS job uploads into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5cdG7AJM6WvxFcC52STFz
