### PR TITLE
Record the hero video, and rebuild the demo it needs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ pnpm-debug.log*
 
 # scratch output from scripts/capture-demo.mjs
 screenshots-out/
+
+# scratch output from scripts/capture-hero-video.mjs
+video-out/

--- a/scripts/capture-demo.mjs
+++ b/scripts/capture-demo.mjs
@@ -16,6 +16,7 @@
  */
 import { mkdir, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { Cdp, hideScrollbars, settle, wait } from './cdp.mjs'
 
 const PORT = Number(process.env.CDP_PORT ?? 9222)
 /**
@@ -123,109 +124,11 @@ const SHOTS = [
   }
 ]
 
-/** Minimal CDP client. Node 22 ships a global WebSocket, so this needs no deps. */
-class Cdp {
-  #socket
-  #nextId = 1
-  #pending = new Map()
-
-  static async attach(port) {
-    const response = await fetch(`http://localhost:${port}/json/list`)
-    const targets = await response.json()
-    const page = targets.find((target) => target.type === 'page')
-    if (!page) throw new Error('No page target. Is the app running with --remote-debugging-port?')
-
-    const client = new Cdp()
-    await client.#connect(page.webSocketDebuggerUrl)
-    return client
-  }
-
-  #connect(url) {
-    return new Promise((resolve, reject) => {
-      this.#socket = new WebSocket(url)
-      this.#socket.addEventListener('open', () => resolve())
-      this.#socket.addEventListener('error', () => reject(new Error(`Cannot connect to ${url}`)))
-      this.#socket.addEventListener('message', (event) => {
-        const message = JSON.parse(event.data)
-        const waiting = this.#pending.get(message.id)
-        if (!waiting) return
-        this.#pending.delete(message.id)
-        if (message.error) waiting.reject(new Error(message.error.message))
-        else waiting.resolve(message.result)
-      })
-    })
-  }
-
-  send(method, params = {}) {
-    const id = this.#nextId++
-    this.#socket.send(JSON.stringify({ id, method, params }))
-    return new Promise((resolve, reject) => this.#pending.set(id, { resolve, reject }))
-  }
-
-  async evaluate(expression) {
-    const result = await this.send('Runtime.evaluate', {
-      expression,
-      returnByValue: true,
-      awaitPromise: true
-    })
-    return result.result?.value
-  }
-
-  close() {
-    this.#socket.close()
-  }
-}
-
-const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-
-/**
- * Wait for the screen to stop changing.
- *
- * Every screen fetches through SWR, so there is a skeleton phase and then a
- * content phase, and the second one arrives whenever git happens to answer.
- * Polling until the rendered text is the same twice in a row is a far better
- * signal than any fixed sleep - and the skeleton check stops it settling on a
- * frame of placeholders.
- */
-async function settle(cdp, { timeout = 15_000 } = {}) {
-  const deadline = Date.now() + timeout
-  let previous = null
-  let stableSince = null
-
-  while (Date.now() < deadline) {
-    const state = await cdp.evaluate(`(() => {
-      const skeletons = document.querySelectorAll('.animate-pulse').length
-      return JSON.stringify({ skeletons, text: document.body.innerText.length })
-    })()`)
-
-    if (state === previous && state !== null) {
-      if (stableSince === null) stableSince = Date.now()
-      const { skeletons } = JSON.parse(state)
-      // Stable for two consecutive polls and nothing still loading.
-      if (skeletons === 0 && Date.now() - stableSince >= 400) return
-    } else {
-      stableSince = null
-    }
-
-    previous = state
-    await wait(250)
-  }
-
-  console.warn('  (timed out waiting for the screen to settle; capturing anyway)')
-}
-
 async function main() {
   await mkdir(OUT_DIR, { recursive: true })
   const cdp = await Cdp.attach(PORT)
 
-  // Overlay scrollbars are a pointing-device affordance, and in a still image
-  // they read as a stray line down the edge of the product.
-  await cdp.evaluate(`(() => {
-    const style = document.createElement('style')
-    style.textContent = '*::-webkit-scrollbar{width:0!important;height:0!important;display:none!important}'
-    document.head.appendChild(style)
-    return 'ok'
-  })()`)
+  await hideScrollbars(cdp)
 
   for (const shot of SHOTS) {
     await cdp.send('Emulation.setDeviceMetricsOverride', {

--- a/scripts/capture-hero-video.mjs
+++ b/scripts/capture-hero-video.mjs
@@ -1,0 +1,408 @@
+/**
+ * Record the landing page's hero video by driving the running app over the
+ * Chrome DevTools Protocol.
+ *
+ * The same reasoning as capture-demo.mjs, applied to motion: no Screen
+ * Recording permission, nothing on the desktop but the app, an exact viewport
+ * at a guaranteed 2x - and, because the whole sequence is scripted, the video
+ * can be re-recorded in one command every time the UI changes. There is no
+ * cursor in the recording on purpose. The storyboard is driven from the
+ * keyboard wherever the app allows it, and the one pointer gesture (opening a
+ * line comment) shows its hover state without a pointer to explain it.
+ *
+ * The story, in about twenty seconds:
+ *
+ *   1. A review that already includes uncommitted work: the amber badge, the
+ *      "1 staged, 1 unstaged, 1 untracked" banner.
+ *   2. `u` folds the working tree out - this is what every other tool shows -
+ *      and back in.
+ *   3. `]` steps to a file that exists only on disk.
+ *   4. A line comment is written on it.
+ *   5. The agent's reply lands, with the (AI) attribution.
+ *
+ * Then a short crossfade back to the first frame, so it loops.
+ *
+ * Setup - the demo repositories, a seeded database and a running app:
+ *
+ *   DEMO_REPO_ROOT=~/Developer/klarluft scripts/make-demo-repos.sh
+ *   rm -rf /tmp/gw-demo
+ *   GITWARREN_DATA_DIR=/tmp/gw-demo DEMO_REPO_ROOT=~/Developer/klarluft npx tsx scripts/seed-demo.ts
+ *   npx electron-vite build
+ *   GITWARREN_DATA_DIR=/tmp/gw-demo ./node_modules/.bin/electron . --remote-debugging-port=9222
+ *
+ * Then, from another terminal (ffmpeg must be on PATH):
+ *
+ *   GITWARREN_DATA_DIR=/tmp/gw-demo node scripts/capture-hero-video.mjs
+ *
+ * The repository path in the banner is part of the picture, which is why the
+ * setup above puts the demo under ~/Developer rather than /tmp.
+ *
+ * Outputs land in VIDEO_DIR (default: a gitignored `video-out/`). The videos
+ * are site assets and belong in the site repository:
+ *
+ *   VIDEO_DIR=~/github.com/klarluft/gitwarren-site/src/assets
+ *
+ * which writes hero.mp4, hero.webm and hero.png (the poster: the first frame,
+ * so the poster and the video start identical).
+ */
+import { spawn } from 'node:child_process'
+import { copyFile, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Cdp, hideScrollbars, settle, wait } from './cdp.mjs'
+
+const PORT = Number(process.env.CDP_PORT ?? 9222)
+const OUT_DIR = process.env.VIDEO_DIR ?? 'video-out'
+const FRAME_DIR = join(tmpdir(), 'gitwarren-hero-frames')
+
+/** The same frame as the hero screenshot: 3:2 at 2x. */
+const SIZE = { width: 1200, height: 800 }
+const SCALE = 2
+const FPS = 30
+/** How long the crossfade back to the opening frame takes. */
+const LOOP_FADE_SECONDS = 0.6
+
+const REVIEW_ID = Number(process.env.DEMO_REVIEW_ID ?? 1)
+/** The untracked file in the seeded review, and the line the comment goes on. */
+const HELP_FILE = 'src/renderer/src/features/reviews/shortcut-help.tsx'
+const COMMENT_LINE_TEXT = "import { Dialog, DialogContent"
+const COMMENT = 'Does this need its own Escape handling, or does the dialog already close on it?'
+const REPLY =
+  "Base UI's `Dialog` closes on Escape by itself, so no. But the registry keeps listening while " +
+  'the overlay is open: `?` pressed twice fires the shortcut behind it. Worth a `[role="dialog"]` ' +
+  'check in `onKeyDown` before it dispatches.'
+
+// ---- input ------------------------------------------------------------------
+
+/** A bare key press, as the hotkey layer sees it. Never inserts text. */
+async function press(cdp, key, code, keyCode) {
+  await cdp.send('Input.dispatchKeyEvent', { type: 'rawKeyDown', key, code, windowsVirtualKeyCode: keyCode })
+  await cdp.send('Input.dispatchKeyEvent', { type: 'keyUp', key, code, windowsVirtualKeyCode: keyCode })
+}
+
+/** Type into whatever has focus, at a human-looking, slightly uneven pace. */
+async function type(cdp, text) {
+  for (const character of text) {
+    await cdp.send('Input.insertText', { text: character })
+    // Word boundaries take a beat longer, the way real typing does.
+    await wait(character === ' ' ? 70 : 28 + Math.random() * 24)
+  }
+}
+
+async function moveMouse(cdp, x, y) {
+  await cdp.send('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y })
+}
+
+async function click(cdp, x, y) {
+  await moveMouse(cdp, x, y)
+  await cdp.send('Input.dispatchMouseEvent', { type: 'mousePressed', x, y, button: 'left', clickCount: 1 })
+  await wait(60)
+  await cdp.send('Input.dispatchMouseEvent', { type: 'mouseReleased', x, y, button: 'left', clickCount: 1 })
+}
+
+// ---- the page --------------------------------------------------------------
+
+/**
+ * Where a diff line and its comment button are.
+ *
+ * The button only has a box while its row is hovered, so this is asked twice:
+ * once for the row, and again after the pointer is over it.
+ */
+async function locateLine(cdp, file, needle) {
+  const found = await cdp.evaluate(`(() => {
+    const card = document.getElementById('file-' + encodeURIComponent(${JSON.stringify(file)}))
+    if (!card) return null
+    const span = [...card.querySelectorAll('span.whitespace-pre')].find((node) =>
+      node.textContent.includes(${JSON.stringify(needle)})
+    )
+    if (!span) return null
+    const row = span.parentElement
+    const rect = (node) => {
+      const r = node.getBoundingClientRect()
+      return { x: r.left + r.width / 2, y: r.top + r.height / 2, width: r.width, height: r.height, left: r.left }
+    }
+    const button = row.querySelector('button[aria-label^="Comment on line"]')
+    return { row: rect(row), button: button && button.offsetParent !== null ? rect(button) : null }
+  })()`)
+  if (!found) throw new Error(`Cannot find "${needle}" in ${file} on screen`)
+  return found
+}
+
+async function submitComposer(cdp) {
+  const result = await cdp.evaluate(`(() => {
+    let node = document.activeElement
+    while (node && node !== document.body) {
+      const button = [...node.querySelectorAll('button')].find((b) => b.textContent.trim() === 'Comment')
+      if (button) {
+        button.click()
+        return 'ok'
+      }
+      node = node.parentElement
+    }
+    return 'no composer around the focused element'
+  })()`)
+  if (result !== 'ok') throw new Error(result)
+}
+
+/**
+ * Ask SWR to re-read the comments now rather than on its 15s clock, and wait
+ * until the given text is actually on screen.
+ *
+ * A single synthetic focus event is not always honoured, so this keeps asking
+ * until the reply shows up; the worst case is one 15s refresh tick, which the
+ * recording would survive but the loop would not enjoy.
+ */
+async function waitForText(cdp, text, { timeout = 20_000 } = {}) {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    await cdp.evaluate(`(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+      window.dispatchEvent(new Event('focus'))
+      return 'ok'
+    })()`)
+    await wait(250)
+    const shown = await cdp.evaluate(`document.body.innerText.includes(${JSON.stringify(text)})`)
+    if (shown) return
+  }
+  throw new Error(`"${text}" never appeared on screen`)
+}
+
+// ---- the agent -------------------------------------------------------------
+
+/**
+ * The reply is written by a separate process through the same service the
+ * MCP server uses, so it carries real agent attribution. The process is
+ * started early and waits for a cue, so the reply lands the moment it is asked
+ * for rather than after a second of tsx start-up.
+ */
+function startAgent() {
+  if (!process.env.GITWARREN_DATA_DIR) {
+    throw new Error('Set GITWARREN_DATA_DIR to the database the app is running against.')
+  }
+  const child = spawn('npx', ['tsx', 'scripts/demo-agent-reply.ts'], {
+    env: {
+      ...process.env,
+      DEMO_REVIEW_ID: String(REVIEW_ID),
+      DEMO_FILE_PATH: HELP_FILE,
+      DEMO_REPLY_BODY: REPLY
+    },
+    stdio: ['pipe', 'inherit', 'inherit']
+  })
+  const done = new Promise((resolve, reject) => {
+    child.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`agent reply exited ${code}`))))
+  })
+  return {
+    reply: () => {
+      child.stdin.write('go\n')
+      child.stdin.end()
+      return done
+    }
+  }
+}
+
+// ---- recording -------------------------------------------------------------
+
+class Recorder {
+  frames = []
+  #writes = []
+  #off = null
+
+  constructor(cdp) {
+    this.cdp = cdp
+  }
+
+  async start() {
+    await rm(FRAME_DIR, { recursive: true, force: true })
+    await mkdir(FRAME_DIR, { recursive: true })
+
+    this.#off = this.cdp.on('Page.screencastFrame', ({ data, metadata, sessionId }) => {
+      const file = join(FRAME_DIR, `${String(this.frames.length).padStart(5, '0')}.png`)
+      this.frames.push({ file, at: metadata.timestamp })
+      this.#writes.push(writeFile(file, Buffer.from(data, 'base64')))
+      void this.cdp.send('Page.screencastFrameAck', { sessionId })
+    })
+
+    // A frame arrives whenever the compositor has something new, stamped with
+    // when that was; nothing arrives while the screen is still. The timestamps
+    // are what make the recording faithful, not any frame rate of ours.
+    await this.cdp.send('Page.startScreencast', {
+      format: 'png',
+      maxWidth: SIZE.width * SCALE,
+      maxHeight: SIZE.height * SCALE,
+      everyNthFrame: 1
+    })
+  }
+
+  async stop() {
+    await this.cdp.send('Page.stopScreencast')
+    this.#off?.()
+    this.endedAt = Date.now() / 1000
+    await Promise.all(this.#writes)
+  }
+}
+
+function run(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'inherit', 'inherit'] })
+    child.on('error', reject)
+    child.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`${command} exited ${code}`))))
+  })
+}
+
+function probe(file) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('ffprobe', ['-v', 'error', '-show_entries', 'format=duration', '-of', 'csv=p=0', file])
+    let out = ''
+    child.stdout.on('data', (chunk) => (out += chunk))
+    child.on('exit', (code) => (code === 0 ? resolve(Number(out.trim())) : reject(new Error('ffprobe failed'))))
+  })
+}
+
+/**
+ * Frames to files.
+ *
+ * The concat demuxer takes each frame with the time until the next one, which
+ * turns the irregular screencast into a constant-rate stream. A near-lossless
+ * master is cut first; the deliverables are encoded from it with the loop
+ * crossfade applied, so the expensive part is done once.
+ */
+async function encode(recorder) {
+  const { frames, endedAt } = recorder
+  if (frames.length < 2) throw new Error('Too few frames recorded')
+
+  const list = frames
+    .map((frame, index) => {
+      const next = frames[index + 1]
+      const duration = Math.max((next ? next.at : endedAt) - frame.at, 1 / FPS)
+      return `file '${frame.file}'\nduration ${duration.toFixed(4)}`
+    })
+    .join('\n')
+  const listFile = join(FRAME_DIR, 'frames.txt')
+  // The demuxer ignores the last duration unless the last file is repeated.
+  await writeFile(listFile, `${list}\nfile '${frames.at(-1).file}'\n`)
+
+  await mkdir(OUT_DIR, { recursive: true })
+  const master = join(FRAME_DIR, 'master.mp4')
+  await run('ffmpeg', [
+    '-y', '-loglevel', 'error',
+    '-f', 'concat', '-safe', '0', '-i', listFile,
+    '-vf', `fps=${FPS},format=yuv444p`,
+    '-c:v', 'libx264', '-preset', 'veryfast', '-crf', '8',
+    master
+  ])
+
+  const duration = await probe(master)
+  const fadeAt = (duration - LOOP_FADE_SECONDS).toFixed(3)
+  const loopFilter =
+    // Both inputs on one clock, or xfade refuses to join them.
+    `[1:v]format=yuv420p,fps=${FPS},settb=AVTB[tail];[0:v]format=yuv420p,fps=${FPS},settb=AVTB[main];` +
+    `[main][tail]xfade=transition=fade:duration=${LOOP_FADE_SECONDS}:offset=${fadeAt}`
+  const loopInputs = [
+    '-i', master,
+    // The opening frame, held just past the fade so the last frame *is* the first.
+    '-loop', '1', '-framerate', String(FPS), '-t', String(LOOP_FADE_SECONDS + 0.2), '-i', frames[0].file
+  ]
+
+  const mp4 = join(OUT_DIR, 'hero.mp4')
+  await run('ffmpeg', [
+    '-y', '-loglevel', 'error', ...loopInputs,
+    '-filter_complex', loopFilter,
+    '-c:v', 'libx264', '-preset', 'slow', '-crf', '23', '-profile:v', 'high', '-level', '5.1',
+    '-pix_fmt', 'yuv420p', '-movflags', '+faststart', '-an',
+    mp4
+  ])
+
+  const webm = join(OUT_DIR, 'hero.webm')
+  await run('ffmpeg', [
+    '-y', '-loglevel', 'error', ...loopInputs,
+    '-filter_complex', loopFilter,
+    '-c:v', 'libvpx-vp9', '-crf', '33', '-b:v', '0', '-row-mt', '1', '-deadline', 'good', '-cpu-used', '1',
+    '-pix_fmt', 'yuv420p', '-an',
+    webm
+  ])
+
+  const poster = join(OUT_DIR, 'hero.png')
+  await copyFile(frames[0].file, poster)
+
+  console.log(`${frames.length} frames, ${duration.toFixed(1)}s`)
+  for (const file of [mp4, webm, poster]) console.log(`  ${file}`)
+}
+
+// ---- the storyboard ----------------------------------------------------------
+
+async function main() {
+  const agent = startAgent()
+  const cdp = await Cdp.attach(PORT)
+
+  // Hover and focus must work even while the OS has some other window in front.
+  await cdp.send('Emulation.setFocusEmulationEnabled', { enabled: true })
+  await cdp.send('Emulation.setDeviceMetricsOverride', {
+    width: SIZE.width,
+    height: SIZE.height,
+    deviceScaleFactor: SCALE,
+    mobile: false
+  })
+  await hideScrollbars(cdp)
+
+  await cdp.evaluate(`location.hash = ${JSON.stringify(`#/reviews/${REVIEW_ID}/files`)}`)
+  await wait(300)
+  await settle(cdp)
+
+  // Warm both diffs so `u` flips between two cached answers instead of showing
+  // a skeleton while git is asked again; the recording should show the
+  // product, not the fetch.
+  await press(cdp, 'u', 'KeyU', 85)
+  await settle(cdp)
+  await press(cdp, 'u', 'KeyU', 85)
+  await settle(cdp)
+
+  // Park the pointer where it hovers nothing, and start from the top.
+  await moveMouse(cdp, SIZE.width - 12, SIZE.height - 12)
+  await cdp.evaluate(`document.querySelector('main')?.scrollTo({ top: 0, behavior: 'instant' })`)
+  await wait(600)
+
+  const recorder = new Recorder(cdp)
+  await recorder.start()
+
+  // 1. The review as it is: uncommitted work already folded in.
+  await wait(2600)
+
+  // 2. Without the working tree, and with it again.
+  await press(cdp, 'u', 'KeyU', 85)
+  await wait(1900)
+  await press(cdp, 'u', 'KeyU', 85)
+  await wait(1700)
+
+  // 3. On to the file that is not a commit yet.
+  await press(cdp, ']', 'BracketRight', 221)
+  await wait(2600)
+
+  // 4. A comment on one of its lines.
+  const line = await locateLine(cdp, HELP_FILE, COMMENT_LINE_TEXT)
+  await moveMouse(cdp, line.row.left + 40, line.row.y)
+  await wait(500)
+  const hovered = await locateLine(cdp, HELP_FILE, COMMENT_LINE_TEXT)
+  if (!hovered.button) throw new Error('The comment button did not appear on hover')
+  await click(cdp, hovered.button.x, hovered.button.y)
+  await wait(900)
+  await type(cdp, COMMENT)
+  await wait(700)
+  await submitComposer(cdp)
+  await wait(1800)
+
+  // 5. The agent answers.
+  await agent.reply()
+  await waitForText(cdp, 'closes on Escape by itself')
+  await wait(4200)
+
+  await recorder.stop()
+  await cdp.send('Emulation.clearDeviceMetricsOverride')
+  cdp.close()
+
+  await encode(recorder)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/capture-hero-video.mjs
+++ b/scripts/capture-hero-video.mjs
@@ -204,11 +204,30 @@ function startAgent() {
 
 class Recorder {
   frames = []
+  marks = {}
+  squeezes = []
   #writes = []
   #off = null
 
   constructor(cdp) {
     this.cdp = cdp
+  }
+
+  /** Remember the moment something happened, on the screencast's clock. */
+  mark(name) {
+    this.marks[name] = Date.now() / 1000
+  }
+
+  /**
+   * Make the stretch between two marks last exactly `seconds` in the cut.
+   *
+   * For waits whose real length is not part of the story - the agent's reply
+   * arrives whenever the comment list next refreshes, which is anything from
+   * a moment to a few seconds - the recording keeps what happened and the
+   * edit decides how long it takes.
+   */
+  squeeze(from, to, seconds) {
+    this.squeezes.push({ from, to, seconds })
   }
 
   async start() {
@@ -267,15 +286,35 @@ function probe(file) {
  * crossfade applied, so the expensive part is done once.
  */
 async function encode(recorder) {
-  const { frames, endedAt } = recorder
+  const { frames, endedAt, marks, squeezes } = recorder
   if (frames.length < 2) throw new Error('Too few frames recorded')
 
-  const list = frames
-    .map((frame, index) => {
-      const next = frames[index + 1]
-      const duration = Math.max((next ? next.at : endedAt) - frame.at, 1 / FPS)
-      return `file '${frame.file}'\nduration ${duration.toFixed(4)}`
+  const durations = frames.map((frame, index) => {
+    const next = frames[index + 1]
+    return Math.max((next ? next.at : endedAt) - frame.at, 1 / FPS)
+  })
+
+  // A frame is on screen from its timestamp until the next one, so the frame
+  // that is showing when a window closes straddles the boundary - the reply
+  // frame's time on screen is mostly the hold after it. Only the part of each
+  // frame inside the window is rescaled; the rest keeps its real length.
+  for (const { from, to, seconds } of squeezes) {
+    const start = marks[from]
+    const end = marks[to]
+    const overlap = frames.map((frame, index) => {
+      const shownUntil = frame.at + durations[index]
+      return Math.max(0, Math.min(shownUntil, end) - Math.max(frame.at, start))
     })
+    const total = overlap.reduce((sum, part) => sum + part, 0)
+    if (total === 0) continue
+    const factor = seconds / total
+    frames.forEach((_, index) => {
+      durations[index] = durations[index] - overlap[index] + overlap[index] * factor
+    })
+  }
+
+  const list = frames
+    .map((frame, index) => `file '${frame.file}'\nduration ${durations[index].toFixed(4)}`)
     .join('\n')
   const listFile = join(FRAME_DIR, 'frames.txt')
   // The demuxer ignores the last duration unless the last file is repeated.
@@ -388,12 +427,16 @@ async function main() {
   await type(cdp, COMMENT)
   await wait(700)
   await submitComposer(cdp)
-  await wait(1800)
+  recorder.mark('posted')
+  await wait(1500)
 
-  // 5. The agent answers.
+  // 5. The agent answers. However long the refresh takes, the cut shows the
+  //    posted comment for a beat and then the reply.
   await agent.reply()
   await waitForText(cdp, 'closes on Escape by itself')
-  await wait(4200)
+  recorder.mark('replied')
+  recorder.squeeze('posted', 'replied', 1.4)
+  await wait(3000)
 
   await recorder.stop()
   await cdp.send('Emulation.clearDeviceMetricsOverride')

--- a/scripts/cdp.mjs
+++ b/scripts/cdp.mjs
@@ -1,0 +1,139 @@
+/**
+ * A minimal Chrome DevTools Protocol client, shared by the capture scripts.
+ *
+ * Node ships a global WebSocket, so this needs no dependencies: it is a JSON-RPC
+ * request/response pairing plus a place to hang event handlers, which is all
+ * the screenshot and video scripts ask of the protocol.
+ *
+ * Start the app with a debugging port first:
+ *
+ *   GITWARREN_DATA_DIR=/tmp/gw-demo ./node_modules/.bin/electron . --remote-debugging-port=9222
+ */
+export class Cdp {
+  #socket
+  #nextId = 1
+  #pending = new Map()
+  #listeners = new Map()
+
+  static async attach(port) {
+    const response = await fetch(`http://localhost:${port}/json/list`)
+    const targets = await response.json()
+    const page = targets.find((target) => target.type === 'page')
+    if (!page) throw new Error('No page target. Is the app running with --remote-debugging-port?')
+
+    const client = new Cdp()
+    await client.#connect(page.webSocketDebuggerUrl)
+    return client
+  }
+
+  #connect(url) {
+    return new Promise((resolve, reject) => {
+      this.#socket = new WebSocket(url)
+      this.#socket.addEventListener('open', () => resolve())
+      this.#socket.addEventListener('error', () => reject(new Error(`Cannot connect to ${url}`)))
+      this.#socket.addEventListener('message', (event) => {
+        const message = JSON.parse(event.data)
+
+        // Events carry a method and no id; responses carry an id and no method.
+        if (message.method) {
+          for (const listener of this.#listeners.get(message.method) ?? []) {
+            listener(message.params)
+          }
+          return
+        }
+
+        const waiting = this.#pending.get(message.id)
+        if (!waiting) return
+        this.#pending.delete(message.id)
+        if (message.error) waiting.reject(new Error(message.error.message))
+        else waiting.resolve(message.result)
+      })
+    })
+  }
+
+  send(method, params = {}) {
+    const id = this.#nextId++
+    this.#socket.send(JSON.stringify({ id, method, params }))
+    return new Promise((resolve, reject) => this.#pending.set(id, { resolve, reject }))
+  }
+
+  /** Subscribe to a protocol event such as `Page.screencastFrame`. */
+  on(method, listener) {
+    const listeners = this.#listeners.get(method) ?? []
+    listeners.push(listener)
+    this.#listeners.set(method, listeners)
+    return () => {
+      this.#listeners.set(
+        method,
+        (this.#listeners.get(method) ?? []).filter((candidate) => candidate !== listener)
+      )
+    }
+  }
+
+  async evaluate(expression) {
+    const result = await this.send('Runtime.evaluate', {
+      expression,
+      returnByValue: true,
+      awaitPromise: true
+    })
+    if (result.exceptionDetails) {
+      throw new Error(result.exceptionDetails.exception?.description ?? 'Evaluation failed')
+    }
+    return result.result?.value
+  }
+
+  close() {
+    this.#socket.close()
+  }
+}
+
+export const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Wait for the screen to stop changing.
+ *
+ * Every screen fetches through SWR, so there is a skeleton phase and then a
+ * content phase, and the second one arrives whenever git happens to answer.
+ * Polling until the rendered text is the same twice in a row is a far better
+ * signal than any fixed sleep - and the skeleton check stops it settling on a
+ * frame of placeholders.
+ */
+export async function settle(cdp, { timeout = 15_000 } = {}) {
+  const deadline = Date.now() + timeout
+  let previous = null
+  let stableSince = null
+
+  while (Date.now() < deadline) {
+    const state = await cdp.evaluate(`(() => {
+      const skeletons = document.querySelectorAll('.animate-pulse').length
+      return JSON.stringify({ skeletons, text: document.body.innerText.length })
+    })()`)
+
+    if (state === previous && state !== null) {
+      if (stableSince === null) stableSince = Date.now()
+      const { skeletons } = JSON.parse(state)
+      // Stable for two consecutive polls and nothing still loading.
+      if (skeletons === 0 && Date.now() - stableSince >= 400) return
+    } else {
+      stableSince = null
+    }
+
+    previous = state
+    await wait(250)
+  }
+
+  console.warn('  (timed out waiting for the screen to settle; capturing anyway)')
+}
+
+/**
+ * Overlay scrollbars are a pointing-device affordance, and in a still image or
+ * a recording they read as a stray line down the edge of the product.
+ */
+export async function hideScrollbars(cdp) {
+  await cdp.evaluate(`(() => {
+    const style = document.createElement('style')
+    style.textContent = '*::-webkit-scrollbar{width:0!important;height:0!important;display:none!important}'
+    document.head.appendChild(style)
+    return 'ok'
+  })()`)
+}

--- a/scripts/demo-agent-reply.ts
+++ b/scripts/demo-agent-reply.ts
@@ -1,0 +1,58 @@
+/**
+ * The agent's half of the hero video: reply to the newest thread on one file.
+ *
+ * Written through the same service the MCP server calls, with the same kind of
+ * attribution an MCP session would stamp on it, so what appears on screen is a
+ * real agent comment rather than a mock-up of one.
+ *
+ * Started by capture-hero-video.mjs ahead of time; it does nothing until a line
+ * arrives on stdin, then replies and exits. That keeps tsx start-up out of the
+ * recording.
+ *
+ *   GITWARREN_DATA_DIR=/tmp/gw-demo DEMO_FILE_PATH=src/x.ts DEMO_REPLY_BODY='…' \
+ *     npx tsx scripts/demo-agent-reply.ts
+ */
+import { and, desc, eq } from 'drizzle-orm'
+import { getDatabase } from '../src/core/db/client.js'
+import { commentThreads } from '../src/core/db/schema.js'
+import { commentsService } from '../src/core/services/comments.js'
+import type { CommentAuthor } from '../src/shared/actors.js'
+
+/** The same session the seeded discussion came from. */
+const CLAUDE: CommentAuthor = {
+  kind: 'agent',
+  name: 'Claude Code',
+  label: 'shortcuts-review',
+  session: 'a3f9c1e8'
+}
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`Set ${name}.`)
+  return value
+}
+
+const reviewId = Number(process.env.DEMO_REVIEW_ID ?? 1)
+const filePath = required('DEMO_FILE_PATH')
+const body = required('DEMO_REPLY_BODY')
+
+async function main(): Promise<void> {
+  await new Promise<void>((resolve) => process.stdin.once('data', () => resolve()))
+
+  const db = getDatabase()
+  const thread = db
+    .select({ id: commentThreads.id })
+    .from(commentThreads)
+    .where(and(eq(commentThreads.reviewId, reviewId), eq(commentThreads.filePath, filePath)))
+    .orderBy(desc(commentThreads.id))
+    .get()
+  if (!thread) throw new Error(`No thread on ${filePath} in review ${reviewId}`)
+
+  await commentsService.reply({ threadId: thread.id, body }, CLAUDE)
+  console.log(`  (agent replied on thread ${thread.id})`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/make-demo-repos.sh
+++ b/scripts/make-demo-repos.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+#
+# Build the throwaway repositories that scripts/seed-demo.ts points at.
+#
+# The seed writes reviews against three repositories and a discussion whose
+# line comments are placed by finding text in the diff. That text has to exist
+# somewhere on disk, in a branch that carries committed, staged, unstaged and
+# untracked work at the same time - which is the whole thing the screenshots
+# and the hero video are about. This script produces exactly that, from a
+# pinned commit of this repository, so the demo can be rebuilt on any machine
+# in a few seconds instead of being reconstructed by hand.
+#
+#   scripts/make-demo-repos.sh                 # into /tmp/gw-demo-repos
+#   DEMO_REPO_ROOT=~/demo scripts/make-demo-repos.sh
+#
+# Then seed a database against it:
+#
+#   rm -rf /tmp/gw-demo
+#   GITWARREN_DATA_DIR=/tmp/gw-demo DEMO_REPO_ROOT=/tmp/gw-demo-repos \
+#     npx tsx scripts/seed-demo.ts
+#
+# The feature the demo branch pretends to add - a scoped shortcut registry with
+# j/k/u bindings and a help overlay - is fiction. The real app grew a different
+# design for the same idea later (src/renderer/src/lib/hotkeys.ts); the demo
+# branch is based on the last commit before that landed, so the story it tells
+# is at least plausible against the code it sits on.
+set -euo pipefail
+
+ROOT="${DEMO_REPO_ROOT:-/tmp/gw-demo-repos}"
+SOURCE="${DEMO_SOURCE_REPO:-$(cd "$(dirname "$0")/.." && git rev-parse --path-format=absolute --git-common-dir)}"
+
+# Merge of PR #8: the last main commit before keyboard shortcuts existed.
+BASE=f41b379
+
+# Two days ago, at a fixed time of day, so the commits tab reads as a
+# conversation that happened over a couple of days rather than one that
+# happened while the script ran.
+DAY_AGO=$(( $(date +%s) - 24 * 60 * 60 ))
+stamp() { date -r "$(( DAY_AGO - $1 * 60 * 60 ))" '+%Y-%m-%dT%H:%M:%S'; }
+commit() {
+  # $1 hours before "yesterday", $2 message
+  local at
+  at="$(stamp "$1")"
+  GIT_AUTHOR_DATE="$at" GIT_COMMITTER_DATE="$at" git commit -q -m "$2"
+}
+
+rm -rf "$ROOT"
+mkdir -p "$ROOT"
+
+# ---- gitwarren-app: the repository the reviews are against -----------------
+
+git clone -q --no-hardlinks "$SOURCE" "$ROOT/gitwarren-app"
+cd "$ROOT/gitwarren-app"
+git config user.name 'Michal Wrzosek'
+git config user.email 'michal@wrzosek.pl'
+
+git checkout -q -B main "$BASE"
+# The clone's origin is a local path that will not exist on another machine,
+# and a fetchable origin would let the app report "behind upstream" for main.
+git remote remove origin
+
+# ---- fix/untracked-file-crash -------------------------------------------------
+
+git checkout -q -b fix/untracked-file-crash
+node - src/core/diff-parser.ts <<'EOF'
+const fs = require('node:fs')
+const file = process.argv.at(-1)
+fs.appendFileSync(
+  file,
+  '\n' +
+    '/**\n' +
+    ' * The hunk header for a file shown in full - an untracked file, or one git\n' +
+    ' * could not diff - must describe the lines actually rendered, not the whole\n' +
+    ' * file. A truncated file that claims all of its lines sends every anchor\n' +
+    ' * past the end of the hunk.\n' +
+    ' */\n' +
+    'export function wholeFileHunkHeader(renderedLines: number): string {\n' +
+    '  return `@@ -0,0 +1,${renderedLines} @@`\n' +
+    '}\n'
+)
+EOF
+git add -A
+commit 60 'Describe only the rendered lines in a whole-file hunk header'
+
+# ---- chore/pin-node-22 (closed in the seed) -------------------------------------
+
+git checkout -q main
+git checkout -q -b chore/pin-node-22
+printf '22.12.0\n' > .nvmrc
+git add -A
+commit 200 'Raise the Node floor to 22.12'
+
+# ---- feat/keyboard-shortcuts ----------------------------------------------
+#
+# Built last, and left checked out: its working tree is deliberately dirty,
+# which is what the review finds, and what would block any later checkout.
+
+git checkout -q main
+git checkout -q -b feat/keyboard-shortcuts
+
+# Commit 1: the registry.
+mkdir -p src/renderer/src/lib
+cat > src/renderer/src/lib/shortcuts.ts <<'EOF'
+/**
+ * Keyboard shortcuts, scoped to the screen that owns them.
+ *
+ * A screen registers the keys it understands while it is mounted and gives
+ * them back when it unmounts, so `j` means "next file" on the diff and nothing
+ * at all on the repository list. One listener on `window` does the dispatch;
+ * React's own handlers run first and can still `stopPropagation` a key they
+ * want for themselves.
+ */
+import { useEffect } from 'react'
+
+export type ShortcutScope = 'files' | 'conversation' | 'commits'
+
+export interface Shortcut {
+  /** A single printable key: `j`, `u`, `?`. */
+  key: string
+  /** Shown in the help overlay. Omit to keep a binding out of it. */
+  description?: string
+  run: () => void
+}
+
+const registry = new Map<ShortcutScope, Shortcut[]>()
+
+/** Keys pressed while typing belong to the text field, not to us. */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.isContentEditable) return true
+  const tag = target.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+}
+
+function onKeyDown(event: KeyboardEvent): void {
+  if (event.defaultPrevented) return
+  if (event.metaKey || event.ctrlKey || event.altKey) return
+  if (isTypingTarget(event.target)) return
+
+  for (const shortcuts of registry.values()) {
+    const match = shortcuts.find((shortcut) => shortcut.key === event.key)
+    if (match) {
+      event.preventDefault()
+      match.run()
+      return
+    }
+  }
+}
+
+let installed = false
+
+export function useShortcuts(scope: ShortcutScope, shortcuts: Shortcut[]): void {
+  useEffect(() => {
+    registry.set(scope, shortcuts)
+    if (!installed) {
+      window.addEventListener('keydown', onKeyDown)
+      installed = true
+    }
+    return () => {
+      registry.delete(scope)
+    }
+  }, [scope, shortcuts])
+}
+
+/** Everything currently bound, for the help overlay. */
+export function boundShortcuts(): ReadonlyMap<ShortcutScope, Shortcut[]> {
+  return registry
+}
+EOF
+git add -A
+commit 26 'Add a scoped shortcut registry'
+
+# Commit 2: bind it in the files tab.
+FILES_TAB=src/renderer/src/features/reviews/review-files-tab.tsx
+node - "$FILES_TAB" <<'EOF'
+const fs = require('node:fs')
+const file = process.argv.at(-1)
+let source = fs.readFileSync(file, 'utf8')
+
+const replace = (from, to) => {
+  if (!source.includes(from)) throw new Error(`Anchor not found in ${file}: ${from}`)
+  source = source.replace(from, to)
+}
+
+replace(
+  "import { useStoredFlag, useStoredPreference } from '@/lib/preferences'\n",
+  "import { useStoredFlag, useStoredPreference } from '@/lib/preferences'\n" +
+    "import { useShortcuts } from '@/lib/shortcuts'\n"
+)
+
+replace(
+  "  const [treeOpen, setTreeOpen] = useStoredFlag('files-tree', true)\n",
+  "  const [treeOpen, setTreeOpen] = useStoredFlag('files-tree', true)\n" +
+    '\n' +
+    '  const stepFile = useCallback(\n' +
+    '    (delta: number): void => {\n' +
+    '      const cards = [...document.querySelectorAll<HTMLElement>(\'[data-file-card]\')]\n' +
+    '      const current = cards.findIndex((card) => card.getBoundingClientRect().top >= 0)\n' +
+    '      const next = cards[Math.max(0, Math.min(cards.length - 1, current + delta))]\n' +
+    "      next?.scrollIntoView({ block: 'start', behavior: 'smooth' })\n" +
+    '    },\n' +
+    '    []\n' +
+    '  )\n' +
+    '\n' +
+    "  useShortcuts('files', [\n" +
+    "    { key: 'j', run: () => stepFile(1) },\n" +
+    "    { key: 'k', run: () => stepFile(-1) },\n" +
+    '    {\n' +
+    "      key: 'u',\n" +
+    '      run: () => setIncludeUncommitted((current) => !current)\n' +
+    '    }\n' +
+    '  ])\n'
+)
+
+fs.writeFileSync(file, source)
+EOF
+git add -A
+commit 25 'Bind j, k and u on the files tab'
+
+# Staged, not committed: descriptions for the help overlay.
+node - "$FILES_TAB" <<'EOF'
+const fs = require('node:fs')
+const file = process.argv.at(-1)
+let source = fs.readFileSync(file, 'utf8')
+const replace = (from, to) => {
+  if (!source.includes(from)) throw new Error(`Anchor not found in ${file}: ${from}`)
+  source = source.replace(from, to)
+}
+replace("    { key: 'j', run: () => stepFile(1) },\n", "    { key: 'j', description: 'Next file', run: () => stepFile(1) },\n")
+replace("    { key: 'k', run: () => stepFile(-1) },\n", "    { key: 'k', description: 'Previous file', run: () => stepFile(-1) },\n")
+replace(
+  "      key: 'u',\n      run:",
+  "      key: 'u',\n      description: 'Include or exclude uncommitted changes',\n      run:"
+)
+fs.writeFileSync(file, source)
+EOF
+git add "$FILES_TAB"
+
+# Unstaged: a guard against key auto-repeat in the registry.
+node - src/renderer/src/lib/shortcuts.ts <<'EOF'
+const fs = require('node:fs')
+const file = process.argv.at(-1)
+let source = fs.readFileSync(file, 'utf8')
+const from = '  if (isTypingTarget(event.target)) return\n'
+if (!source.includes(from)) throw new Error(`Anchor not found in ${file}`)
+source = source.replace(
+  from,
+  from +
+    '  // Holding `j` should not run down the whole file list in one go.\n' +
+    '  if (event.repeat) return\n'
+)
+fs.writeFileSync(file, source)
+EOF
+
+# Untracked: the help overlay, which exists only on disk.
+cat > src/renderer/src/features/reviews/shortcut-help.tsx <<'EOF'
+/**
+ * The `?` overlay: every shortcut the current screen understands.
+ */
+import { boundShortcuts, type ShortcutScope } from '@/lib/shortcuts'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Kbd } from '@/components/ui/kbd'
+
+const SCOPE_TITLES: Record<ShortcutScope, string> = {
+  files: 'Files changed',
+  conversation: 'Conversation',
+  commits: 'Commits'
+}
+
+interface ShortcutHelpProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ShortcutHelp({ open, onOpenChange }: ShortcutHelpProps) {
+  const scopes = [...boundShortcuts().entries()]
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+        </DialogHeader>
+        {scopes.map(([scope, shortcuts]) => (
+          <section key={scope} className="flex flex-col gap-2">
+            <h3 className="text-sm font-medium text-muted-foreground">{SCOPE_TITLES[scope]}</h3>
+            <dl className="grid grid-cols-[auto_1fr] items-center gap-x-4 gap-y-1.5">
+              {shortcuts
+                .filter((shortcut) => shortcut.description)
+                .map((shortcut) => (
+                  <div key={shortcut.key} className="contents">
+                    <dt>
+                      <Kbd>{shortcut.key}</Kbd>
+                    </dt>
+                    <dd className="text-sm">{shortcut.description}</dd>
+                  </div>
+                ))}
+            </dl>
+          </section>
+        ))}
+      </DialogContent>
+    </Dialog>
+  )
+}
+EOF
+
+# ---- two small repositories to fill the list ---------------------------------
+
+filler() {
+  local name="$1" title="$2" hours="$3"
+  mkdir -p "$ROOT/$name"
+  cd "$ROOT/$name"
+  git init -q -b main
+  git config user.name 'Michal Wrzosek'
+  git config user.email 'michal@wrzosek.pl'
+  printf '# %s\n' "$title" > README.md
+  git add -A
+  commit "$hours" 'Initial commit'
+}
+
+filler gitwarren-docs 'GitWarren documentation' 300
+filler klarluft-website 'klarluft.com' 400
+
+cd "$ROOT/gitwarren-app"
+echo "Demo repositories in $ROOT"
+git status --short --branch

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -22,8 +22,8 @@ import { reviewsService } from '../src/core/services/reviews.js'
 import { HUMAN_AUTHOR, type CommentAuthor } from '../src/shared/actors.js'
 import type { ReviewDiff } from '../src/shared/git.js'
 
-/** Where the demo repositories were created. Overridable for a different machine. */
-const DEMO_ROOT = process.env.DEMO_REPO_ROOT ?? `${process.env.HOME}/github.com/klarluft`
+/** Where scripts/make-demo-repos.sh put the demo repositories. */
+const DEMO_ROOT = process.env.DEMO_REPO_ROOT ?? '/tmp/gw-demo-repos'
 
 /**
  * A Claude Code session, as the MCP handshake would describe one. The session


### PR DESCRIPTION
Tooling for the landing page's hero video, on top of the existing screenshot pipeline.

- `scripts/capture-hero-video.mjs` — drives the app over CDP through a ~30s storyboard (`u` out/in, `]` to the untracked file, a typed line comment, the agent's reply), records via `Page.startScreencast`, and cuts `hero.webm` + `hero.mp4` + a poster with ffmpeg, crossfading back to the first frame for a clean loop. No cursor by design.
- `scripts/demo-agent-reply.ts` — posts the agent's reply through `commentsService` with real MCP-style attribution, on a stdin cue.
- `scripts/make-demo-repos.sh` — rebuilds the throwaway demo repositories the seed expects (the screenshots README called recreating them "the only manual part"). Pinned to `f41b379`, the last commit before hotkeys existed.
- `scripts/cdp.mjs` — the CDP client, `settle` and scrollbar hiding, extracted from `capture-demo.mjs` and now shared.
- `seed-demo.ts` defaults `DEMO_REPO_ROOT` to the builder's output.

The resulting video is in the site PR (`klarluft/gitwarren-site`, branch `worktree-hero-video`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Viyamf77hZJSbpjAts5jYP
