### PR TITLE
Keep the Apple certificate away from the Windows runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,17 @@ jobs:
       - run: npm ci
 
       # --- Code signing and notarization (both optional) -------------------
-      # Base64-encode the .p12 and store it as CSC_LINK; macOS and Windows read
-      # the same pair. Everything here is absent until a Developer ID exists.
+      # CSC_LINK / CSC_KEY_PASSWORD are read by *both* the macOS and the
+      # Windows packager, so they must be filled per platform rather than
+      # exported globally. Handing every runner the same pair makes the
+      # Windows job try to Authenticode-sign an .exe with an Apple Developer
+      # ID certificate:
+      #
+      #   ⨯ Cannot extract publisher name from code signing certificate
+      #
+      # The Apple certificate therefore reaches macOS runners only, and
+      # Windows waits for its own certificate in WINDOWS_CSC_* secrets that do
+      # not exist yet — until they do, Windows builds unsigned as before.
       #
       # An absent secret does not leave its variable unset — GitHub Actions
       # exports it as an empty string. electron-builder's macOS packager only
@@ -96,28 +105,68 @@ jobs:
       - name: Export the signing secrets that exist
         shell: bash
         env:
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          MAC_CSC_LINK: ${{ secrets.CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
+          WINDOWS_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          for name in CSC_LINK CSC_KEY_PASSWORD APPLE_ID \
-                      APPLE_APP_SPECIFIC_PASSWORD APPLE_TEAM_ID; do
-            value="${!name}"
-            [ -n "$value" ] || continue
+          emit() {
             # Heredoc form: a base64 .p12 may legitimately contain newlines.
-            printf '%s<<CSC_VALUE_EOF\n%s\nCSC_VALUE_EOF\n' "$name" "$value" \
-              >> "$GITHUB_ENV"
-          done
+            [ -n "$2" ] || return 0
+            printf '%s<<CSC_VALUE_EOF\n%s\nCSC_VALUE_EOF\n' "$1" "$2" >> "$GITHUB_ENV"
+          }
 
-          # Without this, electron-builder hunts the runner keychain for any
-          # usable identity and fails confusingly when it finds none.
-          if [ -n "$CSC_LINK" ]; then
-            echo "CSC_IDENTITY_AUTO_DISCOVERY=true" >> "$GITHUB_ENV"
-          else
-            echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"
+          case "$RUNNER_OS" in
+            macOS)
+              emit CSC_LINK "$MAC_CSC_LINK"
+              emit CSC_KEY_PASSWORD "$MAC_CSC_KEY_PASSWORD"
+              emit APPLE_ID "$APPLE_ID"
+              emit APPLE_APP_SPECIFIC_PASSWORD "$APPLE_APP_SPECIFIC_PASSWORD"
+              emit APPLE_TEAM_ID "$APPLE_TEAM_ID"
+
+              # Without this, electron-builder hunts the runner keychain for
+              # any usable identity and fails confusingly when it finds none.
+              if [ -n "$MAC_CSC_LINK" ]; then
+                echo "CSC_IDENTITY_AUTO_DISCOVERY=true" >> "$GITHUB_ENV"
+              else
+                echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"
+              fi
+              ;;
+            Windows)
+              emit CSC_LINK "$WINDOWS_CSC_LINK"
+              emit CSC_KEY_PASSWORD "$WINDOWS_CSC_KEY_PASSWORD"
+              ;;
+          esac
+
+      # electron-builder reaches the certificate several minutes into the run,
+      # after packaging, and reports a mismatch as a bare `MAC verification
+      # failed during PKCS12 import`. Checking here costs a second and names
+      # the actual cause, which is otherwise easy to misread as a bad
+      # certificate rather than a badly *stored* one — a base64 blob truncated
+      # while being pasted into a prompt looks identical to a wrong password.
+      - name: Check the certificate and its password agree
+        if: runner.os == 'macOS' && env.CSC_LINK != ''
+        shell: bash
+        run: |
+          if ! printf '%s' "$CSC_LINK" | base64 --decode > "$RUNNER_TEMP/csc.p12"; then
+            echo "::error::CSC_LINK is not valid base64. Set it from a file rather" \
+                 "than by pasting: base64 -i cert.p12 | gh secret set CSC_LINK"
+            exit 1
           fi
