### PR TITLE
Let the text field keep its own keyboard shortcuts

### DIFF
--- a/src/renderer/src/lib/__tests__/keys.test.ts
+++ b/src/renderer/src/lib/__tests__/keys.test.ts
@@ -7,7 +7,14 @@
  */
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { bindingSteps, eventToken, formatBinding, formatStep, normalizeStep } from '../keys.js'
+import {
+  bindingSteps,
+  eventToken,
+  formatBinding,
+  formatStep,
+  isTextEditingToken,
+  normalizeStep
+} from '../keys.js'
 
 function press(
   key: string,
@@ -64,4 +71,49 @@ test('renders Mac symbols run together and other platforms with pluses', () => {
 
 test('a chord renders as one step per key', () => {
   assert.deepEqual(formatBinding('g h', 'mac'), ['G', 'H'])
+})
+
+test('caret keys belong to the text field under every modifier', () => {
+  const owned = [
+    'arrowleft',
+    'mod+arrowleft',
+    'mod+arrowright',
+    'alt+arrowleft',
+    'mod+shift+arrowleft',
+    'mod+arrowup',
+    'home',
+    'mod+end',
+    'backspace',
+    'alt+backspace',
+    'mod+delete',
+    'pageup'
+  ]
+  for (const token of owned) {
+    assert.equal(isTextEditingToken(token, 'mac'), true, token)
+  }
+})
+
+test('clipboard and undo belong to the text field on either platform', () => {
+  for (const platform of ['mac', 'other'] as const) {
+    for (const key of ['a', 'c', 'v', 'x', 'z', 'y']) {
+      assert.equal(isTextEditingToken('mod+' + key, platform), true, 'mod+' + key)
+    }
+    assert.equal(isTextEditingToken('mod+shift+z', platform), true)
+  }
+})
+
+test('the emacs bindings belong to the text field only on macOS', () => {
+  assert.equal(isTextEditingToken('ctrl+a', 'mac'), true)
+  assert.equal(isTextEditingToken('ctrl+k', 'mac'), true)
+  assert.equal(isTextEditingToken('ctrl+e', 'mac'), true)
+  // Off a Mac the same physical key reads as `mod`, and a literal control
+  // press is not a text command anywhere else.
+  assert.equal(isTextEditingToken('ctrl+a', 'other'), false)
+})
+
+test('the app keeps the shortcuts a text field has no use for', () => {
+  const free = ['mod+k', 'mod+[', 'mod+]', 'mod+enter', 'mod+b', 'mod+i', 'g', '?']
+  for (const token of free) {
+    assert.equal(isTextEditingToken(token, 'mac'), false, token)
+  }
 })

--- a/src/renderer/src/lib/hotkeys.ts
+++ b/src/renderer/src/lib/hotkeys.ts
@@ -12,7 +12,9 @@
  *   - Nothing fires while a text field has focus. Typing "n" into a comment
  *     must not open a dialog, and no amount of cleverness beats simply not
  *     listening. Bindings that carry the command modifier are exempt, since
- *     ⌘K is expected to work from inside a field.
+ *     ⌘K is expected to work from inside a field - but not the ones the field
+ *     itself answers: ⌘← moves to the start of a line, and a shortcut that
+ *     navigated away instead would take the half-written comment with it.
  *   - Nothing fires while a dialog, menu or select is open. Those own the
  *     keyboard until they are dismissed.
  *
@@ -21,7 +23,7 @@
  * waiting for, which turns a mystery pause into an obvious one.
  */
 import { useEffect, useRef, useState } from 'react'
-import { bindingSteps, eventToken } from './keys'
+import { bindingSteps, eventToken, isTextEditingToken } from './keys'
 
 export interface Hotkey {
   /** `mod+k`, `]`, or a chord like `g h`. */
@@ -80,7 +82,8 @@ export function useHotkeys(hotkeys: Hotkey[]): string | null {
       if (token === null) return
 
       const carriesModifier = token.includes('mod+') || token.includes('meta+')
-      if (isTypingTarget(event.target) && !carriesModifier) return
+      const appOwnsKey = carriesModifier && !isTextEditingToken(token)
+      if (isTypingTarget(event.target) && !appOwnsKey) return
       if (document.querySelector(OVERLAY_SELECTOR) !== null) return
 
       const candidates = latest.current.map((hotkey) => ({

--- a/src/renderer/src/lib/keys.ts
+++ b/src/renderer/src/lib/keys.ts
@@ -156,3 +156,70 @@ export function formatStep(step: string, platform: Platform = currentPlatform())
 export function formatBinding(binding: string, platform: Platform = currentPlatform()): string[] {
   return bindingSteps(binding).map((step) => formatStep(step, platform))
 }
+
+/**
+ * Keys that move the caret or change the text under it, whatever decorates
+ * them: ⌘← is the start of the line, ⌥← is the previous word, ⇧⌘← selects to
+ * the start of it, and a bare ← is all three's undecorated cousin. There is no
+ * modifier combination in which these belong to the app instead.
+ */
+const CARET_KEYS = new Set([
+  'arrowleft',
+  'arrowright',
+  'arrowup',
+  'arrowdown',
+  'home',
+  'end',
+  'pageup',
+  'pagedown',
+  'backspace',
+  'delete'
+])
+
+/** The clipboard and undo commands, which every field answers with `mod`. */
+const MOD_EDITING_KEYS = new Set(['a', 'c', 'v', 'x', 'z', 'y'])
+
+/**
+ * Emacs-style bindings macOS text fields answer on the literal control key -
+ * ⌃A for the start of a line, ⌃K to kill to the end of it, and the rest.
+ * They are not muscle memory for everyone, but they are the system's to give,
+ * not ours to take.
+ */
+const MAC_CTRL_EDITING_KEYS = new Set([
+  'a',
+  'b',
+  'd',
+  'e',
+  'f',
+  'h',
+  'k',
+  'n',
+  'o',
+  'p',
+  't',
+  'v',
+  'w',
+  'y'
+])
+
+/**
+ * Whether a keystroke belongs to the text field rather than to the app.
+ *
+ * The global shortcut layer stands down for these while a field has focus, so
+ * that ⌘← moves to the start of the line the way it does everywhere else on
+ * the machine, instead of navigating back and taking a half-written comment
+ * with it. Outside a text field the same keystrokes are the app's to bind.
+ */
+export function isTextEditingToken(
+  token: string,
+  platform: Platform = currentPlatform()
+): boolean {
+  const parts = normalizeStep(token).split('+')
+  const key = parts.at(-1) ?? ''
+  const modifiers = new Set(parts.slice(0, -1))
+
+  if (CARET_KEYS.has(key)) return true
+  if (modifiers.has('mod') && MOD_EDITING_KEYS.has(key)) return true
+  if (platform === 'mac' && modifiers.has('ctrl') && MAC_CTRL_EDITING_KEYS.has(key)) return true
+  return false
+}


### PR DESCRIPTION
Pressing ⌘← part-way through writing a comment navigated back a screen and took the draft with it, instead of moving the caret to the start of the line.

## Cause

`useHotkeys` stands down inside a text field for bare keys only:

```ts
const carriesModifier = token.includes('mod+') || token.includes('meta+')
if (isTypingTarget(event.target) && !carriesModifier) return
```

The exemption exists so ⌘K still opens the palette from inside a field. But `nav:back` and `nav:forward` carry `mod+arrowleft` / `mod+arrowright` as aliases alongside ⌘[ and ⌘], so they cleared the exemption too — and `preventDefault()` then stopped the caret from moving.

## Fix

A new `isTextEditingToken` in `lib/keys.ts` names the keystrokes a text field owns, and the exemption now stops short of them:

- **caret keys under any modifier** — arrows, Home/End, PageUp/PageDown, Backspace/Delete. ⌘←, ⌥←, ⇧⌘←, ⌥⌫ are all the field's.
- **`mod` + a / c / v / x / z / y** — select-all, clipboard, undo and redo.
- **macOS `ctrl` + the emacs set** — ⌃A, ⌃E, ⌃K and the rest a Cocoa text field has always answered. Off a Mac that physical key reads as `mod`, so the rule is platform-aware.

Outside a text field the same keys stay the app's to bind, and ⌘K still opens the palette from inside one. ⌘[ / ⌘] are untouched: no field answers them, so they keep working everywhere.

## Verification

`npm test` (201 pass), `npm run typecheck`, `npm run lint` all clean. 20 new assertions cover the predicate on both platforms.

## Not in scope

The composer keeps no draft — a comment in progress is lost by any navigation, not just this one. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfRGXqfTNjckbaWdFoEAdU
