### PR TITLE
Allow a review of a ref against itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,15 @@ diverged — rather than the literal difference between the endpoints. So commit
 that landed on `main` after you branched do not show up as reversals in your
 review. The *commits* tab lists the same range, `base..head`.
 
+### A ref against itself
+
+The two endpoints may be the same ref. That is not an empty review: the merge
+base of a ref with itself is its own tip, so the diff is exactly what the
+worktree holds that has not been committed — the review you want when you just
+wrote the code and want a second pair of eyes before it becomes a commit. Such a
+review has no commits by definition, is titled *Uncommitted work on `<ref>`* by
+default, and is drawn with one endpoint rather than an arrow between two.
+
 ### Finding uncommitted work
 
 This is the part that needs care, because **the repository row points at one

--- a/src/core/__tests__/reviews.test.ts
+++ b/src/core/__tests__/reviews.test.ts
@@ -124,10 +124,58 @@ test('creating a review against a ref that does not exist is a field error', asy
   assert.ok(error.fieldErrors?.headRef)
 })
 
-test('a ref cannot be compared against itself', async () => {
-  await expectError('INVALID_INPUT', () =>
-    reviewsService.create({ repositoryId, baseRef: 'main', headRef: 'main' })
+test('a ref compared against itself reviews the uncommitted work on it', async () => {
+  const review = await reviewsService.create({
+    repositoryId,
+    baseRef: 'feature',
+    headRef: 'feature'
+  })
+  assert.equal(review.title, 'Uncommitted work on feature')
+
+  const diff = await reviewsService.diff({ id: review.id, includeUncommitted: true })
+  assert.equal(diff.error, null)
+  assert.equal(diff.includedUncommitted, true)
+
+  // The merge base of a ref with itself is its own tip, so nothing that has
+  // been committed shows up - b.txt and the committed half of a.txt are gone,
+  // and what is left is exactly what has not been committed yet.
+  const paths = diff.files.map((file) => file.path).sort()
+  assert.deepEqual(paths, ['a.txt', 'staged.txt', 'untracked.txt'])
+  assert.ok(diff.files.every((file) => file.hasUncommittedChanges))
+
+  const a = diff.files.find((file) => file.path === 'a.txt')
+  assert.equal(a?.additions, 1)
+  assert.ok(
+    a?.hunks.some((hunk) =>
+      hunk.lines.some((line) => line.type === 'insert' && line.content.includes('uncommitted'))
+    )
   )
+
+  // Nothing is committed between the two endpoints, by definition.
+  const commits = await reviewsService.commits({ id: review.id })
+  assert.equal(commits.error, null)
+  assert.deepEqual(commits.commits, [])
+  assert.equal(commits.workingTree?.isDirty, true)
+})
+
+test('a self-review with uncommitted work excluded is empty', async () => {
+  const review = await reviewsService.create({
+    repositoryId,
+    baseRef: 'feature',
+    headRef: 'feature'
+  })
+
+  const diff = await reviewsService.diff({ id: review.id, includeUncommitted: false })
+  assert.equal(diff.error, null)
+  assert.deepEqual(diff.files, [])
+})
+
+test('an existing review can be repointed at a single ref', async () => {
+  const id = await createReview()
+  const updated = await reviewsService.update({ id, baseRef: 'feature' })
+
+  assert.equal(updated.baseRef, 'feature')
+  assert.equal(updated.headRef, 'feature')
 })
 
 test('the commits tab lists what head added, and finds the uncommitted work', async () => {

--- a/src/core/git-compare.ts
+++ b/src/core/git-compare.ts
@@ -16,6 +16,11 @@
  * patch. Untracked files are then synthesised on top (see `diff-parser.ts`),
  * because staging them into a scratch index would mean writing to a repository
  * this app promises only to read.
+ *
+ * A consequence worth naming: when both endpoints are the *same* ref the merge
+ * base is that ref's own tip, so the diff reduces to exactly the uncommitted
+ * work in its worktree. Nothing here special-cases it - it falls out of the
+ * rules above - and reviews are allowed to be shaped that way on purpose.
  */
 import { readFile, stat } from 'node:fs/promises'
 import { join, resolve, sep } from 'node:path'

--- a/src/core/services/reviews.ts
+++ b/src/core/services/reviews.ts
@@ -28,6 +28,7 @@ import { AppError } from '../../shared/errors.js'
 import { parseWithSchema as parse } from '../../shared/validation.js'
 import {
   createReviewInputSchema,
+  defaultReviewTitle,
   getReviewInputSchema,
   listReviewsInputSchema,
   removeReviewInputSchema,
@@ -154,7 +155,7 @@ export const reviewsService = {
       .insert(reviews)
       .values({
         repositoryId,
-        title: title ?? `${headRef} into ${baseRef}`,
+        title: title ?? defaultReviewTitle(baseRef, headRef),
         description: description ?? '',
         baseRef,
         headRef,
@@ -179,11 +180,6 @@ export const reviewsService = {
 
     const nextBase = baseRef ?? current.baseRef
     const nextHead = headRef ?? current.headRef
-    if (nextBase === nextHead) {
-      throw new AppError('INVALID_INPUT', 'Pick two different refs.', {
-        headRef: ['Pick two different refs - a ref compared against itself is empty.']
-      })
-    }
     if (baseRef !== undefined || headRef !== undefined) {
       await assertComparable(requireRepository(current.repositoryId).path, nextBase, nextHead)
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -294,7 +294,10 @@ server.registerTool(
       'diff is taken from their merge base, like a pull request. Both refs must exist and share ' +
       'history, or the call fails with INVALID_INPUT. `title` defaults to "<head> into <base>". ' +
       'If the head branch is checked out in a worktree, its uncommitted changes are part of the ' +
-      'review as well - a review can be opened on work that has never been committed.' +
+      'review as well - a review can be opened on work that has never been committed. Passing ' +
+      'the same ref as both endpoints is allowed and does exactly that: the review then holds ' +
+      'only the uncommitted work on that ref, and its title defaults to "Uncommitted work on ' +
+      '<ref>".' +
       GUI_URL_NOTE,
     inputSchema: createReviewInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false }

--- a/src/renderer/src/features/reviews/review-commits-tab.tsx
+++ b/src/renderer/src/features/reviews/review-commits-tab.tsx
@@ -14,6 +14,7 @@ import { errorMessage } from '@/lib/errors'
 import { absoluteTime, plural, relativeTime } from '@/lib/format'
 import { CompareErrorCard, NoWorktreeNotice, WorkingTreeBanner } from './compare-notices'
 import { useReviewCommits } from './use-reviews'
+import { isSelfReview } from '@shared/schemas'
 import type { GitCommit } from '@shared/git'
 import type { Review } from '@shared/schemas'
 
@@ -43,6 +44,7 @@ export function ReviewCommitsTab({ review }: { review: Review }) {
   }
 
   const { commits, workingTree } = data
+  const selfReview = isSelfReview(review)
 
   return (
     <div className="flex flex-col gap-3">
@@ -70,11 +72,15 @@ export function ReviewCommitsTab({ review }: { review: Review }) {
           <div className="rounded-full bg-muted p-3 text-muted-foreground">
             <GitCommitHorizontal className="size-6" />
           </div>
-          <h3 className="font-medium">No commits yet</h3>
+          <h3 className="font-medium">{selfReview ? 'Nothing committed here' : 'No commits yet'}</h3>
           <p className="mx-auto max-w-sm text-sm text-muted-foreground">
             {workingTree?.isDirty
               ? 'Everything in this review is still uncommitted. The files changed tab has it.'
-              : `${review.headRef} has nothing that ${review.baseRef} does not already have.`}
+              : selfReview
+                ? // A ref against itself never has commits between its endpoints,
+                  // so "no commits" is the permanent, correct state of this tab.
+                  `This review is ${review.headRef} against itself, so it holds only uncommitted work — and there is none right now.`
+                : `${review.headRef} has nothing that ${review.baseRef} does not already have.`}
           </p>
         </Card>
       ) : (

--- a/src/renderer/src/features/reviews/review-detail.tsx
+++ b/src/renderer/src/features/reviews/review-detail.tsx
@@ -39,6 +39,7 @@ import { ReviewFilesTab } from './review-files-tab'
 import { ReviewFormDialog } from './review-form-dialog'
 import { RemoveReviewDialog } from './remove-review-dialog'
 import { useReview, useReviewCommits, useReviewMutations } from './use-reviews'
+import { isSelfReview } from '@shared/schemas'
 import type { CompareEndpoint } from '@shared/git'
 import type { Review } from '@shared/schemas'
 
@@ -178,6 +179,7 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
 
   const workingTree = commits.data?.workingTree ?? null
   const isOpen = review.status === 'open'
+  const selfReview = isSelfReview(review)
   const unresolvedThreads = threads.filter((thread) => thread.resolvedAt === null).length
 
   return (
@@ -206,9 +208,16 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
             </div>
 
             <p className="mt-1.5 flex flex-wrap items-center gap-1.5 font-mono text-xs text-muted-foreground">
-              <span className="rounded bg-muted px-1.5 py-0.5">{review.baseRef}</span>
-              <UpstreamDrift endpoint={commits.data?.base} role="base" />
-              <ArrowRight className="size-3" />
+              {/* A ref against itself is one endpoint, not two: "main → main"
+                  reads like a mistake, when it is a review of what has not been
+                  committed on main yet. */}
+              {!selfReview && (
+                <>
+                  <span className="rounded bg-muted px-1.5 py-0.5">{review.baseRef}</span>
+                  <UpstreamDrift endpoint={commits.data?.base} role="base" />
+                  <ArrowRight className="size-3" />
+                </>
+              )}
               <span className="rounded bg-muted px-1.5 py-0.5">{review.headRef}</span>
               <UpstreamDrift endpoint={commits.data?.head} role="head" />
               {workingTree?.isDirty && (

--- a/src/renderer/src/features/reviews/review-files-tab.tsx
+++ b/src/renderer/src/features/reviews/review-files-tab.tsx
@@ -50,6 +50,7 @@ import { useEditors, useReviewDiff } from './use-reviews'
 import { findAnchorFile, isInlineAnchor, resolveAnchor } from '@shared/comment-anchors'
 import { threadSnippet } from '@shared/comment-snippets'
 import type { FileDiff as FileDiffData } from '@shared/git'
+import { isSelfReview } from '@shared/schemas'
 import type { CommentThread, Review } from '@shared/schemas'
 
 /**
@@ -411,6 +412,7 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
   }
 
   const hasWorktree = data.workingTree !== null
+  const selfReview = isSelfReview(review)
 
   return (
     <div className="flex flex-col gap-3">
@@ -465,9 +467,13 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
           <label
             className="flex items-center gap-2 text-xs text-muted-foreground"
             title={
-              hasWorktree
-                ? 'Fold the head worktree’s staged, unstaged and untracked changes into the diff'
-                : `No worktree has ${review.headRef} checked out, so there is nothing uncommitted to include`
+              !hasWorktree
+                ? `No worktree has ${review.headRef} checked out, so there is nothing uncommitted to include`
+                : selfReview
+                  ? // Turning it off on a self-review leaves an empty diff; the
+                    // switch stays usable, but say so rather than let it look broken.
+                    'This review is uncommitted work only — turning this off leaves nothing to show'
+                  : 'Fold the head worktree’s staged, unstaged and untracked changes into the diff'
             }
           >
             <Switch
@@ -547,10 +553,26 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
             <FileDiff className="size-6" />
           </div>
           <h3 className="font-medium">No changes</h3>
-          <p className="mx-auto max-w-sm text-sm text-muted-foreground">
-            <span className="font-mono">{review.headRef}</span> has nothing that{' '}
-            <span className="font-mono">{review.baseRef}</span> does not already have.
-          </p>
+          {selfReview ? (
+            <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+              {includeUncommitted ? (
+                <>
+                  Nothing is uncommitted on <span className="font-mono">{review.headRef}</span>{' '}
+                  right now. Edit a file and refresh — it will show up here.
+                </>
+              ) : (
+                <>
+                  This review is <span className="font-mono">{review.headRef}</span> against itself,
+                  so it holds only uncommitted work. Turn the switch back on to see it.
+                </>
+              )}
+            </p>
+          ) : (
+            <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+              <span className="font-mono">{review.headRef}</span> has nothing that{' '}
+              <span className="font-mono">{review.baseRef}</span> does not already have.
+            </p>
+          )}
         </Card>
       ) : (
         // `items-start` so the tree can stick to the top of the viewport while

--- a/src/renderer/src/features/reviews/review-form-dialog.tsx
+++ b/src/renderer/src/features/reviews/review-form-dialog.tsx
@@ -7,7 +7,10 @@
  *
  * The endpoints default to "the trunk, and whatever you are working on" -
  * `defaultBranch` into `currentBranch` - which is the review the user almost
- * always wants and saves them two menu visits.
+ * always wants and saves them two menu visits. When those are the same branch
+ * that default stands: a ref against itself is a review of the uncommitted work
+ * on it, which is exactly what someone sitting on the trunk with a dirty tree
+ * is after.
  */
 import { useState, type FormEvent } from 'react'
 import { ArrowRight, CircleDot, Loader2 } from 'lucide-react'
@@ -27,7 +30,12 @@ import { Textarea } from '@/components/ui/textarea'
 import { errorMessage, firstFieldError } from '@/lib/errors'
 import { RefSelect } from './ref-select'
 import { useRepositoryRefs, useReviewMutations } from './use-reviews'
-import { createReviewInputSchema, updateReviewInputSchema } from '@shared/schemas'
+import {
+  createReviewInputSchema,
+  defaultReviewTitle,
+  isSelfReview,
+  updateReviewInputSchema
+} from '@shared/schemas'
 import { parseWithSchema } from '@shared/validation'
 import type { GitRef } from '@shared/git'
 import type { Review } from '@shared/schemas'
@@ -87,16 +95,11 @@ function ReviewForm({ repositoryId, review, onDone, onCreated }: ReviewFormProps
   const [error, setError] = useState<unknown>(null)
 
   const base = baseRef ?? refs?.defaultBranch ?? ''
-  const head =
-    headRef ??
-    // Don't default head to the same ref as base - that review is empty by
-    // definition, and the form would open already invalid.
-    (refs?.currentBranch && refs.currentBranch !== (refs.defaultBranch ?? '')
-      ? refs.currentBranch
-      : '')
+  const head = headRef ?? refs?.currentBranch ?? ''
 
   const availableRefs: GitRef[] = refs?.refs ?? []
   const headDetails = availableRefs.find((ref) => ref.name === head)
+  const selfReview = base !== '' && isSelfReview({ baseRef: base, headRef: head })
 
   async function submit(event: FormEvent): Promise<void> {
     event.preventDefault()
@@ -156,7 +159,8 @@ function ReviewForm({ repositoryId, review, onDone, onCreated }: ReviewFormProps
       <DialogHeader>
         <DialogTitle>{isEditing ? 'Edit review' : 'New review'}</DialogTitle>
         <DialogDescription>
-          Changes are compared from where the two refs diverged, the way a pull request is.
+          Changes are compared from where the two refs diverged, the way a pull request is. Pick
+          the same ref twice to review only what is uncommitted on it.
         </DialogDescription>
       </DialogHeader>
 
@@ -207,7 +211,38 @@ function ReviewForm({ repositoryId, review, onDone, onCreated }: ReviewFormProps
               <FieldError>{baseError ?? headError}</FieldError>
             )}
 
-            {headDetails?.hasUncommittedChanges && (
+            {/* A self-review has nothing committed in it, so what it holds is
+                worth stating before the user creates one - especially when the
+                answer right now is "nothing". */}
+            {selfReview && (
+              <p
+                className={`flex items-start gap-2 rounded-md px-3 py-2 text-xs ${
+                  headDetails?.hasUncommittedChanges
+                    ? 'bg-warning/10 text-warning'
+                    : 'bg-muted/60 text-muted-foreground'
+                }`}
+              >
+                <CircleDot className="mt-0.5 size-3.5 shrink-0" />
+                {headDetails?.hasUncommittedChanges ? (
+                  <span>
+                    This review is <span className="font-mono">{head}</span> against itself, so it
+                    holds only the uncommitted work in{' '}
+                    <span data-selectable className="font-mono">
+                      {headDetails.checkedOutAt}
+                    </span>
+                    .
+                  </span>
+                ) : (
+                  <span>
+                    This review is <span className="font-mono">{head}</span> against itself, so it
+                    holds only uncommitted work. There is none right now — it will fill in as you
+                    edit.
+                  </span>
+                )}
+              </p>
+            )}
+
+            {!selfReview && headDetails?.hasUncommittedChanges && (
               <p className="flex items-start gap-2 rounded-md bg-warning/10 px-3 py-2 text-xs text-warning">
                 <CircleDot className="mt-0.5 size-3.5 shrink-0" />
                 <span>
@@ -226,7 +261,7 @@ function ReviewForm({ repositoryId, review, onDone, onCreated }: ReviewFormProps
                 id="review-title"
                 value={title}
                 onChange={(event) => setTitle(event.target.value)}
-                placeholder={base && head ? `${head} into ${base}` : 'Describe the change'}
+                placeholder={base && head ? defaultReviewTitle(base, head) : 'Describe the change'}
                 data-invalid={titleError ? '' : undefined}
                 autoComplete="off"
               />

--- a/src/renderer/src/features/reviews/review-list.tsx
+++ b/src/renderer/src/features/reviews/review-list.tsx
@@ -16,6 +16,7 @@ import { navigate } from '@/lib/router'
 import { cn } from '@/lib/utils'
 import { ReviewFormDialog } from './review-form-dialog'
 import { useReviews } from './use-reviews'
+import { isSelfReview } from '@shared/schemas'
 import type { Review, ReviewStatus } from '@shared/schemas'
 
 type Filter = 'all' | ReviewStatus
@@ -185,8 +186,13 @@ function ReviewCard({ review }: { review: Review }) {
           {review.status === 'closed' && <Badge variant="outline">Closed</Badge>}
         </div>
         <p className="mt-1 flex items-center gap-1.5 truncate font-mono text-xs text-muted-foreground">
-          <span className="truncate">{review.baseRef}</span>
-          <ArrowRight className="size-3 shrink-0" />
+          {/* One endpoint, not two, when the review is a ref against itself. */}
+          {!isSelfReview(review) && (
+            <>
+              <span className="truncate">{review.baseRef}</span>
+              <ArrowRight className="size-3 shrink-0" />
+            </>
+          )}
           <span className="truncate">{review.headRef}</span>
         </p>
       </div>

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -135,22 +135,41 @@ export const listReviewsInputSchema = z.object({
   status: reviewStatusSchema.optional()
 })
 
-export const createReviewInputSchema = z
-  .object({
-    repositoryId: repositoryIdSchema,
-    /** Defaults to "<head> into <base>", the way a repository name defaults to
-     *  its folder name. */
-    title: z.string().trim().min(1, 'Title cannot be empty.').max(MAX_TITLE_LENGTH).optional(),
-    description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
-    /** What the changes are measured against - usually the trunk. */
-    baseRef: refSchema,
-    /** The branch under review. */
-    headRef: refSchema
-  })
-  .refine((value) => value.baseRef !== value.headRef, {
-    message: 'Pick two different refs - a ref compared against itself is empty.',
-    path: ['headRef']
-  })
+/**
+ * The two endpoints may be the *same* ref. That review is not empty: it holds
+ * whatever is uncommitted in the worktree that has the ref checked out, which
+ * is the state a reviewer most often wants a second pair of eyes on before it
+ * becomes a commit. See `isSelfReview`.
+ */
+export const createReviewInputSchema = z.object({
+  repositoryId: repositoryIdSchema,
+  /** Defaults to "<head> into <base>", or "Uncommitted work on <ref>" when the
+   *  two endpoints are the same ref. */
+  title: z.string().trim().min(1, 'Title cannot be empty.').max(MAX_TITLE_LENGTH).optional(),
+  description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
+  /** What the changes are measured against - usually the trunk. */
+  baseRef: refSchema,
+  /** The branch under review. */
+  headRef: refSchema
+})
+
+/**
+ * Is this review a ref compared against itself?
+ *
+ * Shared rather than inlined because the answer changes copy in four places -
+ * the review header, the list row, both tabs' empty states - and they should
+ * never disagree about what the user is looking at.
+ */
+export function isSelfReview(refs: { baseRef: string; headRef: string }): boolean {
+  return refs.baseRef === refs.headRef
+}
+
+/** The title a review gets when the user did not write one. */
+export function defaultReviewTitle(baseRef: string, headRef: string): string {
+  return isSelfReview({ baseRef, headRef })
+    ? `Uncommitted work on ${headRef}`
+    : `${headRef} into ${baseRef}`
+}
 
 export const updateReviewInputSchema = z
   .object({


### PR DESCRIPTION
Comparing a branch with itself was rejected on creation and on update, but it is a real review: the merge base of a ref with itself is its own tip, so the diff is exactly the uncommitted work in that ref's worktree — the state you most want a second pair of eyes on before it becomes a commit.

**The git layer needed no changes.** The restriction was purely the zod `refine` on `createReviewInputSchema` and the matching guard in `reviewsService.update`. Both are gone, and `isSelfReview` / `defaultReviewTitle` moved into `@shared/schemas` so every surface tells the same story.

What is new around it is the copy, so a review with one endpoint does not read like a mistake:

- default title is **Uncommitted work on `<ref>`**
- the review header and the list row draw one ref instead of an arrow between two
- the files tab's empty state distinguishes "nothing uncommitted right now" from "you turned the include-uncommitted switch off, which leaves this review empty by definition"
- the commits tab says a self-review holds only uncommitted work, rather than claiming head has nothing base does not
- the new-review form describes the option, warns when the picked ref has nothing uncommitted, and now defaults head to the current branch even when that is the trunk — so someone sitting on `main` with a dirty tree opens the form on exactly this review

The MCP `create_review` description and the README document the shape.

## Tests

`src/core/__tests__/reviews.test.ts` replaces "a ref cannot be compared against itself" with coverage that a self-review of the `feature` worktree contains `a.txt`, `staged.txt` and `untracked.txt` but *not* the committed `b.txt`, has zero commits, is empty with uncommitted work excluded, and can be reached by repointing an existing review.

`npm run typecheck`, `npm run lint`, `npm test` (197 pass) and `npm run build` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiAw6DzGMx8n8dwgZqZsUm
