### PR TITLE
Nudge the Homebrew tap when a release is published

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,0 +1,41 @@
+name: Homebrew tap
+
+# Tells klarluft/homebrew-tap that a release has been published, so its cask
+# can move to the new version and checksums straight away. The tap's own
+# workflow does the actual work (scripts/bump.sh over there); this one only
+# rings the bell.
+#
+# `release: published` for the same reason deploy-site.yml uses it: the
+# release starts life as a draft, and only publishing makes its assets
+# visible to the API the bump reads from.
+#
+# Needs HOMEBREW_TAP_TOKEN — a fine-grained PAT for the klarluft/homebrew-tap
+# repository with *Contents: read and write* (a repository_dispatch counts as
+# a write to contents). Without it the job is skipped rather than failed: the
+# tap also polls on a schedule and catches the release within a few hours.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    name: Ask the tap to bump
+    runs-on: ubuntu-latest
+    env:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+    steps:
+      - name: Send repository_dispatch
+        if: env.HOMEBREW_TAP_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh api repos/klarluft/homebrew-tap/dispatches \
+            --method POST \
+            --field event_type=release-published \
+            --field "client_payload[tag]=$TAG"
+
+      - name: Explain the skip
+        if: env.HOMEBREW_TAP_TOKEN == ''
+        run: echo "HOMEBREW_TAP_TOKEN is not set; the tap will pick this release up on its schedule."

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 # GitWarren
 
 **[gitwarren.com](https://gitwarren.com)** — the official site, with downloads for
-macOS, Windows and Linux.
+macOS, Windows and Linux. On macOS there is also a Homebrew cask:
+
+```bash
+brew install --cask klarluft/tap/gitwarren
+```
 
 A cross-platform desktop app for doing local code reviews of your own git
 repositories. Single user, single machine, no server, no account.
@@ -889,6 +893,14 @@ git push --follow-tags
 installers, and uploads them plus the manifests to a GitHub release for the
 current tag. The release is created as a **draft** — publish it in the GitHub UI
 when you are ready, and that is the moment clients begin to see the update.
+
+Publishing also fans out to two other places, both on the `release: published`
+event: `deploy-site.yml` rebuilds gitwarren.com so its download buttons point at
+the new assets, and `homebrew-tap.yml` asks
+[klarluft/homebrew-tap](https://github.com/klarluft/homebrew-tap) to move its
+cask to the new version and checksums. The tap needs a `HOMEBREW_TAP_TOKEN`
+secret for that nudge to be immediate; without one it still catches the
+release on its own schedule within a few hours.
 
 To build without publishing (for local testing):
 


### PR DESCRIPTION
Part of shipping GitWarren through Homebrew (`brew install --cask klarluft/tap/gitwarren`).

- `.github/workflows/homebrew-tap.yml`: on `release: published`, sends a `repository_dispatch` to `klarluft/homebrew-tap` so its cask moves to the new version and checksums immediately. Needs a `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT, Contents read/write on the tap repo). Without it the job skips, and the tap's scheduled run catches the release within six hours.
- README: the brew one-liner near the top, and a note in the release process about what publishing fans out to.

Companion changes: the tap repo itself (`klarluft/homebrew-tap`, cask + self-bump workflow) and the site's download section (gitwarren-site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiT9zqQz8pU5ntKqhVMdFi
