### PR TITLE
Turn on notarization and document the Developer ID setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,8 +120,10 @@ jobs:
           fi
 
       # With no certificate the macOS build falls back to the ad-hoc signature
-      # from scripts/adhoc-sign.mjs, and notarization stays inert regardless
-      # while `notarize: false` is set in electron-builder.yml.
+      # from scripts/adhoc-sign.mjs. `notarize: true` in electron-builder.yml
+      # is inert in that case — notarization is only attempted once a real
+      # signature has succeeded — and with a certificate but no APPLE_* secrets
+      # it logs `skipped macOS notarization` rather than failing the build.
       - name: Build and publish
         env:
           # electron-builder uploads to the repo named in the `publish` block

--- a/README.md
+++ b/README.md
@@ -895,12 +895,15 @@ that only the **Account Holder** can create one under an organization
 membership — a plain Admin cannot, and the certificate type simply will not
 appear in the list for them.
 
-With Xcode installed, *Settings → Accounts → Manage Certificates → + →
-Developer ID Application* does the whole thing. With only the Command Line
-Tools, generate the request by hand:
+Do this through the developer portal rather than through Xcode. Xcode's
+*Settings → Accounts → Manage Certificates* is fewer clicks, but it never asks
+which sub-CA to issue under and has been observed picking the legacy one — see
+*Check which sub-CA issued it* below, which is worth reading before you start
+rather than after.
 
 1. Open **Keychain Access → Certificate Assistant → Request a Certificate From
-   a Certificate Authority**.
+   a Certificate Authority**. (This works with only the Command Line Tools
+   installed; Xcode is not needed for any of it.)
 2. Enter your Apple ID email and a common name, leave *CA Email Address* empty,
    choose **Saved to disk** and tick **Let me specify key pair information**.
 3. Key size 2048 bits, algorithm RSA. Save the `.certSigningRequest`.
@@ -914,7 +917,7 @@ The private key never leaves your Mac — Apple only ever sees the request. That
 also means **Apple cannot re-issue this key if you lose it**, so export the
 `.p12` described under *CI secrets* below and keep a copy somewhere durable. An
 account is limited to five Developer ID Application certificates, and each is
-valid for five years.
+valid for five years when issued under the current sub-CA.
 
 Confirm the result:
 
