### PR TITLE
Link gitwarren.com from the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 # GitWarren
 
+**[gitwarren.com](https://gitwarren.com)** — the official site, with downloads for
+macOS, Windows and Linux.
+
 A cross-platform desktop app for doing local code reviews of your own git
 repositories. Single user, single machine, no server, no account.
 


### PR DESCRIPTION
The README never mentioned the landing page, so someone arriving at the repository had no pointer to the place that actually hands out installers.

Adds a two-line pointer directly under the title:

```
**[gitwarren.com](https://gitwarren.com)** — the official site, with downloads for
macOS, Windows and Linux.
```

The platform list matches the artifacts in the README's own *What gets produced* table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Uk5XaAzNMeQs6wNDJtGwb