### PR TITLE
Fix the Deploy site action: read the site's Node from package.json

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -36,11 +36,13 @@ jobs:
           ref: main
 
       # The checkout above is the *site*, so this reads gitwarren-site's own
-      # .nvmrc — that repository declares the Node its lockfile is written
-      # with, and this job simply obeys it. Nothing to keep in sync by hand.
+      # package.json — setup-node takes the version from its `engines.node`,
+      # which is where that repository states the Node it builds with. Nothing
+      # to keep in sync by hand. (It has no .nvmrc; pointing at one here is
+      # what broke the v0.1.3 deploy.)
       - uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          node-version-file: package.json
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
## What broke

The `Deploy site` run for **v0.1.3** failed 11 seconds in:

```
##[error]The specified node version file at: .nvmrc does not exist
```

gitwarren.com never got rebuilt for v0.1.3, so its download buttons were still baked against the previous release.

## Why

`1a7892d` ("Pin the Node toolchain in one file") swept all three workflows from an explicit `node-version` to `node-version-file: .nvmrc`. That is correct for `ci.yml` and `release.yml`, which build *this* repository — it has a `.nvmrc`.

`deploy-site.yml` is the odd one out: it checks out **`klarluft/gitwarren-site`** first, so the path resolves against that repository, and gitwarren-site has no `.nvmrc` and never has. It states its Node in `package.json`'s `engines.node` instead. The sweep silently pointed the step at a file that does not exist.

The comment's premise — the site declares its own Node, this job just obeys — was right. The file it named was wrong.

## The fix

`setup-node` reads `engines.node` when `node-version-file` points at a `package.json`, so point it there. The site still owns the version and there is still nothing to keep in sync by hand.

## Verified

Dispatched on this branch — [run 33753094304](https://github.com/klarluft/gitwarren-app/actions/runs/33753094304), green:

```
Resolved package.json as >=22.12.0
Found in cache @ /opt/hostedtoolcache/node/24.20.0/x64
node: v24.20.0
✨ Success! Uploaded 1 file (68 already uploaded)
Uploaded gitwarren-site (3.19 sec)
```

Node **24.20.0** — the same version this repo's `.nvmrc` pins, and the one `e07f9cb` deliberately moved the site build to when Node 22's npm 10 could not read the site's npm 11 lockfile. gitwarren.com is now deployed with the v0.1.3 links, so the missed release deploy is caught up.

## One caveat worth knowing

`engines.node` is a floor, not a pin, and `setup-node` resolves a range to the newest satisfying version available on the runner. Today that is 24.20.0; if a runner later carries Node 25+, this deploy would float up to it without a commit here. If you'd rather have it pinned, the tidy follow-up is to add a `.nvmrc` to gitwarren-site and revert this line — that repo would then declare its Node the same way this one does. Happy to do that if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hda59YYwSWuTZihrwbkTnN