@@ -927,6 +930,24 @@ security find-identity -v -p codesigning
 The parenthesised code is the **Team ID**. It is also on
 [developer.apple.com/account](https://developer.apple.com/account) under
 *Membership details*.
+
+**Check which sub-CA issued it.** Apple's original *Developer ID Certification
+Authority* intermediate expires on **1 February 2027**, and a leaf certificate
+cannot outlive its issuer — so a certificate issued under it is silently
+truncated to whatever remains of that date instead of running the full five
+years. The *G2 Sub-CA* exists to replace it:
+
+```bash
+security find-certificate -c "Developer ID Application" -p |
+  openssl x509 -noout -issuer -dates
+```
+
+An expiry of exactly `Feb  1 22:12:15 2027 GMT` means the legacy sub-CA issued
+it, whatever the portal appeared to offer. Create a fresh one under **G2
+Sub-CA** and revoke the short one — cheaply done before anything has shipped,
+and much less so afterwards, since revocation invalidates already-distributed
+builds. Note that an account is limited to five Developer ID Application
+certificates, so revoke rather than abandon the unwanted one.
 
 **2. Create an app-specific password for notarization.**
 

--- a/README.md
+++ b/README.md
@@ -944,10 +944,10 @@ security find-certificate -c "Developer ID Application" -p |
 
 An expiry of exactly `Feb  1 22:12:15 2027 GMT` means the legacy sub-CA issued
 it, whatever the portal appeared to offer. Create a fresh one under **G2
-Sub-CA** and revoke the short one — cheaply done before anything has shipped,
-and much less so afterwards, since revocation invalidates already-distributed
-builds. Note that an account is limited to five Developer ID Application
-certificates, so revoke rather than abandon the unwanted one.
+Sub-CA** and retire the short one as described below. Note that an account is
+limited to five Developer ID Application certificates and a retired one still
+occupies a slot until it expires, so it is worth getting this right rather than
+iterating.
 
 **If the new certificate shows up as invalid, the intermediate is missing.**
 macOS ships the original Developer ID intermediate but not necessarily the G2
@@ -972,11 +972,30 @@ security add-certificates -k ~/Library/Keychains/login.keychain-db DeveloperIDG2
 It grants no new trust — the intermediate is itself issued by Apple Root CA,
 which macOS already trusts. It only supplies the link needed to build the chain.
 
-**Do not leave both certificates in the keychain.** They have identical common
-names, and electron-builder resolves the identity by name and takes what it
-finds first — so a release would pick between them unpredictably. Once the
-replacement is confirmed working, revoke the old certificate in the portal and
-delete it, with its private key, from Keychain Access.
+**Do not leave both certificates in the keychain.** Their common names are
+identical, so `codesign` cannot tell them apart and refuses to guess:
+
+```
+Developer ID Application: ... : ambiguous (matches "Developer ID Application: ..."
+and "Developer ID Application: ..." in .../login.keychain-db)
+```
+
+That is a build failure, not a silent wrong choice — and pinning
+`mac.identity` to a SHA-1 hash does not avoid it, because electron-builder
+resolves the hash and then passes `codesign` the *name*. Once the replacement
+is confirmed working, delete the old certificate and its private key:
+
+```bash
+security delete-identity -Z <sha-1 of the old certificate> ~/Library/Keychains/login.keychain-db
+```
+
+**Retiring is all you can do — a Developer ID certificate cannot be revoked
+from the portal.** App Store certificates have a *Revoke* button; Developer ID
+certificates deliberately do not, because revocation invalidates every app ever
+signed with that certificate, timestamps included. It is reserved for a
+*compromised* private key and has to be arranged with Apple Product Security by
+email. Deleting the key you no longer want is not that situation: with the key
+gone the certificate cannot sign anything, and it simply expires on schedule.
 
 **2. Create an app-specific password for notarization.**
 

--- a/README.md
+++ b/README.md
@@ -875,39 +875,202 @@ They *are* required before distributing to anyone else — and specifically,
 **auto-update on macOS will not work unsigned**, because Squirrel.Mac validates
 the code signature of the downloaded build before swapping it in.
 
-**macOS.** Needs an Apple Developer account ($99/year), a *Developer ID
-Application* certificate in the login keychain, and an app-specific password (or
-App Store Connect API key) for notarization. Then set `notarize: true` in
-`electron-builder.yml` and provide:
+The hardened runtime is already enabled, with entitlements in
+`build/entitlements.mac.plist` covering what this app actually needs: JIT for
+V8, library validation disabled (the app spawns `git`, and agents spawn the
+bundled MCP server), and user-selected file access for repositories on any
+volume. `notarize: true` is set in `electron-builder.yml`, which stays inert
+until both a signature and Apple credentials exist — see *How the switches
+interact* below.
+
+### macOS: one-time setup
+
+Everything here happens once per developer account, not once per release. It
+needs a paid Apple Developer Program membership ($99/year).
+
+**1. Create the Developer ID Application certificate.**
+
+This is the certificate for apps distributed outside the Mac App Store. Note
+that only the **Account Holder** can create one under an organization
+membership — a plain Admin cannot, and the certificate type simply will not
+appear in the list for them.
+
+With Xcode installed, *Settings → Accounts → Manage Certificates → + →
+Developer ID Application* does the whole thing. With only the Command Line
+Tools, generate the request by hand:
+
+1. Open **Keychain Access → Certificate Assistant → Request a Certificate From
+   a Certificate Authority**.
+2. Enter your Apple ID email and a common name, leave *CA Email Address* empty,
+   choose **Saved to disk** and tick **Let me specify key pair information**.
+3. Key size 2048 bits, algorithm RSA. Save the `.certSigningRequest`.
+4. Go to [developer.apple.com/account/resources/certificates](https://developer.apple.com/account/resources/certificates),
+   press **+**, choose **Developer ID Application**, and upload the request.
+   Pick the *G2 Sub-CA* profile type when asked.
+5. Download the resulting `.cer` and double-click it to install into the login
+   keychain.
+
+The private key never leaves your Mac — Apple only ever sees the request. That
+also means **Apple cannot re-issue this key if you lose it**, so export the
+`.p12` described under *CI secrets* below and keep a copy somewhere durable. An
+account is limited to five Developer ID Application certificates, and each is
+valid for five years.
+
+Confirm the result:
+
+```bash
+security find-identity -v -p codesigning
+# 1) ABC123... "Developer ID Application: Klarluft B.V. (XXXXXXXXXX)"
+#    1 valid identities found
+```
+
+The parenthesised code is the **Team ID**. It is also on
+[developer.apple.com/account](https://developer.apple.com/account) under
+*Membership details*.
+
+**2. Create an app-specific password for notarization.**
+
+Notarization uploads the build to Apple and cannot use your ordinary password
+under two-factor auth. At [appleid.apple.com](https://appleid.apple.com) →
+*Sign-In and Security → App-Specific Passwords*, generate one and keep the
+`xxxx-xxxx-xxxx-xxxx` string.
+
+An App Store Connect API key works instead, via `APPLE_API_KEY`,
+`APPLE_API_KEY_ID` and `APPLE_API_ISSUER`. It is the better choice for a shared
+CI account, because it is scoped and revocable without touching a person's
+Apple ID; the app-specific password is fewer steps for a single developer.
+
+### Building a signed release locally
+
+electron-builder finds the certificate in the login keychain on its own.
+Notarization needs the credentials in the environment:
 
 ```bash
 export APPLE_ID="you@example.com"
 export APPLE_APP_SPECIFIC_PASSWORD="xxxx-xxxx-xxxx-xxxx"
 export APPLE_TEAM_ID="XXXXXXXXXX"
+
+npm run package
 ```
 
-The hardened runtime is already enabled, with entitlements in
-`build/entitlements.mac.plist` covering what this app actually needs: JIT for
-V8, library validation disabled (the app spawns `git`, and agents spawn the
-bundled MCP server), and user-selected file access for repositories on any
-volume.
+Storing the password in the keychain instead keeps it out of the shell history
+and out of a dotfile:
 
-**Windows.** Needs a code-signing certificate — since June 2023 an OV
-certificate must live on a hardware token or an HSM, so the practical options
-are a cloud signing service or an EV certificate. Configure it through
+```bash
+xcrun notarytool store-credentials gitwarren \
+  --apple-id "you@example.com" \
+  --team-id "XXXXXXXXXX" \
+  --password "xxxx-xxxx-xxxx-xxxx"
+
+export APPLE_KEYCHAIN_PROFILE=gitwarren
+npm run package
+```
+
+Expect the run to take noticeably longer than an unsigned one. Apple's
+notarization service usually answers within a few minutes, but it queues, and
+each architecture is submitted separately. The log lines to look for are
+`signing  file=release/.../GitWarren.app  identityName=Developer ID
+Application: ...`, then `notarization successful`. Stapling happens
+automatically after that, so the finished app validates on the user's machine
+without a network round-trip.
+
+### Verifying a signed build
+
+Worth doing once, on the first signed release, rather than discovering a
+problem from a user:
+
+```bash
+APP="release/0.1.0/mac-arm64/GitWarren.app"
+
+# The signature is intact and covers every nested binary.
+codesign --verify --deep --strict --verbose=2 "$APP"
+
+# Signed by the right authority, with the hardened runtime on.
+codesign -dv --verbose=4 "$APP" 2>&1 | grep -E 'Authority|TeamIdentifier|flags'
+# Authority=Developer ID Application: Klarluft B.V. (XXXXXXXXXX)
+# TeamIdentifier=XXXXXXXXXX
+# flags=0x10000(runtime)
+
+# The notarization ticket is stapled to the bundle.
+xcrun stapler validate "$APP"
+
+# What Gatekeeper will decide on the user's machine.
+spctl -a -vvv -t install "$APP"
+# source=Notarized Developer ID
+```
+
+`source=Notarized Developer ID` is the line that matters. Anything else — most
+often `source=Unnotarized Developer ID` — means the signature landed but the
+notarization did not, and the download will still be refused.
+
+### CI secrets
+
+The release workflow reads five optional secrets. Setting them switches the
+GitHub Actions build from ad-hoc to properly signed and notarized; leaving them
+unset keeps the existing unsigned behaviour.
+
+Export the certificate *with its private key* from Keychain Access — select the
+**Developer ID Application** entry under *My Certificates*, right-click →
+*Export*, choose **Personal Information Exchange (.p12)**, and set a password.
+Then:
+
+```bash
+base64 -i certificate.p12 | pbcopy   # this is CSC_LINK
+
+gh secret set CSC_LINK                    # base64 of the .p12
+gh secret set CSC_KEY_PASSWORD            # the .p12 export password
+gh secret set APPLE_ID                    # your Apple ID email
+gh secret set APPLE_APP_SPECIFIC_PASSWORD # xxxx-xxxx-xxxx-xxxx
+gh secret set APPLE_TEAM_ID               # XXXXXXXXXX
+```
+
+The same `CSC_LINK` / `CSC_KEY_PASSWORD` pair is what a Windows certificate
+would use, so adding one later does not introduce a second mechanism.
+
+The workflow deliberately exports these through `$GITHUB_ENV` rather than a
+step-level `env:` block. An absent secret is not an unset variable in GitHub
+Actions — it is an empty string, and electron-builder's macOS packager only
+null-checks `CSC_LINK`, so an empty one wins over every other source and is
+then resolved as a path relative to the project directory, failing with
+`⨯ /Users/runner/work/<repo>/<repo> not a file`. The loop in *Export the
+signing secrets that exist* skips empty values so the unset case stays unset.
+
+### How the switches interact
+
+Three independent things decide what a macOS build comes out as, which is why
+none of them has to be toggled per build:
+
+| Certificate | Apple credentials | Result |
+| --- | --- | --- |
+| absent | either way | ad-hoc signed by `scripts/adhoc-sign.mjs`, not notarized |
+| present | absent | signed, `skipped macOS notarization` warning, not notarized |
+| present | present | signed, notarized, stapled |
+
+Notarization is only attempted after a real signature succeeds, so `notarize:
+true` is harmless on a machine with no certificate — the code path is never
+reached. `scripts/adhoc-sign.mjs` stands down as soon as either `CSC_LINK` is
+set or a Developer ID identity is in the keychain, so it never fights with the
+real signature.
+
+### Windows
+
+Needs a code-signing certificate — since June 2023 an OV certificate must live
+on a hardware token or an HSM, so the practical options are a cloud signing
+service or an EV certificate. Configure it through
 `win.certificateFile`/`certificatePassword`, or a signing hook for a cloud
 provider. Without signing, SmartScreen warns users on first run; updates still
 work, since electron-updater verifies the sha512 from the manifest rather than
 a signature.
 
-**Linux.** AppImage needs no signing.
+### Linux
+
+AppImage needs no signing.
 
 ### Releasing before the certificates exist
 
 The release pipeline is complete without any of the above. Every signing secret
 is optional, so tagging a version today produces installers for all three
-platforms; adding the certificates later changes no workflow and no config
-beyond `notarize`.
+platforms; adding the certificates later changes no workflow and no config.
 
 What each platform costs while unsigned:
 

--- a/README.md
+++ b/README.md
@@ -949,6 +949,35 @@ and much less so afterwards, since revocation invalidates already-distributed
 builds. Note that an account is limited to five Developer ID Application
 certificates, so revoke rather than abandon the unwanted one.
 
+**If the new certificate shows up as invalid, the intermediate is missing.**
+macOS ships the original Developer ID intermediate but not necessarily the G2
+one, and a certificate whose chain cannot be completed is not counted as a
+valid identity — so `security find-identity -v` stays silent about it while
+`security find-identity` (no `-v`) lists it happily. That difference is the
+diagnosis:
+
+```bash
+security find-identity -p codesigning        # lists it
+security find-identity -v -p codesigning     # does not
+```
+
+Install the missing link from [Apple's certificate authority
+page](https://www.apple.com/certificateauthority/):
+
+```bash
+curl -O https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
+security add-certificates -k ~/Library/Keychains/login.keychain-db DeveloperIDG2CA.cer
+```
+
+It grants no new trust — the intermediate is itself issued by Apple Root CA,
+which macOS already trusts. It only supplies the link needed to build the chain.
+
+**Do not leave both certificates in the keychain.** They have identical common
+names, and electron-builder resolves the identity by name and takes what it
+finds first — so a release would pick between them unpredictably. Once the
+replacement is confirmed working, revoke the old certificate in the portal and
+delete it, with its private key, from Keychain Access.
+
 **2. Create an app-specific password for notarization.**
 
 Notarization uploads the build to Apple and cannot use your ordinary password

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -65,9 +65,14 @@ mac:
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
-  # Signing and notarisation are opt-in; see the README. Unsigned local builds
-  # are expected during development.
-  notarize: false
+  # Notarisation runs only after a real Developer ID signature succeeds, and
+  # only when Apple credentials are present in the environment (the APPLE_ID
+  # trio, an App Store Connect API key, or APPLE_KEYCHAIN_PROFILE). An unsigned
+  # local build never reaches it, and a signed build with no credentials logs
+  # `skipped macOS notarization` and carries on — so leaving this on costs
+  # nothing and stops a release shipping un-notarised by omission. See the
+  # README for the setup steps.
+  notarize: true
 
 dmg:
   artifactName: ${productName}-${version}-${arch}.${ext}

--- a/scripts/adhoc-sign.mjs
+++ b/scripts/adhoc-sign.mjs
@@ -21,17 +21,46 @@
  * substitute for a Developer ID — the app still cannot notarize and still
  * cannot auto-update.
  *
- * Skipped when CSC_LINK is set, since electron-builder is then about to sign
- * properly and would overwrite this anyway.
+ * Skipped whenever electron-builder is about to sign for real and would
+ * overwrite this anyway: CSC_LINK set (the CI path, a base64 .p12), or a
+ * Developer ID Application identity already in the keychain (the local path,
+ * after `npm run package` on a machine enrolled in the Developer Program).
  */
 import { execFileSync } from 'node:child_process'
 import { join } from 'node:path'
+
+/**
+ * True when the keychain holds a Developer ID Application identity that
+ * electron-builder will find on its own. Auto-discovery being off means it
+ * will not go looking, so the keychain does not matter in that case.
+ */
+function hasDeveloperIdIdentity() {
+  if (process.env.CSC_IDENTITY_AUTO_DISCOVERY === 'false') return false
+
+  try {
+    const identities = execFileSync('security', ['find-identity', '-v', '-p', 'codesigning'], {
+      encoding: 'utf8'
+    })
+    return identities.includes('Developer ID Application')
+  } catch {
+    // No keychain, or `security` unavailable — treat it as no identity and
+    // fall through to the ad-hoc signature.
+    return false
+  }
+}
 
 export default async function adhocSign(context) {
   if (context.electronPlatformName !== 'darwin') return
 
   if (process.env.CSC_LINK) {
     console.log('  • ad-hoc signing skipped   reason=CSC_LINK is set, real signing will run')
+    return
+  }
+
+  if (hasDeveloperIdIdentity()) {
+    console.log(
+      '  • ad-hoc signing skipped   reason=Developer ID in keychain, real signing will run'
+    )
     return
   }
 


### PR DESCRIPTION
Prompted by the Apple Developer Program enrolment — the release pipeline already accepted every signing secret, but nothing connected a membership to a signed, notarized build.

## `notarize: false` → `true`

As it stood, the first release built with a certificate would have been signed but **not** notarized, which Gatekeeper refuses exactly as it refuses an unsigned build — a failure that would only have shown up on a user's machine.

Leaving it on costs nothing, because notarization is reached only after a real signature succeeds:

| Certificate | Apple credentials | Result |
| --- | --- | --- |
| absent | either way | ad-hoc signed, not notarized (unchanged) |
| present | absent | signed, `skipped macOS notarization` warning |
| present | present | signed, notarized, stapled |

Verified by running `npm run package:dir` on a machine with no signing identity: the ad-hoc hook still runs, real signing is skipped for the usual reason, and the notarization code path is never entered.

## Ad-hoc hook stands down for a keychain identity

`scripts/adhoc-sign.mjs` only skipped itself when `CSC_LINK` was set — the CI path. A developer signing locally from the login keychain sets no such variable, so the hook would ad-hoc sign a bundle electron-builder was about to sign properly a moment later. It now also checks for a `Developer ID Application` identity, honouring `CSC_IDENTITY_AUTO_DISCOVERY=false`.

## README becomes a runbook

The section covered *what* signing needs without saying how to get any of it. It now walks through creating the Developer ID Application certificate via a Keychain Access CSR (no full Xcode needed), the app-specific password, building and verifying a signed release, and the five CI secrets — plus the `spctl` check whose `source=Notarized Developer ID` line is the one that actually predicts what a user's Mac will do.

The existing material on the unsigned era is kept; it stays true for contributors building without certificates.

## Still to do outside this PR

The certificate itself, and `gh secret set` for `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVDBAA8TYS1fiWntarAnX7
