### PR TITLE
Store the signing certificate and its password as one verified unit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,11 +157,18 @@ jobs:
             exit 1
           fi
 
-          if ! openssl pkcs12 -in "$RUNNER_TEMP/csc.p12" -passin env:CSC_KEY_PASSWORD \
-               -noout 2>/dev/null; then
+          # /usr/bin/openssl, not whatever is on PATH: Keychain Access encrypts
+          # .p12 files with 40-bit RC2, which OpenSSL 3 refuses unless its
+          # legacy provider is loaded, reporting it indistinguishably from a
+          # wrong password. macOS ships LibreSSL here, which reads them and
+          # still rejects a genuinely wrong password.
+          if ! err=$(/usr/bin/openssl pkcs12 -in "$RUNNER_TEMP/csc.p12" \
+                       -passin env:CSC_KEY_PASSWORD -noout 2>&1); then
             echo "::error::CSC_LINK and CSC_KEY_PASSWORD disagree. Either the password" \
                  "is wrong, carries a trailing newline (use printf '%s', not echo), or" \
-                 "the base64 was truncated when the secret was set."
+                 "the base64 was truncated when the secret was set." \
+                 "Set both with scripts/set-signing-secrets.sh, which stores them as a" \
+                 "verified pair. openssl said: $err"
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -1089,19 +1089,31 @@ into an interactive prompt. The result is a secret that looks set and fails
 much later as `MAC verification failed during PKCS12 import (wrong password?)`
 — which reads as a password problem when the certificate is what got cut short.
 