+
+          if ! openssl pkcs12 -in "$RUNNER_TEMP/csc.p12" -passin env:CSC_KEY_PASSWORD \
+               -noout 2>/dev/null; then
+            echo "::error::CSC_LINK and CSC_KEY_PASSWORD disagree. Either the password" \
+                 "is wrong, carries a trailing newline (use printf '%s', not echo), or" \
+                 "the base64 was truncated when the secret was set."
+            exit 1
+          fi
+
+          rm -f "$RUNNER_TEMP/csc.p12"
+          echo "Certificate opens with the stored password."
 
       # With no certificate the macOS build falls back to the ad-hoc signature
       # from scripts/adhoc-sign.mjs. `notarize: true` in electron-builder.yml

--- a/README.md
+++ b/README.md
@@ -1083,18 +1083,34 @@ Export the certificate *with its private key* from Keychain Access — select th
 *Export*, choose **Personal Information Exchange (.p12)**, and set a password.
 Then:
 
-```bash
-base64 -i certificate.p12 | pbcopy   # this is CSC_LINK
+**Pipe the values in; do not paste them.** A base64 `.p12` runs to several
+thousand characters, and many terminals silently truncate a paste of that size
+into an interactive prompt. The result is a secret that looks set and fails
+much later as `MAC verification failed during PKCS12 import (wrong password?)`
+— which reads as a password problem when the certificate is what got cut short.
 
-gh secret set CSC_LINK                    # base64 of the .p12
-gh secret set CSC_KEY_PASSWORD            # the .p12 export password
-gh secret set APPLE_ID                    # your Apple ID email
-gh secret set APPLE_APP_SPECIFIC_PASSWORD # xxxx-xxxx-xxxx-xxxx
-gh secret set APPLE_TEAM_ID               # XXXXXXXXXX
+```bash
+base64 -i certificate.p12 | gh secret set CSC_LINK
+printf '%s' 'the .p12 export password' | gh secret set CSC_KEY_PASSWORD
+printf '%s' 'you@example.com'          | gh secret set APPLE_ID
+printf '%s' 'xxxx-xxxx-xxxx-xxxx'      | gh secret set APPLE_APP_SPECIFIC_PASSWORD
+printf '%s' 'XXXXXXXXXX'               | gh secret set APPLE_TEAM_ID
 ```
 
-The same `CSC_LINK` / `CSC_KEY_PASSWORD` pair is what a Windows certificate
-would use, so adding one later does not introduce a second mechanism.
+`printf '%s'` rather than `echo`, because `gh` stores stdin verbatim and a
+trailing newline from `echo` becomes part of the password.
+
+The release workflow checks that `CSC_LINK` and `CSC_KEY_PASSWORD` agree before
+it builds anything, so a mistake here surfaces in seconds with a message naming
+the cause rather than several minutes in.
+
+**These are macOS-only.** `CSC_LINK` and `CSC_KEY_PASSWORD` are read by
+electron-builder's Windows packager too, so the workflow deliberately exports
+them on macOS runners alone — handed to a Windows runner, the same pair makes
+it try to Authenticode-sign an `.exe` with an Apple Developer ID certificate
+and fail with `Cannot extract publisher name from code signing certificate`. A
+Windows certificate, when there is one, goes in separate `WINDOWS_CSC_LINK` and
+`WINDOWS_CSC_KEY_PASSWORD` secrets, which the workflow already reads.
 
 The workflow deliberately exports these through `$GITHUB_ENV` rather than a
 step-level `env:` block. An absent secret is not an unset variable in GitHub

--- a/README.md
+++ b/README.md
@@ -1091,14 +1091,17 @@ much later as `MAC verification failed during PKCS12 import (wrong password?)`
 
 ```bash
 base64 -i certificate.p12 | gh secret set CSC_LINK
