### PR TITLE
Show images in the diff instead of "binary file"

### DIFF
--- a/src/core/__tests__/diff-parser.test.ts
+++ b/src/core/__tests__/diff-parser.test.ts
@@ -124,6 +124,53 @@ test('binary files are flagged rather than parsed', () => {
   const [file] = parseUnifiedDiff(patch)
   assert.equal(file?.isBinary, true)
   assert.equal(file?.hunks.length, 0)
+  // No `---`/`+++` pair is emitted for a binary file, so the name has to come
+  // off the `diff --git` line or the file arrives nameless.
+  assert.equal(file?.path, 'logo.png')
+  assert.equal(file?.oldPath, null)
+})
+
+test('a binary path with a space in it is split on the repeated half', () => {
+  const patch = [
+    'diff --git a/art/my logo.png b/art/my logo.png',
+    'index 1234567..89abcde 100644',
+    'Binary files a/art/my logo.png and b/art/my logo.png differ',
+    ''
+  ].join('\n')
+
+  const [file] = parseUnifiedDiff(patch)
+  assert.equal(file?.path, 'art/my logo.png')
+})
+
+test('a renamed binary file takes its paths from the rename headers', () => {
+  const patch = [
+    'diff --git a/old/logo.png b/new/logo.png',
+    'similarity index 74%',
+    'rename from old/logo.png',
+    'rename to new/logo.png',
+    'index 1234567..89abcde 100644',
+    'Binary files a/old/logo.png and b/new/logo.png differ',
+    ''
+  ].join('\n')
+
+  const [file] = parseUnifiedDiff(patch)
+  assert.equal(file?.status, 'renamed')
+  assert.equal(file?.oldPath, 'old/logo.png')
+  assert.equal(file?.path, 'new/logo.png')
+})
+
+test('a deleted binary file keeps the path it used to have', () => {
+  const patch = [
+    'diff --git a/docs/banner.png b/docs/banner.png',
+    'deleted file mode 100644',
+    'index 1234567..0000000',
+    'Binary files a/docs/banner.png and /dev/null differ',
+    ''
+  ].join('\n')
+
+  const [file] = parseUnifiedDiff(patch)
+  assert.equal(file?.status, 'deleted')
+  assert.equal(file?.path, 'docs/banner.png')
 })
 
 test('several files in one patch are kept apart', () => {

--- a/src/core/__tests__/image-preview.test.ts
+++ b/src/core/__tests__/image-preview.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Coverage for showing an image in a diff instead of the words "binary file".
+ *
+ * Runs against a real repository with real PNGs in it, because the thing worth
+ * proving is that the bytes survive the trip: a blob read as text and re-encoded
+ * comes out corrupted, and the only way to notice is to compare it byte for byte
+ * with what was committed.
+ */
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, test } from 'node:test'
+
+import { readReviewImage } from '../git-compare.js'
+import { imageMediaType } from '../../shared/git.js'
+
+/** 1×1 PNGs, one red and one blue - different bytes, both genuinely decodable. */
+const RED_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
+const BLUE_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhQGAWpKrfwAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+const workDir = mkdtempSync(join(tmpdir(), 'gitwarren-image-'))
+const repoPath = join(workDir, 'project')
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}
+
+/** The image bytes back out of a `data:` URL, for comparing with the source. */
+function decode(dataUrl: string): { mediaType: string; bytes: Buffer } {
+  const match = /^data:([^;]+);base64,(.*)$/.exec(dataUrl)
+  assert.ok(match, `not a base64 data URL: ${dataUrl.slice(0, 40)}`)
+  const [, mediaType = '', body = ''] = match
+  return { mediaType, bytes: Buffer.from(body, 'base64') }
+}
+
+before(() => {
+  mkdirSync(repoPath, { recursive: true })
+  git(repoPath, 'init', '-b', 'main')
+  git(repoPath, 'config', 'user.email', 'test@example.com')
+  git(repoPath, 'config', 'user.name', 'Test')
+
+  writeFileSync(join(repoPath, 'logo.png'), RED_PNG)
+  writeFileSync(join(repoPath, 'notes.txt'), 'text\n')
+  git(repoPath, 'add', '.')
+  git(repoPath, 'commit', '-m', 'initial')
+
+  git(repoPath, 'checkout', '-b', 'feature')
+  // Changed on the head side, plus one that only exists there at all.
+  writeFileSync(join(repoPath, 'logo.png'), BLUE_PNG)
+  writeFileSync(join(repoPath, 'added.png'), BLUE_PNG)
+  git(repoPath, 'add', '.')
+  git(repoPath, 'commit', '-m', 'new artwork')
+
+  // And one that has not been committed anywhere, plus an uncommitted edit on
+  // top of the committed change - which is what the `uncommitted` view is about.
+  writeFileSync(join(repoPath, 'dirty.png'), RED_PNG)
+  writeFileSync(join(repoPath, 'logo.png'), RED_PNG)
+})
+
+after(() => {
+  rmSync(workDir, { recursive: true, force: true })
+})
+
+test('an extension decides whether a path is previewable', () => {
+  assert.equal(imageMediaType('docs/logo.PNG'), 'image/png')
+  assert.equal(imageMediaType('a/b.jpeg'), 'image/jpeg')
+  assert.equal(imageMediaType('src/index.ts'), null)
+  assert.equal(imageMediaType('icon.svg'), null, 'SVG has a real text diff already')
+  assert.equal(imageMediaType('.png'), null, 'a dotfile is not an extension')
+  assert.equal(imageMediaType('no-extension'), null)
+})
+
+test('both sides of a changed image come back, byte for byte', async () => {
+  const base = await readReviewImage(repoPath, 'main', 'feature', 'logo.png', 'base', {
+    changes: 'committed'
+  })
+  const head = await readReviewImage(repoPath, 'main', 'feature', 'logo.png', 'head', {
+    changes: 'committed'
+  })
+
+  assert.equal(base.error, null)
+  assert.equal(head.error, null)
+  assert.equal(base.source, 'commit')
+
+  const decodedBase = decode(base.dataUrl as string)
+  const decodedHead = decode(head.dataUrl as string)
+  assert.equal(decodedBase.mediaType, 'image/png')
+  assert.ok(decodedBase.bytes.equals(RED_PNG), 'the base blob should survive the round trip')
+  assert.ok(decodedHead.bytes.equals(BLUE_PNG), 'the head blob should survive the round trip')
+  assert.equal(base.byteSize, RED_PNG.byteLength)
+})
+
+test('an image that exists only on the head side has no base to read', async () => {
+  const base = await readReviewImage(repoPath, 'main', 'feature', 'added.png', 'base', {
+    changes: 'committed'
+  })
+
+  assert.ok(base.error, 'a blob that is not in the merge base should be reported, not thrown')
+  assert.equal(base.dataUrl, null)
+})
+
+test('uncommitted image work is read off disk, not from a commit', async () => {
+  const head = await readReviewImage(repoPath, 'main', 'feature', 'dirty.png', 'head', {
+    changes: 'all'
+  })
+
+  assert.equal(head.error, null)
+  assert.equal(head.source, 'worktree')
+  assert.ok(decode(head.dataUrl as string).bytes.equals(RED_PNG))
+})
+
+test('the uncommitted view measures "before" against the head commit', async () => {
+  // The whole point of that view is the edit being made right now, so its base
+  // is what was committed on the branch - not the merge base, which would put
+  // the whole branch's artwork on screen as though it were part of this change.
+  const base = await readReviewImage(repoPath, 'main', 'feature', 'logo.png', 'base', {
+    changes: 'uncommitted'
+  })
+  const head = await readReviewImage(repoPath, 'main', 'feature', 'logo.png', 'head', {
+    changes: 'uncommitted'
+  })
+
+  assert.equal(base.error, null)
+  assert.equal(base.source, 'commit')
+  assert.ok(decode(base.dataUrl as string).bytes.equals(BLUE_PNG), 'base is the head commit')
+  assert.equal(head.source, 'worktree')
+  assert.ok(decode(head.dataUrl as string).bytes.equals(RED_PNG))
+
+  // The same file in the whole-branch view starts from the merge base instead.
+  const wide = await readReviewImage(repoPath, 'main', 'feature', 'logo.png', 'base', {
+    changes: 'all'
+  })
+  assert.ok(decode(wide.dataUrl as string).bytes.equals(RED_PNG), 'base is the merge base')
+})
+
+test('a path outside the repository is refused rather than read', async () => {
+  const image = await readReviewImage(repoPath, 'main', 'feature', '../../secret.png', 'head', {
+    changes: 'committed'
+  })
+
+  assert.ok(image.error)
+  assert.equal(image.dataUrl, null)
+})
+
+test('a file that is not an image is refused before git is asked', async () => {
+  const image = await readReviewImage(repoPath, 'main', 'feature', 'notes.txt', 'head', {
+    changes: 'committed'
+  })
+
+  assert.ok(image.error)
+  assert.equal(image.dataUrl, null)
+})