-```bash
-base64 -i certificate.p12 | gh secret set CSC_LINK
+The certificate pair has to be stored as one verified unit, so
+[`scripts/set-signing-secrets.sh`](scripts/set-signing-secrets.sh) does it:
 
-# Short enough to paste safely; the prompt also keeps them out of shell history.
-gh secret set CSC_KEY_PASSWORD            # the .p12 export password
+```bash
+./scripts/set-signing-secrets.sh ~/Documents/certificate.p12
+```
+
+It prompts for the password without echoing it, refuses to store anything
+unless that password actually opens the `.p12` *and* a private key is inside,
+and then sets both secrets from exactly those bytes. The remaining three are
+short enough to paste at a prompt, which also keeps them out of shell history:
+
+```bash
 gh secret set APPLE_ID                    # you@example.com
 gh secret set APPLE_APP_SPECIFIC_PASSWORD # xxxx-xxxx-xxxx-xxxx
 gh secret set APPLE_TEAM_ID               # XXXXXXXXXX
 ```
 
-Only the base64 needs piping — it is the one value long enough to be truncated.
-If you do pipe a short secret, use `printf '%s'` rather than `echo`: `gh` stores
-stdin verbatim, so `echo` puts a trailing newline inside the password.
+Setting the pair by hand is where this goes wrong, in two ways that produce an
+identical error. A base64 `.p12` runs to several thousand characters and many
+terminals silently truncate a paste that long, and `echo "$pw" | gh secret set`
+stores the trailing newline as part of the password. Both surface much later as
+`MAC verification failed during PKCS12 import (wrong password?)`, which reads
+as a bad certificate rather than a badly stored one. If you do set them by
+hand, pipe the base64 from the file and use `printf '%s'` rather than `echo`.
 
 The release workflow checks that `CSC_LINK` and `CSC_KEY_PASSWORD` agree before
 it builds anything, so a mistake here surfaces in seconds with a message naming

--- a/scripts/set-signing-secrets.sh
+++ b/scripts/set-signing-secrets.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Verifies a .p12 against a password, then stores both as repo secrets from
+# those exact bytes. Works in bash and zsh; the password is never echoed, never
+# on the command line, and so never in shell history.
+#
+# Usage: bash set-signing-secrets.sh ~/Documents/Certificates2.p12
+set -u
+
+P12="${1:?usage: set-signing-secrets.sh <path to .p12>}"
+[ -f "$P12" ] || { echo "No such file: $P12" >&2; exit 1; }
+
+printf 'Password for %s: ' "$(basename "$P12")"
+read -rs PW
+echo
+
+# env: reads the environment, so PW has to be exported, not just set.
+export PW
+if ! openssl pkcs12 -in "$P12" -passin env:PW -noout 2>/dev/null; then
+  echo "✗ That password does not open this .p12. Nothing was changed." >&2
+  exit 1
+fi
+echo "✓ Password opens the certificate (${#PW} characters)."
+
+# The private key must be in there, or CI signs nothing.
+if ! openssl pkcs12 -in "$P12" -passin env:PW -nocerts -nodes 2>/dev/null |
+     grep -q 'PRIVATE KEY'; then
+  echo "✗ No private key in this .p12 — re-export from 'My Certificates'." >&2
+  exit 1
+fi
+echo "✓ Private key present."
+
+base64 -i "$P12" | gh secret set CSC_LINK
+echo "✓ CSC_LINK set ($(base64 -i "$P12" | wc -c | tr -d ' ') base64 characters)."
+
+# printf, not echo: gh stores stdin verbatim and a newline would land inside
+# the password.
+printf '%s' "$PW" | gh secret set CSC_KEY_PASSWORD
+echo "✓ CSC_KEY_PASSWORD set from the same bytes that just verified."
+
+unset PW
+echo
+echo "Both secrets now come from one verified pair."

--- a/scripts/set-signing-secrets.sh
+++ b/scripts/set-signing-secrets.sh
@@ -9,20 +9,32 @@ set -u
 P12="${1:?usage: set-signing-secrets.sh <path to .p12>}"
 [ -f "$P12" ] || { echo "No such file: $P12" >&2; exit 1; }
 
+# Keychain Access writes .p12 files encrypted with 40-bit RC2, which OpenSSL 3
+# moved to its legacy provider and so refuses by default:
+#
+#   Algorithm (RC2-40-CBC : 0), Properties () — unsupported
+#
+# It surfaces as `Error outputting keys and certificates`, indistinguishable
+# from a wrong password. macOS ships LibreSSL at /usr/bin/openssl, which reads
+# these files and still rejects a genuinely wrong password, so prefer it over
+# whatever a Homebrew or conda install has put earlier on PATH.
+OPENSSL=/usr/bin/openssl
+[ -x "$OPENSSL" ] || OPENSSL=openssl
+
 printf 'Password for %s: ' "$(basename "$P12")"
 read -rs PW
 echo
 
 # env: reads the environment, so PW has to be exported, not just set.
 export PW
-if ! openssl pkcs12 -in "$P12" -passin env:PW -noout 2>/dev/null; then
+if ! "$OPENSSL" pkcs12 -in "$P12" -passin env:PW -noout 2>/dev/null; then
   echo "✗ That password does not open this .p12. Nothing was changed." >&2
   exit 1
 fi
 echo "✓ Password opens the certificate (${#PW} characters)."
 
 # The private key must be in there, or CI signs nothing.
-if ! openssl pkcs12 -in "$P12" -passin env:PW -nocerts -nodes 2>/dev/null |
+if ! "$OPENSSL" pkcs12 -in "$P12" -passin env:PW -nocerts -nodes 2>/dev/null |
      grep -q 'PRIVATE KEY'; then
   echo "✗ No private key in this .p12 — re-export from 'My Certificates'." >&2
   exit 1


### PR DESCRIPTION
Setting `CSC_LINK` and `CSC_KEY_PASSWORD` by hand has now failed twice on this repo, both times looking like a certificate problem when it was a storage problem.

The two ways it goes wrong are invisible and produce the identical error:

- a base64 `.p12` runs to several thousand characters, and many terminals silently truncate a paste that long into an interactive prompt
- `echo "$pw" | gh secret set` stores the trailing newline as part of the password

Both surface minutes later, inside electron-builder, as:

```
security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
```

which reads as *bad certificate* rather than *badly stored certificate*.

## What the script does

```bash
./scripts/set-signing-secrets.sh ~/Documents/certificate.p12
```

- prompts for the password without echoing it, so it never reaches the command line or shell history
- refuses to store anything unless that password actually opens the `.p12`
- refuses unless a **private key** is inside — a certificate exported from Keychain Access's *Certificates* category instead of *My Certificates* has none, and signs nothing
- sets both secrets from exactly the bytes that just verified, using `printf '%s'` so no newline creeps in

Tested against a throwaway certificate, with `gh` stubbed to report byte counts:

| Case | Result |
| --- | --- |
| correct password, key present | stores both; password stored as exactly its own length in bytes |
| wrong password | refuses, stores nothing |
| certificate without private key | refuses, stores nothing |

That third case caught a real bug in the first draft of the check, which had used `-nocerts -noout` and passed a key-less `.p12`.

Syntax-checked under both `bash -n` and `zsh -n`, since the repo's shell is zsh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVDBAA8TYS1fiWntarAnX7