-printf '%s' 'the .p12 export password' | gh secret set CSC_KEY_PASSWORD
-printf '%s' 'you@example.com'          | gh secret set APPLE_ID
-printf '%s' 'xxxx-xxxx-xxxx-xxxx'      | gh secret set APPLE_APP_SPECIFIC_PASSWORD
-printf '%s' 'XXXXXXXXXX'               | gh secret set APPLE_TEAM_ID
+
+# Short enough to paste safely; the prompt also keeps them out of shell history.
+gh secret set CSC_KEY_PASSWORD            # the .p12 export password
+gh secret set APPLE_ID                    # you@example.com
+gh secret set APPLE_APP_SPECIFIC_PASSWORD # xxxx-xxxx-xxxx-xxxx
+gh secret set APPLE_TEAM_ID               # XXXXXXXXXX
 ```
 
-`printf '%s'` rather than `echo`, because `gh` stores stdin verbatim and a
-trailing newline from `echo` becomes part of the password.
+Only the base64 needs piping — it is the one value long enough to be truncated.
+If you do pipe a short secret, use `printf '%s'` rather than `echo`: `gh` stores
+stdin verbatim, so `echo` puts a trailing newline inside the password.
 
 The release workflow checks that `CSC_LINK` and `CSC_KEY_PASSWORD` agree before
 it builds anything, so a mistake here surfaces in seconds with a message naming


### PR DESCRIPTION
The v0.1.1 release failed on macOS and Windows ([run 33732993007](https://github.com/klarluft/gitwarren-app/actions/runs/33732993007)). Two separate causes, one of which is a bug in the workflow.

## Windows was handed the Apple certificate

```
⨯ Cannot extract publisher name from code signing certificate
```

`CSC_LINK` / `CSC_KEY_PASSWORD` are read by electron-builder's **Windows** packager as well as its macOS one. Exporting them for every runner meant the Windows job tried to Authenticode-sign an `.exe` with a Developer ID Application certificate. Even with a valid password that is wrong — it would have signed Windows binaries with an Apple certificate.

They now reach macOS runners only. A Windows certificate, when there is one, goes in `WINDOWS_CSC_LINK` / `WINDOWS_CSC_KEY_PASSWORD`, which the workflow already reads; until those exist Windows builds unsigned exactly as before.

Verified by simulating the step for each runner OS:

| Runner | Exports |
| --- | --- |
| macOS | `CSC_LINK`, `CSC_KEY_PASSWORD`, the three `APPLE_*`, `CSC_IDENTITY_AUTO_DISCOVERY=true` |
| Windows | nothing (no `WINDOWS_CSC_*` secrets yet) |
| Linux | nothing |

## The stored certificate and password disagree

```
security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
```

That is a repository-secret problem, not a code one, so this PR cannot fix it — but it can stop it costing a release cycle to discover. A new preflight step opens the `.p12` with the stored password before packaging begins, so the failure arrives in seconds with a message naming the cause.

It matters because the two likely causes fail *identically*: a wrong password, and a `CSC_LINK` truncated when a 4,000-character base64 blob was pasted into an interactive prompt. The README now says to pipe values in rather than paste them, and to use `printf '%s'` rather than `echo` so a trailing newline doesn't end up inside the password.

Exercised against a throwaway certificate:

| Case | Result |
| --- | --- |
| correct password | passes |
| wrong password | fails, names the cause |
| truncated base64 | fails, names the cause |

## Before the next tag

`CSC_LINK` and `CSC_KEY_PASSWORD` need re-setting by pipe. The macOS signing chain itself is known good — a local build with this certificate notarizes and staples, and `spctl` reports `source=Notarized Developer ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVDBAA8TYS1fiWntarAnX7