--- a/src/core/diff-parser.ts
+++ b/src/core/diff-parser.ts
@@ -116,6 +116,52 @@ function stripPrefix(value: string): string {
   return path.replace(/^[ab]\//, '')
 }
 
+/**
+ * The two paths on a `diff --git a/x b/x` line.
+ *
+ * Normally redundant - the `---`/`+++` pair says the same thing and says it
+ * unambiguously - but a binary file has no such pair, so for a changed image
+ * this line is the *only* place its name appears in the patch. Without this a
+ * PNG arrives with an empty path.
+ *
+ * The ambiguity is real: git does not quote a name merely because it contains
+ * a space, so `a/my file.png b/my file.png` has to be split by knowing that
+ * both halves are the same path. When they are not - a rename - the extended
+ * `rename from`/`rename to` headers follow and overwrite whatever is guessed
+ * here, so an imperfect split costs nothing.
+ */
+function pathsFromGitHeader(rest: string): { oldPath: string; path: string } | null {
+  if (rest.startsWith('"')) {
+    // Quoted, which git does for control characters and (with quotePath on)
+    // non-ASCII. Each side is quoted separately, so a `" "` splits them.
+    const separator = rest.indexOf('" "')
+    if (separator === -1) return null
+    return {
+      oldPath: stripPrefix(rest.slice(0, separator + 1)),
+      path: stripPrefix(rest.slice(separator + 2))
+    }
+  }
+
+  // `a/` + path + ` b/` + path, with the same path twice: its length is what
+  // is left once the two prefixes and the separating space are taken out.
+  const length = (rest.length - 5) / 2
+  if (Number.isInteger(length) && length > 0) {
+    const candidate = rest.slice(2, 2 + length)
+    if (rest.startsWith('a/') && rest.slice(2 + length, 5 + length) === ' b/') {
+      return { oldPath: stripPrefix(`a/${candidate}`), path: stripPrefix(`b/${candidate}`) }
+    }
+  }
+
+  // Different paths on the two sides. Ambiguous in general; the first ` b/`
+  // is the best guess, and a rename header will correct it in a moment.
+  const split = rest.indexOf(' b/')
+  if (split === -1) return null
+  return {
+    oldPath: stripPrefix(rest.slice(0, split)),
+    path: stripPrefix(rest.slice(split + 1))
+  }
+}
+
 export function parseUnifiedDiff(patch: string, options: ParseDiffOptions = {}): FileDiff[] {
   const maxLines = options.maxLinesPerFile ?? DEFAULT_MAX_LINES_PER_FILE
   if (!patch.trim()) return []
@@ -138,6 +184,14 @@ export function parseUnifiedDiff(patch: string, options: ParseDiffOptions = {}):
       finishFile()
       file = emptyFile()
       hunk = null
+
+      const header = pathsFromGitHeader(line.slice('diff --git '.length))
+      if (header) {
+        file.path = header.path
+        // Only when the two sides genuinely differ, so an ordinary edit keeps
+        // the null that means "this file has always been called this".
+        if (header.oldPath && header.oldPath !== header.path) file.oldPath = header.oldPath
+      }
       continue
     }
 

--- a/src/core/git-compare.ts
+++ b/src/core/git-compare.ts
@@ -29,14 +29,17 @@
  */
 import { readFile, stat } from 'node:fs/promises'
 import { join, resolve, sep } from 'node:path'
-import { canonicalise, isDirectory, runGit, runGitRaw } from './git-exec.js'
+import { canonicalise, isDirectory, runGit, runGitBinary, runGitRaw } from './git-exec.js'
 import { buildUntrackedFileDiff, parseUnifiedDiff } from './diff-parser.js'
 import { AppError } from '../shared/errors.js'
+import { imageMediaType } from '../shared/git.js'
 import type {
   CompareEndpoint,
   DiffChanges,
+  DiffFileSide,
   FileContent,
   FileDiff,
+  FileImage,
   GitCommit,
   GitRef,
   GitWorktree,
@@ -788,6 +791,119 @@ export async function readReviewFile(
 
   const { lines, truncated } = toLines(result.stdout)
   return { path: filePath, source: 'commit', lines, truncated, isBinary: false, error: null }
+}
+
+/**
+ * Past this an image is named but not shown. Well above anything a repository
+ * has business carrying, and low enough that base64 crossing IPC stays cheap.
+ */
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024
+
+function emptyImage(path: string, side: DiffFileSide, error: string): FileImage {
+  return { path, side, dataUrl: null, byteSize: 0, source: null, error }
+}
+
+function toImage(
+  path: string,
+  side: DiffFileSide,
+  source: 'worktree' | 'commit',
+  mediaType: string,
+  bytes: Buffer
+): FileImage {
+  if (bytes.byteLength === 0) return emptyImage(path, side, 'That file is empty.')
+  if (bytes.byteLength > MAX_IMAGE_BYTES) {
+    return emptyImage(path, side, 'This image is too large to preview.')
+  }
+  return {
+    path,
+    side,
+    dataUrl: `data:${mediaType};base64,${bytes.toString('base64')}`,
+    byteSize: bytes.byteLength,
+    source,
+    error: null
+  }
+}
+
+/**
+ * One side's bytes of an image in a review, for showing the picture instead of
+ * the words "binary file".
+ *
+ * The side is the caller's to choose, and so is the path: a renamed file is a
+ * different path on each end of the comparison, and the UI is the only place
+ * that knows which one it is asking about. Base is read at the merge base, for
+ * the same reason the diff is taken there - it is the version the head branch
+ * actually started from, not whatever the base branch has moved on to.
+ */
+export async function readReviewImage(
+  repositoryPath: string,
+  baseRef: string,
+  headRef: string,
+  filePath: string,
+  side: DiffFileSide,
+  options: ReadDiffOptions
+): Promise<FileImage> {
+  if (!isSafeRelativePath(filePath)) {
+    return emptyImage(filePath, side, 'That is not a path inside this repository.')
+  }
+
+  const mediaType = imageMediaType(filePath)
+  if (mediaType === null) {
+    return emptyImage(filePath, side, 'That file is not an image this app can show.')
+  }
+
+  const compare = await resolveCompare(repositoryPath, baseRef, headRef)
+  if (compare.error) return emptyImage(filePath, side, compare.error)
+
+  const changes = effectiveChanges(options.changes, compare)
+
+  // Same rule as the diff and as the text read: unless the patch is
+  // committed-only, its head side *is* the worktree, so an image edited but not
+  // committed has to come off disk or the preview would show the old picture
+  // next to a diff that says it changed.
+  const worktree = side === 'head' && changes !== 'committed' ? compare.headWorktree : null
+
+  if (worktree) {
+    const absolute = join(worktree.path, filePath)
+    try {
+      const info = await stat(absolute)
+      if (!info.isFile()) throw new Error('not a file')
+      if (info.size > MAX_IMAGE_BYTES) {
+        return emptyImage(filePath, side, 'This image is too large to preview.')
+      }
+      return toImage(filePath, side, 'worktree', mediaType, await readFile(absolute))
+    } catch {
+      // Not on disk - deleted in the worktree, or never written there. The
+      // committed blob below is still the truth for the committed part.
+    }
+  }
+
+  // What "before" means follows the diff exactly: the merge base for a patch
+  // about the branch, the head commit for one about the working tree only.
+  // Reading the wrong one would put a picture on screen that no line of the
+  // diff claims changed.
+  const sha =
+    side === 'head' || changes === 'uncommitted' ? compare.head.sha : compare.mergeBase
+  if (!sha) {
+    return emptyImage(
+      filePath,
+      side,
+      side === 'base' && changes !== 'uncommitted'
+        ? 'These refs have no common history to compare against.'
+        : 'The head ref does not resolve to a commit.'
+    )
+  }
+
+  // Deliberately roomier than the preview ceiling: `execFile` *throws* when the
+  // output overruns `maxBuffer`, and an oversized image deserves the sentence
+  // saying so rather than a generic git failure. `toImage` applies the real cap.
+  const result = await runGitBinary(['cat-file', 'blob', `${sha}:${filePath}`], repositoryPath, {
+    maxBuffer: MAX_IMAGE_BYTES * 2
+  })
+  if (result.code !== 0) {
+    return emptyImage(filePath, side, result.stderr.trim() || 'Could not read that file from git.')
+  }
+
+  return toImage(filePath, side, 'commit', mediaType, result.stdout)
 }
 
 /**

--- a/src/core/git-exec.ts
+++ b/src/core/git-exec.ts
@@ -114,6 +114,54 @@ export async function runGitRaw(
   }
 }
 
+export interface GitBinaryResult {
+  stdout: Buffer
+  stderr: string
+  code: number
+}
+
+/**
+ * Like `runGitRaw`, but hands back the bytes.
+ *
+ * Needed for exactly one thing: reading an image blob out of the object
+ * database. Decoding a PNG as UTF-8 and re-encoding it does not round-trip, so
+ * the string-returning variants cannot be used for content that is not text.
+ */
+export async function runGitBinary(
+  args: string[],
+  cwd: string,
+  options: RunGitOptions = {}
+): Promise<GitBinaryResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync('git', args, {
+      cwd,
+      timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      maxBuffer: options.maxBuffer ?? DEFAULT_MAX_BUFFER,
+      windowsHide: true,
+      encoding: 'buffer',
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_OPTIONAL_LOCKS: '0' }
+    })
+    return { stdout, stderr: stderr.toString('utf8'), code: 0 }
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & {
+      stdout?: Buffer
+      stderr?: Buffer
+      code?: unknown
+    }
+    if (err.code === 'ENOENT') {
+      throw new AppError(
+        'GIT_UNAVAILABLE',
+        'Could not run `git`. Make sure git is installed and available on your PATH.'
+      )
+    }
+    return {
+      stdout: err.stdout ?? Buffer.alloc(0),
+      stderr: err.stderr?.toString('utf8') ?? '',
+      code: typeof err.code === 'number' ? err.code : 1
+    }
+  }
+}
+
 export async function isDirectory(path: string): Promise<boolean> {
   try {
     return (await stat(path)).isDirectory()

--- a/src/core/services/reviews.ts
+++ b/src/core/services/reviews.ts
@@ -21,6 +21,7 @@ import {
   readReviewCommits,
   readReviewDiff,
   readReviewFile,
+  readReviewImage,
   resolveCompare,
   resolveReviewFilePath
 } from '../git-compare.js'
@@ -35,11 +36,12 @@ import {
   reviewCommitsInputSchema,
   reviewDiffInputSchema,
   reviewFileInputSchema,
+  reviewImageInputSchema,
   updateReviewInputSchema,
   type Review,
   type ReviewWithRepository
 } from '../../shared/schemas.js'
-import type { FileContent, ReviewCommits, ReviewDiff } from '../../shared/git.js'
+import type { FileContent, FileImage, ReviewCommits, ReviewDiff } from '../../shared/git.js'
 
 function toReview(row: ReviewRow): Review {
   return {
@@ -240,6 +242,17 @@ export const reviewsService = {
     const row = requireReview(id)
     const repository = requireRepository(row.repositoryId)
     return readReviewFile(repository.path, row.baseRef, row.headRef, path, { changes })
+  },
+
+  /**
+   * One side's bytes of an image in this review, so the diff can show the
+   * picture instead of the words "binary file".
+   */
+  async image(input: unknown): Promise<FileImage> {
+    const { id, path, side, changes } = parse(reviewImageInputSchema, input)
+    const row = requireReview(id)
+    const repository = requireRepository(row.repositoryId)
+    return readReviewImage(repository.path, row.baseRef, row.headRef, path, side, { changes })
   },
 
   /**

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -64,6 +64,7 @@ export function registerIpcHandlers(): void {
   handle(IPC_CHANNELS.reviewsCommits, (input) => reviewsService.commits(input))
   handle(IPC_CHANNELS.reviewsDiff, (input) => reviewsService.diff(input))
   handle(IPC_CHANNELS.reviewsFile, (input) => reviewsService.file(input))
+  handle(IPC_CHANNELS.reviewsImage, (input) => reviewsService.image(input))
 
   // Two steps rather than one service call: *which* file on disk is review
   // knowledge and belongs in the service, while launching an application is a

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,7 +17,13 @@ import {
   type IpcResult,
   type UpdateStatus
 } from '../shared/api.js'
-import type { FileContent, RepositoryRefs, ReviewCommits, ReviewDiff } from '../shared/git.js'
+import type {
+  FileContent,
+  FileImage,
+  RepositoryRefs,
+  ReviewCommits,
+  ReviewDiff
+} from '../shared/git.js'
 import type {
   AddRepositoryInput,
   Attachment,
@@ -42,6 +48,7 @@ import type {
   ReviewDiffInput,
   ReviewedFile,
   ReviewFileInput,
+  ReviewImageInput,
   ReviewWithRepository,
   ListReviewedFilesInput,
   SetFileReviewedInput,
@@ -82,6 +89,7 @@ const api: GitWarrenApi = {
       invoke<ReviewCommits>(IPC_CHANNELS.reviewsCommits, input),
     diff: (input: ReviewDiffInput) => invoke<ReviewDiff>(IPC_CHANNELS.reviewsDiff, input),
     file: (input: ReviewFileInput) => invoke<FileContent>(IPC_CHANNELS.reviewsFile, input),
+    image: (input: ReviewImageInput) => invoke<FileImage>(IPC_CHANNELS.reviewsImage, input),
     openInEditor: (input: OpenReviewFileInput) =>
       invoke<void>(IPC_CHANNELS.reviewsOpenInEditor, input),
     reviewedFiles: (input: ListReviewedFilesInput) =>

--- a/src/renderer/src/features/reviews/diff-view.tsx
+++ b/src/renderer/src/features/reviews/diff-view.tsx
@@ -51,6 +51,7 @@ import { CommentComposer } from '../comments/comment-composer'
 import { CommentThreadCard } from '../comments/comment-thread-card'
 import { DiffSnippet } from './diff-snippet'
 import { FilePath } from './file-path'
+import { ImageDiff } from './image-diff'
 import { lineDomId } from './dom-ids'
 import { useReviewFile } from './use-reviews'
 import type { CommentMutations } from '../comments/use-comments'
@@ -64,6 +65,7 @@ import {
   type GapSegment
 } from '@shared/diff-gaps'
 import { errorMessage } from '@/lib/errors'
+import { imageMediaType } from '@shared/git'
 import type { DiffChanges, DiffHunk, DiffLine, FileChangeStatus, FileDiff } from '@shared/git'
 import type { CommentThread } from '@shared/schemas'
 
@@ -406,6 +408,13 @@ export function FileDiffCard({
   const unresolvedCount = threads.filter((thread) => thread.resolvedAt === null).length
 
   const hasBody = file.hunks.length > 0
+  /**
+   * A binary file git cannot diff, but a person can still see. The card then
+   * has something worth opening even though it has no lines - which is why the
+   * fold below asks `canToggle` rather than `hasBody`.
+   */
+  const showsImage = source !== undefined && file.isBinary && imageMediaType(file.path) !== null
+  const canToggle = hasBody || showsImage
   const totalLines = text.content && !text.content.isBinary ? text.content.lines.length : null
 
   const expandControls: ExpandControls = {
@@ -434,14 +443,14 @@ export function FileDiffCard({
           <button
             type="button"
             onClick={() => setExpanded(!expanded)}
-            disabled={!hasBody}
+            disabled={!canToggle}
             aria-expanded={expanded}
             className={cn(
               'flex min-w-0 items-center gap-2 px-3 py-2 text-left transition-colors',
-              hasBody ? 'hover:bg-muted/50' : 'cursor-default'
+              canToggle ? 'hover:bg-muted/50' : 'cursor-default'
             )}
           >
-            {hasBody ? (
+            {canToggle ? (
               expanded ? (
                 <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
               ) : (
@@ -636,7 +645,11 @@ export function FileDiffCard({
         </div>
       )}
 
-      {expanded && !hasBody && file.isBinary && (
+      {expanded && showsImage && source && (
+        <ImageDiff file={file} reviewId={source.reviewId} changes={source.changes} />
+      )}
+
+      {expanded && !hasBody && file.isBinary && !showsImage && (
         <p className="border-t border-border px-3 py-3 text-xs text-muted-foreground">
           Binary file — no text diff to show.
         </p>

--- a/src/renderer/src/features/reviews/image-diff.tsx
+++ b/src/renderer/src/features/reviews/image-diff.tsx
@@ -1,0 +1,172 @@
+/**
+ * The picture, instead of the words "binary file".
+ *
+ * A change to an image is two images, so this shows both ends of it side by
+ * side - the version the branch started from and the version it has now -
+ * labelled in the same red and green the line gutters use. A file that only
+ * exists on one side gets one pane, because inventing an empty second one
+ * would suggest the other version exists and is blank.
+ *
+ * The two sides are read independently: a rename means a different path on each
+ * end, and one side failing (a blob that is gone, an image past the size
+ * ceiling) should still leave the other on screen. Nothing is measured up
+ * front - the browser decodes the image anyway, so the dimensions are taken
+ * from the element once it has loaded rather than from a parser here.
+ */
+import { useState } from 'react'
+import { Skeleton } from '@/components/ui/skeleton'
+import { fileSize } from '@/lib/format'
+import { errorMessage } from '@/lib/errors'
+import { cn } from '@/lib/utils'
+import { useReviewImage } from './use-reviews'
+import type { DiffChanges, DiffFileSide, FileDiff } from '@shared/git'
+
+/**
+ * Which sides of the comparison hold an image, and under what path.
+ *
+ * Null means the file does not exist on that side at all. The base side of a
+ * rename is the *old* path, which is the one detail a caller cannot guess from
+ * `file.path` alone.
+ */
+export function imageSides(file: FileDiff): { base: string | null; head: string | null } {
+  const gone = file.status === 'deleted'
+  const fresh = file.status === 'added' || file.isUntracked
+  return {
+    base: fresh ? null : (file.oldPath ?? file.path),
+    head: gone ? null : file.path
+  }
+}
+
+/**
+ * A transparent PNG should read as transparent rather than as white-on-white or
+ * black-on-black, so it sits on the usual checkerboard. Drawn from the theme's
+ * own muted colour, which keeps it quiet in both light and dark.
+ */
+const CHECKERBOARD = {
+  backgroundImage:
+    'repeating-conic-gradient(var(--muted) 0% 25%, var(--card) 0% 50%)',
+  backgroundSize: '16px 16px'
+}
+
+const SIDE_LABELS: Record<DiffFileSide, string> = { base: 'Before', head: 'After' }
+
+export function ImageDiff({
+  file,
+  reviewId,
+  changes
+}: {
+  file: FileDiff
+  reviewId: number
+  changes: DiffChanges
+}) {
+  const sides = imageSides(file)
+  const both = sides.base !== null && sides.head !== null
+
+  return (
+    <div
+      className={cn(
+        'grid gap-3 border-t border-border p-3',
+        // One pane spans the width; two share it, and only once there is room
+        // for both to stay legible - a narrow window stacks them instead.
+        both && 'md:grid-cols-2'
+      )}
+    >
+      {sides.base !== null && (
+        <ImagePane
+          reviewId={reviewId}
+          path={sides.base}
+          side="base"
+          changes={changes}
+          renamedFrom={both && sides.base !== sides.head ? sides.base : null}
+        />
+      )}
+      {sides.head !== null && (
+        <ImagePane
+          reviewId={reviewId}
+          path={sides.head}
+          side="head"
+          changes={changes}
+          renamedFrom={null}
+        />
+      )}
+    </div>
+  )
+}
+
+function ImagePane({
+  reviewId,
+  path,
+  side,
+  changes,
+  renamedFrom
+}: {
+  reviewId: number
+  path: string
+  side: DiffFileSide
+  changes: DiffChanges
+  /** Set on the base pane of a rename, where the old name is worth showing. */
+  renamedFrom: string | null
+}) {
+  const { image, error, isLoading } = useReviewImage(reviewId, path, side, changes)
+  /** Filled in by the browser once it has decoded the image. */
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null)
+  const [failed, setFailed] = useState(false)
+
+  const problem = failed
+    ? 'This image could not be displayed.'
+    : (image?.error ?? (error === undefined ? null : errorMessage(error)))
+
+  return (
+    <figure className="flex min-w-0 flex-col gap-2">
+      <figcaption className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-xs">
+        <span className={side === 'base' ? 'text-destructive' : 'text-success'}>
+          {SIDE_LABELS[side]}
+        </span>
+        {renamedFrom !== null && (
+          <span className="min-w-0 truncate font-mono text-muted-foreground" title={renamedFrom}>
+            {renamedFrom}
+          </span>
+        )}
+        {size !== null && (
+          <span className="font-mono text-muted-foreground tabular-nums">
+            {size.width}×{size.height}
+          </span>
+        )}
+        {image?.dataUrl && (
+          <span className="font-mono text-muted-foreground tabular-nums">
+            {fileSize(image.byteSize)}
+          </span>
+        )}
+      </figcaption>
+
+      {problem !== null ? (
+        <p className="rounded-md border border-border bg-muted/40 px-3 py-6 text-center text-xs text-muted-foreground">
+          {problem}
+        </p>
+      ) : isLoading || !image?.dataUrl ? (
+        <Skeleton className="h-40 w-full" />
+      ) : (
+        <div
+          className="flex items-center justify-center overflow-hidden rounded-md border border-border p-2"
+          style={CHECKERBOARD}
+        >
+          <img
+            src={image.dataUrl}
+            alt={`${SIDE_LABELS[side]}: ${path}`}
+            // Capped rather than free-scrolling: the point is to see what
+            // changed at a glance, and a screenshot committed at retina size
+            // would otherwise push the next file off the screen entirely.
+            className="max-h-96 max-w-full object-contain"
+            onLoad={(event) =>
+              setSize({
+                width: event.currentTarget.naturalWidth,
+                height: event.currentTarget.naturalHeight
+              })
+            }
+            onError={() => setFailed(true)}
+          />
+        </div>
+      )}
+    </figure>
+  )
+}

--- a/src/renderer/src/features/reviews/use-reviews.ts
+++ b/src/renderer/src/features/reviews/use-reviews.ts
@@ -18,7 +18,9 @@ import { api, CACHE_KEYS, CACHE_PREFIXES } from '@/lib/api'
 import type { EditorList } from '@shared/api'
 import type {
   DiffChanges,
+  DiffFileSide,
   FileContent,
+  FileImage,
   RepositoryRefs,
   ReviewCommits,
   ReviewDiff
@@ -143,6 +145,29 @@ export function useReviewFile(
     requested,
     load: useCallback(() => setRequested(true), [])
   }
+}
+
+/**
+ * One side of an image in the diff, as a `data:` URL.
+ *
+ * Read as soon as it is asked for, unlike the text of a file: the caller is a
+ * preview that is already on screen, so there is nothing to defer. A null path
+ * means this side of the change has no image at all - a new file has no base,
+ * a deleted one has no head - and skips the read entirely.
+ */
+export function useReviewImage(
+  reviewId: number,
+  path: string | null,
+  side: DiffFileSide,
+  changes: DiffChanges
+): { image: FileImage | undefined; error: unknown; isLoading: boolean } {
+  const result = useSWR<FileImage, unknown>(
+    path === null ? null : CACHE_KEYS.reviewImage(reviewId, path, side, changes),
+    () => api.reviews.image({ id: reviewId, path: path as string, side, changes }),
+    LIVE_READ_OPTIONS
+  )
+
+  return { image: result.data, error: result.error, isLoading: result.isLoading }
 }
 
 /**

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -39,6 +39,13 @@ export const CACHE_KEYS = {
    */
   reviewFile: (reviewId: number, path: string, changes: DiffChanges) =>
     `review-file:${reviewId}:${changes}:${path}`,
+  /**
+   * One side of an image preview, keyed by the same setting for the same
+   * reason: which version of the picture is "before" depends on what the diff
+   * is made of.
+   */
+  reviewImage: (reviewId: number, path: string, side: string, changes: DiffChanges) =>
+    `review-image:${reviewId}:${changes}:${side}:${path}`,
   /** Installed code editors. Probed once per run; see `main/editors.ts`. */
   editors: 'editors',
   /**
@@ -64,6 +71,7 @@ export const CACHE_PREFIXES = {
   reviewCommits: 'review-commits:',
   reviewDiff: 'review-diff:',
   reviewFile: 'review-file:',
+  reviewImage: 'review-image:',
   reviewComments: 'review-comments:',
   reviewedFiles: 'review-reviewed:'
 } as const

--- a/src/renderer/src/lib/format.ts
+++ b/src/renderer/src/lib/format.ts
@@ -37,6 +37,22 @@ export function absoluteTime(iso: string | null): string {
   return Number.isNaN(timestamp) ? iso : ABSOLUTE.format(timestamp)
 }
 
+/**
+ * "412 KB". Powers of two with the units people expect next to a file, which
+ * is what every git host prints beside an image.
+ */
+export function fileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  const units = ['KB', 'MB', 'GB']
+  let value = bytes / 1024
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`
+}
+
 /** "3 files" / "1 file" - pluralisation is not worth a dependency. */
 export function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : pluralForm}`

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -7,7 +7,7 @@
  * this file is transport, not behaviour.
  */
 import type { SerializedAppError } from './errors.js'
-import type { FileContent, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
+import type { FileContent, FileImage, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
 import type {
   AddRepositoryInput,
   Attachment,
@@ -32,6 +32,7 @@ import type {
   ReviewDiffInput,
   ReviewedFile,
   ReviewFileInput,
+  ReviewImageInput,
   ReviewWithRepository,
   ListReviewedFilesInput,
   SetFileReviewedInput,
@@ -56,6 +57,7 @@ export const IPC_CHANNELS = {
   reviewsCommits: 'reviews:commits',
   reviewsDiff: 'reviews:diff',
   reviewsFile: 'reviews:file',
+  reviewsImage: 'reviews:image',
   reviewsOpenInEditor: 'reviews:openInEditor',
   reviewsReviewedFiles: 'reviews:reviewedFiles',
   reviewsSetFileReviewed: 'reviews:setFileReviewed',
@@ -184,6 +186,11 @@ export interface GitWarrenApi {
      * expanded context comes from the same version of the file.
      */
     file(input: ReviewFileInput): Promise<FileContent>
+    /**
+     * One side's bytes of an image in this review, as a `data:` URL. Asked for
+     * a side at a time, because a change to a picture is two pictures.
+     */
+    image(input: ReviewImageInput): Promise<FileImage>
     /** Open a file of this review in the reviewer's editor, at a line. */
     openInEditor(input: OpenReviewFileInput): Promise<void>
     /**

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -160,6 +160,62 @@ export interface FileContent {
 }
 
 /**
+ * Image formats a diff previews rather than writing off as "binary".
+ *
+ * Raster only, and deliberately so. SVG is text, so it already gets a real line
+ * diff, and rendering arbitrary agent-reachable markup as a document is a
+ * larger decision than showing a picture of a PNG.
+ */
+const IMAGE_MEDIA_TYPES: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+  avif: 'image/avif'
+}
+
+/**
+ * The media type to preview a path as, or null when it is not an image this
+ * app will show. Decided from the extension, the way every diff viewer decides
+ * it: the layout has to be chosen before any bytes are asked for.
+ */
+export function imageMediaType(path: string): string | null {
+  const name = path.slice(path.lastIndexOf('/') + 1)
+  const dot = name.lastIndexOf('.')
+  if (dot <= 0) return null
+  return IMAGE_MEDIA_TYPES[name.slice(dot + 1).toLowerCase()] ?? null
+}
+
+/**
+ * One side's bytes of an image in a review, as a `data:` URL an `<img>` can
+ * take directly.
+ *
+ * A data URL rather than a URL into the `gitwarren:` scheme, because the
+ * alternative is a second way to read blobs out of a repository - one that
+ * would have to re-derive which review, which ref and which path from a string
+ * anything on the page could construct. The images people commit are small
+ * enough that sending them over the same review-scoped call as the diff is the
+ * cheaper trade.
+ */
+export interface FileImage {
+  path: string
+  side: DiffFileSide
+  /** Null whenever `error` is set, and only then. */
+  dataUrl: string | null
+  /** Bytes of the image itself, not of the base64 that carried it. */
+  byteSize: number
+  /** Where the bytes came from - the worktree on disk, or a committed blob. */
+  source: 'worktree' | 'commit' | null
+  error: string | null
+}
+
+/** Which end of the comparison a blob is being read from. */
+export type DiffFileSide = 'base' | 'head'
+
+/**
  * Where a local branch stands against the remote branch it tracks.
  *
  * Worth carrying because a review's endpoints are branch *names*, and a name

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -223,6 +223,17 @@ export const reviewFileInputSchema = z.object({
 })
 
 /**
+ * One side's bytes of an image in a review. `side` is explicit because a
+ * preview shows both ends of the change at once, and `path` goes with it - a
+ * renamed file has a different name on each side.
+ */
+export const reviewImageInputSchema = reviewFileInputSchema.extend({
+  // Spelled out rather than reusing `diffSideSchema`, which is declared further
+  // down with the comment schemas and would not exist yet at this point.
+  side: z.enum(['base', 'head'])
+})
+
+/**
  * The same file, on its way to the user's editor. `editorId` comes from
  * `system.editors()`; an unknown one falls back to the first editor found
  * rather than failing, because the alternative is a dead button.
@@ -245,6 +256,7 @@ export type RemoveReviewInput = z.input<typeof removeReviewInputSchema>
 export type ReviewCommitsInput = z.input<typeof reviewCommitsInputSchema>
 export type ReviewDiffInput = z.input<typeof reviewDiffInputSchema>
 export type ReviewFileInput = z.input<typeof reviewFileInputSchema>
+export type ReviewImageInput = z.input<typeof reviewImageInputSchema>
 export type OpenReviewFileInput = z.input<typeof openReviewFileInputSchema>
 export type RepositoryRefsInput = z.input<typeof repositoryRefsInputSchema>
 


### PR DESCRIPTION
An image in a review is a change you judge by looking at it, so the file card now shows the picture rather than the sentence "Binary file — no text diff to show."

## What it looks like

A changed image gets both ends side by side — **Before** in red, **After** in green — on a checkerboard so a transparent PNG reads as transparent, each side labelled with its pixel dimensions and byte size. Added and deleted images get a single pane; a rename shows the old path over the base side. The card folds and unfolds like any other, and everything else in the diff is untouched.

## How the bytes get there

They cross IPC as a `data:` URL on the existing review-scoped call (`reviews.image`, one side at a time). The alternative — a second host under the `gitwarren:` scheme — would be a second, separately-authorised way to read blobs out of a repository, one that has to re-derive which review, which ref and which path from a string anything on the page can construct. Images people commit are small enough that the simpler path is the cheaper trade. The base side is read at the merge base, for the same reason the diff is taken there.

Reading raw bytes needed a buffer-returning `runGitBinary`: decoding a PNG as UTF-8 and re-encoding it does not round-trip, which the tests check byte for byte. Uncommitted image work is read off disk when the diff includes it, so an edited-but-uncommitted picture shows the picture on screen.

Raster formats only (png, jpg, gif, webp, bmp, ico, avif) with an 8 MB ceiling. SVG is text and already gets a real line diff, and rendering agent-reachable markup as a document is a larger decision than showing a picture of a PNG.

## A bug found on the way

A binary file arrived in the diff with an **empty path** — a changed image was listed as a nameless card. Git emits no `---`/`+++` pair for a binary file, and the parser took paths only from that pair. The `diff --git` line is now the fallback, split on the fact that both halves are the same path: git does not quote a name merely for containing a space, so the repeated-half length is the only unambiguous split point. Rename headers still win where they exist.

## Checks

`npm run typecheck`, `npm run lint`, and the full suite (206 tests, including 10 new ones) all pass. Verified in the running app against a scratch repo with a modified, an added, a deleted and an uncommitted image, in both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhSTR6kticdku3jrAZZM6C
