### PR TITLE
Give the macOS signing keychain its own password

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,25 +75,36 @@ jobs:
       - run: npm ci
 
       # --- Code signing and notarization (both optional) -------------------
-      # CSC_LINK / CSC_KEY_PASSWORD are read by *both* the macOS and the
-      # Windows packager, so they must be filled per platform rather than
-      # exported globally. Handing every runner the same pair makes the
-      # Windows job try to Authenticode-sign an .exe with an Apple Developer
-      # ID certificate:
+      # Only the Windows certificate travels under CSC_LINK / CSC_KEY_PASSWORD.
+      # Handing a Windows runner the Apple .p12 makes it try to Authenticode-
+      # sign an .exe with a Developer ID certificate:
       #
       #   ⨯ Cannot extract publisher name from code signing certificate
       #
-      # The Apple certificate therefore reaches macOS runners only, and
-      # Windows waits for its own certificate in WINDOWS_CSC_* secrets that do
-      # not exist yet — until they do, Windows builds unsigned as before.
+      # macOS deliberately does *not* use them. Setting CSC_LINK there sends
+      # electron-builder down its own createKeychain path, which imports the
+      # certificate and then runs
+      #
+      #   security set-key-partition-list -S apple-tool:,apple: -s -k <pw>
+      #
+      # passing the *certificate* password to a flag that means the *keychain*
+      # password (app-builder-lib/out/codeSign/macCodeSign.js; the keychain's
+      # own password is a random value generated a few lines above and never
+      # reused here). macOS rejects it and the build dies minutes in with
+      #
+      #   security: SecKeychainUnlock: The user name or passphrase you entered
+      #   is not correct.
+      #
+      # which reads as a bad certificate even though the certificate is fine.
+      # Unchanged as of 26.16.0, so upgrading is not the fix. The step below
+      # therefore builds the keychain itself — passing the keychain password
+      # where it belongs — and hands electron-builder CSC_KEYCHAIN, which
+      # macPackager consults only when CSC_LINK is absent.
       #
       # An absent secret does not leave its variable unset — GitHub Actions
-      # exports it as an empty string. electron-builder's macOS packager only
-      # null-checks CSC_LINK (its Windows one also rejects ""), so the empty
-      # string wins over every other source and is then resolved as a path
-      # relative to the project directory — which is a directory, not a file:
+      # exports it as an empty string, and electron-builder's Windows packager
+      # resolves "" as a path relative to the project directory:
       #
-      #   • empty password will be used  reason=CSC_KEY_PASSWORD is not defined
       #   ⨯ /Users/runner/work/<repo>/<repo> not a file
       #
       # Exporting through $GITHUB_ENV instead lets the unset case stay unset.
@@ -102,8 +113,6 @@ jobs:
       - name: Export the signing secrets that exist
         shell: bash
         env:
-          MAC_CSC_LINK: ${{ secrets.CSC_LINK }}
-          MAC_CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           WINDOWS_CSC_LINK: ${{ secrets.WINDOWS_CSC_LINK }}
           WINDOWS_CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -118,19 +127,9 @@ jobs:
 
           case "$RUNNER_OS" in
             macOS)
-              emit CSC_LINK "$MAC_CSC_LINK"
-              emit CSC_KEY_PASSWORD "$MAC_CSC_KEY_PASSWORD"
               emit APPLE_ID "$APPLE_ID"
               emit APPLE_APP_SPECIFIC_PASSWORD "$APPLE_APP_SPECIFIC_PASSWORD"
               emit APPLE_TEAM_ID "$APPLE_TEAM_ID"
-
-              # Without this, electron-builder hunts the runner keychain for
-              # any usable identity and fails confusingly when it finds none.
-              if [ -n "$MAC_CSC_LINK" ]; then
-                echo "CSC_IDENTITY_AUTO_DISCOVERY=true" >> "$GITHUB_ENV"
-              else
-                echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"
-              fi
               ;;
             Windows)
               emit CSC_LINK "$WINDOWS_CSC_LINK"
@@ -138,17 +137,30 @@ jobs:
               ;;
           esac
 
