### PR TITLE
Authenticate the site build's releases API call

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -53,3 +53,11 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # The site build reads this repository's releases API. Unauthenticated,
+          # that is 60 requests an hour shared across every runner on the host
+          # IP, and it is routinely exhausted — which is how gitwarren.com came
+          # to advertise v0.1.0 while v0.1.3 was current. The default token
+          # raises it to 5000 an hour, counted per token. The site now fails its
+          # build rather than deploy fallback links, so without this a deploy
+          # can stop outright.
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
One line of `env:` on the site deploy step.

`gitwarren.com` resolves its download URLs from this repository's releases API at build time — electron-builder puts the version in every asset name, so there's no static URL the site could link instead. That call is unauthenticated, and unauthenticated `api.github.com` allows **60 requests an hour per IP**, an IP an Actions runner shares. The quota is routinely already spent.

When it failed, the site fell back to the releases index and a hard-coded version number. That's how gitwarren.com came to advertise `v0.1.0` while v0.1.3 was current.

`${{ github.token }}` raises the limit to 5000/hour, counted per token rather than per IP. Nothing to create — the default token already carries the public read this needs.

**This is an improvement, not a fix.** klarluft/gitwarren-site#8 makes the site fall through to a github.com lookup that has no API quota to exhaust, so the deploy is correct with or without this. What the token buys is staying on the better of the two paths: the API sees prereleases and reads the real asset names, while the fallback skips prereleases and predicts names. Free here, so worth taking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBGkg8yuMNn6ZQCUVW6623