-      # electron-builder reaches the certificate several minutes into the run,
-      # after packaging, and reports a mismatch as a bare `MAC verification
-      # failed during PKCS12 import`. Checking here costs a second and names
-      # the actual cause, which is otherwise easy to misread as a bad
-      # certificate rather than a badly *stored* one — a base64 blob truncated
-      # while being pasted into a prompt looks identical to a wrong password.
-      - name: Check the certificate and its password agree
-        if: runner.os == 'macOS' && env.CSC_LINK != ''
+      # Builds the signing keychain by hand, for the reason above. It also
+      # checks the certificate up front: electron-builder would otherwise
+      # reach it several minutes into the run and report a mismatch as a bare
+      # `MAC verification failed during PKCS12 import`, easy to misread as a
+      # bad certificate rather than a badly *stored* one — a base64 blob
+      # truncated while being pasted looks identical to a wrong password.
+      - name: Import the Apple certificate into a keychain
+        if: runner.os == 'macOS'
         shell: bash
+        env:
+          MAC_CSC_LINK: ${{ secrets.CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
-          if ! printf '%s' "$CSC_LINK" | base64 --decode > "$RUNNER_TEMP/csc.p12"; then
+          if [ -z "$MAC_CSC_LINK" ]; then
+            # No certificate: scripts/adhoc-sign.mjs takes over. Auto-discovery
+            # has to be off, or electron-builder hunts the runner keychain for
+            # an identity that is not there and fails confusingly.
+            echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"
+            echo "No Apple certificate configured; this build will be ad-hoc signed."
+            exit 0
+          fi
+
+          p12="$RUNNER_TEMP/csc.p12"
+          if ! printf '%s' "$MAC_CSC_LINK" | base64 --decode > "$p12"; then
             echo "::error::CSC_LINK is not valid base64. Set it from a file rather" \
                  "than by pasting: base64 -i cert.p12 | gh secret set CSC_LINK"
             exit 1
@@ -159,8 +171,8 @@ jobs:
           # legacy provider is loaded, reporting it indistinguishably from a
           # wrong password. macOS ships LibreSSL here, which reads them and
           # still rejects a genuinely wrong password.
-          if ! err=$(/usr/bin/openssl pkcs12 -in "$RUNNER_TEMP/csc.p12" \
-                       -passin env:CSC_KEY_PASSWORD -noout 2>&1); then
+          if ! err=$(/usr/bin/openssl pkcs12 -in "$p12" \
+                       -passin env:MAC_CSC_KEY_PASSWORD -noout 2>&1); then
             echo "::error::CSC_LINK and CSC_KEY_PASSWORD disagree. Either the password" \
                  "is wrong, carries a trailing newline (use printf '%s', not echo), or" \
                  "the base64 was truncated when the secret was set." \
@@ -169,8 +181,43 @@ jobs:
             exit 1
           fi
 
-          rm -f "$RUNNER_TEMP/csc.p12"
-          echo "Certificate opens with the stored password."
+          keychain="$RUNNER_TEMP/signing.keychain-db"
+          # Never printed, and thrown away with the runner.
+          keychain_password=$(/usr/bin/openssl rand -base64 24)
+
+          security create-keychain -p "$keychain_password" "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          # No auto-lock: the default five-minute timeout expires mid-build,
+          # and codesign against a locked keychain fails.
+          security set-keychain-settings "$keychain"
+          # codesign only searches the user's keychain list, so the temporary
+          # keychain has to join it — keeping whatever is already there.
+          security list-keychains -d user -s "$keychain" \
+            $(security list-keychains -d user | tr -d '"')
+
+          security import "$p12" -k "$keychain" -P "$MAC_CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild
+          # -k takes the *keychain* password, which is the whole point of this
+          # step. Without the partition list every codesign call blocks on a
+          # UI prompt that no one is there to answer.
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$keychain_password" "$keychain" > /dev/null
+
+          rm -f "$p12"
+
+          if ! security find-identity -v -p codesigning "$keychain" \
+               | grep -q "Developer ID Application"; then
+            echo "::error::The certificate imported but carries no Developer ID" \
+                 "Application identity. An Apple Development or Mac Development" \
+                 "certificate cannot sign a distributed build."
+            exit 1
+          fi
+
+          # electron-builder reads this only when CSC_LINK is unset, which is
+          # exactly why CSC_LINK is not exported on macOS.
+          echo "CSC_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+          echo "CSC_IDENTITY_AUTO_DISCOVERY=true" >> "$GITHUB_ENV"
+          security find-identity -v -p codesigning "$keychain"
 
       # With no certificate the macOS build falls back to the ad-hoc signature
       # from scripts/adhoc-sign.mjs. `notarize: true` in electron-builder.yml

--- a/README.md
+++ b/README.md
@@ -1124,23 +1124,50 @@ hand, pipe the base64 from the file and use `printf '%s'` rather than `echo`.
 
 The release workflow checks that `CSC_LINK` and `CSC_KEY_PASSWORD` agree before
 it builds anything, so a mistake here surfaces in seconds with a message naming
-the cause rather than several minutes in.
+the cause rather than several minutes in. The secret names are unchanged, and
+`scripts/set-signing-secrets.sh` still sets them.
 
-**These are macOS-only.** `CSC_LINK` and `CSC_KEY_PASSWORD` are read by
-electron-builder's Windows packager too, so the workflow deliberately exports
-them on macOS runners alone — handed to a Windows runner, the same pair makes
-it try to Authenticode-sign an `.exe` with an Apple Developer ID certificate
-and fail with `Cannot extract publisher name from code signing certificate`. A
-Windows certificate, when there is one, goes in separate `WINDOWS_CSC_LINK` and
-`WINDOWS_CSC_KEY_PASSWORD` secrets, which the workflow already reads.
+**The Apple certificate never reaches a Windows runner.** electron-builder's
+Windows packager reads `CSC_LINK` and `CSC_KEY_PASSWORD` too, and handed the
+Apple pair it tries to Authenticode-sign an `.exe` with a Developer ID
+certificate, failing with `Cannot extract publisher name from code signing
+certificate`. A Windows certificate, when there is one, goes in separate
+`WINDOWS_CSC_LINK` and `WINDOWS_CSC_KEY_PASSWORD` secrets, which the workflow
+already reads.
 
-The workflow deliberately exports these through `$GITHUB_ENV` rather than a
-step-level `env:` block. An absent secret is not an unset variable in GitHub
-Actions — it is an empty string, and electron-builder's macOS packager only
-null-checks `CSC_LINK`, so an empty one wins over every other source and is
-then resolved as a path relative to the project directory, failing with
-`⨯ /Users/runner/work/<repo>/<repo> not a file`. The loop in *Export the
-signing secrets that exist* skips empty values so the unset case stays unset.
+**On macOS the workflow builds the keychain itself** and never exports
+`CSC_LINK`. Setting it would send electron-builder down its own
+`createKeychain` path, which imports the certificate and then runs
+
+```
+security set-key-partition-list -S apple-tool:,apple: -s -k <password>
+```
+
+passing the *certificate* password to a flag that means the *keychain*
+password — the keychain's own password is a random value generated a few lines
+earlier in `app-builder-lib/out/codeSign/macCodeSign.js` and never reused
+there. macOS rejects it and the build dies several minutes in with
+
+```
+security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
+```
+
+which reads as a bad certificate even when the certificate is perfectly good.
+It is unchanged as of electron-builder 26.16.0, so upgrading is not the fix.
+The *Import the Apple certificate into a keychain* step therefore creates,
+unlocks and populates a temporary keychain itself — passing the keychain
+password where it belongs — verifies a Developer ID Application identity
+actually landed in it, and hands electron-builder `CSC_KEYCHAIN`, which
+`macPackager` consults only when `CSC_LINK` is absent. That step also does the
+`CSC_LINK`/`CSC_KEY_PASSWORD` agreement check, so a badly stored secret still
+surfaces in seconds rather than several minutes in.
+
+The Windows secrets go through `$GITHUB_ENV` rather than a step-level `env:`
+block. An absent secret is not an unset variable in GitHub Actions — it is an
+empty string, which electron-builder resolves as a path relative to the project
+directory, failing with `⨯ /Users/runner/work/<repo>/<repo> not a file`. The
+loop in *Export the signing secrets that exist* skips empty values so the unset
+case stays unset.
 
 ### How the switches interact
 
@@ -1155,9 +1182,9 @@ none of them has to be toggled per build:
 
 Notarization is only attempted after a real signature succeeds, so `notarize:
 true` is harmless on a machine with no certificate — the code path is never
-reached. `scripts/adhoc-sign.mjs` stands down as soon as either `CSC_LINK` is
-set or a Developer ID identity is in the keychain, so it never fights with the
-real signature.
+reached. `scripts/adhoc-sign.mjs` stands down as soon as `CSC_KEYCHAIN` or
+`CSC_LINK` is set, or a Developer ID identity is in the keychain, so it never
+fights with the real signature.
 
 ### Windows
 

--- a/scripts/adhoc-sign.mjs
+++ b/scripts/adhoc-sign.mjs
@@ -22,7 +22,10 @@
  * cannot auto-update.
  *
  * Skipped whenever electron-builder is about to sign for real and would
- * overwrite this anyway: CSC_LINK set (the CI path, a base64 .p12), or a
+ * overwrite this anyway: CSC_KEYCHAIN set (the CI path — the release workflow
+ * imports the .p12 into a keychain of its own rather than letting
+ * electron-builder do it, see the comment there), CSC_LINK set (the same on
+ * Windows, and still honoured on macOS for anyone signing by hand), or a
  * Developer ID Application identity already in the keychain (the local path,
  * after `npm run package` on a machine enrolled in the Developer Program).
  */
@@ -37,8 +40,14 @@ import { join } from 'node:path'
 function hasDeveloperIdIdentity() {
   if (process.env.CSC_IDENTITY_AUTO_DISCOVERY === 'false') return false
 
+  // CSC_KEYCHAIN names a keychain that may not be in the default search list,
+  // so ask about it directly rather than trusting the list to include it.
+  const keychain = process.env.CSC_KEYCHAIN
+  const args = ['find-identity', '-v', '-p', 'codesigning']
+  if (keychain) args.push(keychain)
+
   try {
-    const identities = execFileSync('security', ['find-identity', '-v', '-p', 'codesigning'], {
+    const identities = execFileSync('security', args, {
       encoding: 'utf8'
     })
     return identities.includes('Developer ID Application')
@@ -51,6 +60,11 @@ function hasDeveloperIdIdentity() {
 
 export default async function adhocSign(context) {
   if (context.electronPlatformName !== 'darwin') return
+
+  if (process.env.CSC_KEYCHAIN) {
+    console.log('  • ad-hoc signing skipped   reason=CSC_KEYCHAIN is set, real signing will run')
+    return
+  }
 
   if (process.env.CSC_LINK) {
     console.log('  • ad-hoc signing skipped   reason=CSC_LINK is set, real signing will run')


### PR DESCRIPTION
v0.1.2 shipped no macOS artifacts. The mac job failed a minute in — invisible on the run page, because the build matrix sets `continue-on-error: true`.

```
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

The certificate is fine. The same password opened the `.p12` in the verification step and again in `security import` immediately before.

**Cause.** Setting `CSC_LINK` sends electron-builder down its own `createKeychain` path. That creates a keychain with a random password, imports the certificate, then runs `set-key-partition-list` with the **certificate** password in `-k` — a flag that means the **keychain** password (`app-builder-lib/out/codeSign/macCodeSign.js`). The two are never equal, so the unlock always fails once that path is entered. Identical in 26.16.0, so upgrading is not the fix.

That is why v0.1.0 and v0.1.1 built fine: no certificate, `CSC_LINK` unset, path never entered. Adding the Developer ID secrets is what broke the mac build.

**Fix.** Build the keychain in the workflow, passing the keychain password where it belongs, and hand electron-builder `CSC_KEYCHAIN` — which `macPackager` reads only when `CSC_LINK` is absent. The certificate/password agreement check folds into the same step, keeping its fast and specific failure, and the step now also asserts that a Developer ID Application identity really landed, so a Mac Development certificate fails in seconds instead of at codesign time.

`scripts/adhoc-sign.mjs` used `CSC_LINK` to know real signing was coming; on macOS that signal is now `CSC_KEYCHAIN`, so it checks both. Without that it would ad-hoc sign over a genuine signature.

Secret names are unchanged — `scripts/set-signing-secrets.sh` still works as documented.

## Verification

- Workflow YAML parses; step list is as intended.
- `node --check scripts/adhoc-sign.mjs` passes.
- Ran the step's exact keychain sequence on macOS 26.6.2 against a throwaway `.p12` — create, unlock, `set-keychain-settings`, `import`, `set-key-partition-list` — all pass.
- Reproduced the CI failure locally: `set-key-partition-list` given anything other than the keychain's own password emits precisely the error above, locked or unlocked.

Not verified: a full signed + notarized run, which needs the real secrets on a runner. That happens on the next tag.

## After merging

v0.1.2's draft release has Windows and Linux assets but no `latest-mac.yml`. Re-run the Release workflow against the tag (`workflow_dispatch`) to add the mac assets to the same draft before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jfx76NMCWoEJW321MNiWRz