### PR TITLE
Make branch names copyable, and the ref picker searchable

### DIFF
--- a/src/renderer/src/components/breakable.tsx
+++ b/src/renderer/src/components/breakable.tsx
@@ -1,0 +1,41 @@
+/**
+ * Text that wraps at its separators rather than mid-word.
+ *
+ * Browsers do not reliably offer a break opportunity after `/`, so a long
+ * slash-separated string - a path, a branch name like
+ * `feat/searchable-branch-picker-in-review-form` - either overflows its column
+ * or has to be broken with `break-all`, which cuts through the middle of a
+ * word and makes the result harder to read than the overflow was. An explicit
+ * `<wbr>` after each separator gives the browser the break it would not find
+ * on its own, so `break-words` can do the rest without ever splitting a
+ * segment that would have fitted.
+ *
+ * See `features/reviews/file-path.tsx` for the same reasoning applied to a
+ * path that also wants its directories dimmed; this is the plain-text half of
+ * it, for the places that only need the wrapping.
+ */
+import { Fragment } from 'react'
+
+/** Hyphens and dots already break naturally; only `/` needs the hint. */
+export function Breakable({ text }: { text: string }) {
+  if (!text.includes('/')) return <>{text}</>
+
+  // `'a/b/'.split('/')` ends in an empty segment; the separator before it has
+  // already been printed, so nothing is owed for that tail.
+  const segments = text.split('/')
+
+  return (
+    <>
+      {segments.map((segment, index) => (
+        <Fragment key={index}>
+          {segment}
+          {index < segments.length - 1 && (
+            <>
+              /<wbr />
+            </>
+          )}
+        </Fragment>
+      ))}
+    </>
+  )
+}

--- a/src/renderer/src/components/highlighted-text.tsx
+++ b/src/renderer/src/components/highlighted-text.tsx
@@ -1,0 +1,57 @@
+/**
+ * Text with the characters a fuzzy query actually hit picked out.
+ *
+ * Shared by every search surface in the app, because a fuzzy result that does
+ * not show *why* it matched looks like the search misfired: "wsc" landing on
+ * `worktree-self-compare` is obvious only once the three letters are marked.
+ *
+ * The indices come from `fuzzyMatch`; adjacent hits are coalesced into one
+ * <mark> so a run reads as a word rather than as separate letters.
+ *
+ * Runs go through `Breakable` because what gets searched here is mostly
+ * slash-separated - paths, branch names - and a wrapped result should break at
+ * its separators rather than through the middle of a segment.
+ */
+import { Breakable } from '@/components/breakable'
+import { cn } from '@/lib/utils'
+
+interface HighlightedTextProps {
+  text: string
+  /** Indices into `text`, ascending. Empty means "no query", so render plain. */
+  indices: number[]
+  /** Styling for the matched runs. Defaults to the command palette's weight. */
+  markClassName?: string
+}
+
+export function HighlightedText({ text, indices, markClassName }: HighlightedTextProps) {
+  if (indices.length === 0) return <Breakable text={text} />
+
+  const hit = new Set(indices)
+  const parts: { text: string; match: boolean }[] = []
+
+  for (let position = 0; position < text.length; position += 1) {
+    const match = hit.has(position)
+    const last = parts.at(-1)
+    if (last && last.match === match) last.text += text[position]
+    else parts.push({ text: text[position] as string, match })
+  }
+
+  return (
+    <>
+      {parts.map((part, partIndex) =>
+        part.match ? (
+          <mark
+            key={partIndex}
+            className={cn('bg-transparent font-semibold text-foreground', markClassName)}
+          >
+            <Breakable text={part.text} />
+          </mark>
+        ) : (
+          <span key={partIndex}>
+            <Breakable text={part.text} />
+          </span>
+        )
+      )}
+    </>
+  )
+}

--- a/src/renderer/src/components/ui/combobox.tsx
+++ b/src/renderer/src/components/ui/combobox.tsx
@@ -1,0 +1,162 @@
+/**
+ * Combobox on Base UI's Combobox primitive - a select you can type into.
+ *
+ * The search field lives *inside* the popup rather than replacing the trigger.
+ * That keeps the closed control reading as a value ("main") rather than as an
+ * empty text box, while still putting a query one keystroke away once it is
+ * open; Base UI clears the query when the popup closes, so the field never
+ * holds a stale search.
+ *
+ * The popup deliberately refuses to inherit the trigger's width. A trigger can
+ * be half of a narrow dialog, and a list of branch names read at that width is
+ * the problem this component exists to solve - so the popup takes the wider of
+ * the anchor and its own floor, capped only by what the window has.
+ */
+import { Combobox as BaseCombobox } from '@base-ui/react/combobox'
+import { Check, ChevronsUpDown, Search } from 'lucide-react'
+import type { ComponentProps } from 'react'
+import { cn } from '@/lib/utils'
+
+export const Combobox = BaseCombobox.Root
+export const ComboboxValue = BaseCombobox.Value
+export const ComboboxCollection = BaseCombobox.Collection
+
+export function ComboboxTrigger({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof BaseCombobox.Trigger>) {
+  return (
+    <BaseCombobox.Trigger
+      className={cn(
+        'flex h-9 w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent',
+        'px-3 py-1 text-left text-sm shadow-sm transition-colors',
+        'hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50',
+        'data-[invalid]:border-destructive',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <BaseCombobox.Icon className="shrink-0 text-muted-foreground">
+        <ChevronsUpDown className="size-4" />
+      </BaseCombobox.Icon>
+    </BaseCombobox.Trigger>
+  )
+}
+
+/**
+ * The popup shell. `minWidth` is the floor the list may widen to, independent
+ * of the trigger; callers set it from how wide their content actually needs to
+ * be rather than from how wide the field happens to be.
+ */
+export function ComboboxContent({
+  className,
+  children,
+  minWidth = '24rem',
+  ...props
+}: ComponentProps<typeof BaseCombobox.Popup> & { minWidth?: string }) {
+  return (
+    <BaseCombobox.Portal>
+      <BaseCombobox.Positioner align="start" sideOffset={4} className="z-50 outline-none">
+        <BaseCombobox.Popup
+          style={{ width: `max(var(--anchor-width), ${minWidth})` }}
+          className={cn(
+            'flex max-h-[min(28rem,var(--available-height))] max-w-[var(--available-width)] flex-col',
+            'overflow-hidden rounded-md border border-border bg-card text-card-foreground shadow-lg',
+            'transition-[opacity,transform] duration-100',
+            'data-[starting-style]:scale-95 data-[starting-style]:opacity-0',
+            'data-[ending-style]:scale-95 data-[ending-style]:opacity-0',
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </BaseCombobox.Popup>
+      </BaseCombobox.Positioner>
+    </BaseCombobox.Portal>
+  )
+}
+
+export function ComboboxInput({ className, ...props }: ComponentProps<typeof BaseCombobox.Input>) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-border px-3">
+      <Search className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+      <BaseCombobox.Input
+        className={cn(
+          'h-9 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+export function ComboboxList({ className, ...props }: ComponentProps<typeof BaseCombobox.List>) {
+  return (
+    <BaseCombobox.List
+      className={cn('min-h-0 flex-1 overflow-y-auto overscroll-contain p-1 outline-none', className)}
+      {...props}
+    />
+  )
+}
+
+/**
+ * The "nothing matched" line.
+ *
+ * Base UI keeps this element mounted whatever the list is doing - it is the
+ * live region that announces the result count - and only swaps its children
+ * out. So the padding has to be conditional too: `empty:p-0` is what stops a
+ * silent, childless div from leaving a blank band above the first group.
+ */
+export function ComboboxEmpty({ className, ...props }: ComponentProps<typeof BaseCombobox.Empty>) {
+  return (
+    <BaseCombobox.Empty
+      className={cn('px-3 py-6 text-center text-sm text-muted-foreground empty:p-0', className)}
+      {...props}
+    />
+  )
+}
+
+export function ComboboxGroup({ className, ...props }: ComponentProps<typeof BaseCombobox.Group>) {
+  return <BaseCombobox.Group className={cn('block pb-1 last:pb-0', className)} {...props} />
+}
+
+export function ComboboxGroupLabel({
+  className,
+  ...props
+}: ComponentProps<typeof BaseCombobox.GroupLabel>) {
+  return (
+    <BaseCombobox.GroupLabel
+      className={cn(
+        'px-2 pb-1 pt-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export function ComboboxItem({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof BaseCombobox.Item>) {
+  return (
+    <BaseCombobox.Item
+      className={cn(
+        'relative flex cursor-default select-none items-start gap-2 rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none',
+        'data-[highlighted]:bg-muted data-[highlighted]:text-foreground',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <BaseCombobox.ItemIndicator className="absolute right-2 top-1.5 flex items-center text-primary">
+        <Check className="size-4" />
+      </BaseCombobox.ItemIndicator>
+    </BaseCombobox.Item>
+  )
+}

--- a/src/renderer/src/features/commands/command-palette.tsx
+++ b/src/renderer/src/features/commands/command-palette.tsx
@@ -25,6 +25,7 @@ import {
 } from 'react'
 import useSWR, { useSWRConfig } from 'swr'
 import { CornerDownLeft, FileDiff, FolderGit2, GitPullRequestArrow, Search } from 'lucide-react'
+import { HighlightedText } from '@/components/highlighted-text'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { Kbd } from '@/components/ui/kbd'
 import { api, CACHE_KEYS } from '@/lib/api'
@@ -445,7 +446,7 @@ function Row({
     >
       {Icon && <Icon className="size-4 shrink-0 text-muted-foreground" />}
       <span className="min-w-0 flex-1 truncate">
-        <Highlighted text={item.label} indices={entry.match.indices} />
+        <HighlightedText text={item.label} indices={entry.match.indices} />
       </span>
       {item.hint !== undefined && (
         <span className="max-w-[45%] shrink-0 truncate font-mono text-xs text-muted-foreground">
@@ -457,34 +458,5 @@ function Row({
         <CornerDownLeft className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
       )}
     </div>
-  )
-}
-
-/** The label with the characters the query actually hit picked out. */
-function Highlighted({ text, indices }: { text: string; indices: number[] }) {
-  if (indices.length === 0) return <>{text}</>
-
-  const hit = new Set(indices)
-  const parts: { text: string; match: boolean }[] = []
-
-  for (let position = 0; position < text.length; position += 1) {
-    const match = hit.has(position)
-    const last = parts.at(-1)
-    if (last && last.match === match) last.text += text[position]
-    else parts.push({ text: text[position] as string, match })
-  }
-
-  return (
-    <>
-      {parts.map((part, partIndex) =>
-        part.match ? (
-          <mark key={partIndex} className="bg-transparent font-semibold text-foreground">
-            {part.text}
-          </mark>
-        ) : (
-          <span key={partIndex}>{part.text}</span>
-        )
-      )}
-    </>
   )
 }

--- a/src/renderer/src/features/reviews/ref-chip.tsx
+++ b/src/renderer/src/features/reviews/ref-chip.tsx
@@ -1,0 +1,82 @@
+/**
+ * A ref name in the review header, which you can get back out again.
+ *
+ * The app sets `user-select: none` on the body - it is chrome, not a document -
+ * and that quietly made the one string a reviewer most often needs elsewhere
+ * (the branch they are about to check out) impossible to take with them. So
+ * this does both: the name is `data-selectable`, so a drag selects it the way
+ * it would anywhere else, and a copy button sits beside it for the far more
+ * common case of wanting the whole name in one click.
+ *
+ * The button is always rendered rather than revealed on hover. An affordance
+ * that only exists once you have found it is not much of an affordance, and at
+ * this size it costs a few pixels.
+ */
+import { Check, Copy } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { Breakable } from '@/components/breakable'
+import { Tooltip } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+interface RefChipProps {
+  name: string
+  /** What the ref is, for the copy button's label: "base ref", "compare ref". */
+  role: string
+  className?: string
+}
+
+export function RefChip({ name, role, className }: RefChipProps) {
+  const [copied, setCopied] = useState(false)
+  const timer = useRef<number | null>(null)
+
+  // The chip outlives no navigation, but the timer can: unmounting mid-flash
+  // would otherwise set state on a gone component.
+  useEffect(
+    () => () => {
+      if (timer.current !== null) window.clearTimeout(timer.current)
+    },
+    []
+  )
+
+  async function copy(): Promise<void> {
+    await navigator.clipboard.writeText(name)
+    setCopied(true)
+    if (timer.current !== null) window.clearTimeout(timer.current)
+    // Long enough to be read, short enough that the button is itself again
+    // before the reviewer next looks at it.
+    timer.current = window.setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex max-w-full items-center gap-1 rounded bg-muted py-0.5 pl-1.5 pr-0.5',
+        className
+      )}
+    >
+      {/* No `title`: the name is shown in full - it wraps rather than clips -
+          and a tooltip repeating it would only shadow the more useful one on
+          the copy button beside it. */}
+      <span data-selectable className="min-w-0 break-words">
+        <Breakable text={name} />
+      </span>
+      <Tooltip label={copied ? 'Copied' : `Copy ${role}`}>
+        <button
+          type="button"
+          onClick={() => void copy()}
+          aria-label={copied ? `${role} copied` : `Copy ${role}`}
+          className={cn(
+            'flex size-5 shrink-0 items-center justify-center rounded transition-colors',
+            'text-muted-foreground hover:bg-foreground/10 hover:text-foreground'
+          )}
+        >
+          {copied ? (
+            <Check className="size-3 text-success" />
+          ) : (
+            <Copy className="size-3" />
+          )}
+        </button>
+      </Tooltip>
+    </span>
+  )
+}

--- a/src/renderer/src/features/reviews/ref-select.tsx
+++ b/src/renderer/src/features/reviews/ref-select.tsx
@@ -6,18 +6,33 @@
  * somewhere and whether that worktree is dirty. Surfacing the dirty flag *here*,
  * before the review exists, is the point: it is how the user discovers there is
  * uncommitted work they could be reviewing.
+ *
+ * It is a combobox rather than a plain select for two reasons that only show up
+ * on a real repository. A checkout with a hundred branches is not navigable by
+ * scrolling, so the popup opens with a search field and scores against the same
+ * fuzzy matcher as the command palette - "wsc" finds `worktree-self-compare`,
+ * and the matched characters are marked so the hit explains itself. And branch
+ * names are long, while the field holding them is half of a dialog, so the
+ * popup takes a width of its own and rows *wrap* instead of truncating: the one
+ * place the full name is guaranteed legible is the place you pick it.
  */
 import { CircleDot, GitBranch, Tag } from 'lucide-react'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+import { HighlightedText } from '@/components/highlighted-text'
 import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectGroupLabel,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from '@/components/ui/select'
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxGroupLabel,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+  ComboboxValue
+} from '@/components/ui/combobox'
+import { fuzzyMatch } from '@/lib/fuzzy'
 import type { GitRef } from '@shared/git'
 
 interface RefSelectProps {
@@ -35,53 +50,119 @@ const GROUPS = [
   { kind: 'tag' as const, label: 'Tags', icon: Tag }
 ]
 
+/** One group as Base UI wants it: a `value` to key on and its `items`. */
+interface RefGroup {
+  value: string
+  items: string[]
+}
+
 export function RefSelect({ id, refs, value, onChange, disabled, invalid }: RefSelectProps) {
-  // `items` is what lets the trigger render the chosen ref's label rather than
-  // its raw value; it also keeps a since-deleted ref displayable.
-  const items = useMemo(
-    () => refs.map((ref) => ({ value: ref.name, label: ref.name })),
+  const [query, setQuery] = useState('')
+
+  // Names alone are the item values, so selection stays a plain string and the
+  // trigger can render a ref that has since been deleted. Everything the rows
+  // need beyond the name is looked up here.
+  const byName = useMemo(() => {
+    const map = new Map<string, GitRef>()
+    for (const ref of refs) map.set(ref.name, ref)
+    return map
+  }, [refs])
+
+  const allGroups = useMemo<RefGroup[]>(
+    () =>
+      GROUPS.map(({ kind, label }) => ({
+        value: label,
+        items: refs.filter((ref) => ref.kind === kind).map((ref) => ref.name)
+      })).filter((group) => group.items.length > 0),
     [refs]
   )
 
+  // Filtering is ours rather than the primitive's so the ranking and the
+  // highlight positions come from the same pass: within a group the best match
+  // rises to the top, and each row is told which characters to mark.
+  const { groups, marks } = useMemo(() => {
+    const trimmed = query.trim()
+    if (trimmed === '') return { groups: allGroups, marks: new Map<string, number[]>() }
+
+    const hits = new Map<string, number[]>()
+    const filtered: RefGroup[] = []
+
+    for (const group of allGroups) {
+      const scored: { name: string; score: number }[] = []
+      for (const name of group.items) {
+        const match = fuzzyMatch(trimmed, name)
+        if (match === null) continue
+        hits.set(name, match.indices)
+        scored.push({ name, score: match.score })
+      }
+      if (scored.length === 0) continue
+
+      scored.sort((a, b) => b.score - a.score)
+      filtered.push({ value: group.value, items: scored.map((entry) => entry.name) })
+    }
+
+    return { groups: filtered, marks: hits }
+  }, [allGroups, query])
+
+  const iconFor = (name: string): typeof GitBranch =>
+    byName.get(name)?.kind === 'tag' ? Tag : GitBranch
+
   return (
-    <Select
-      items={items}
+    <Combobox
+      items={allGroups}
+      filteredItems={groups}
       value={value}
       onValueChange={(next) => onChange(typeof next === 'string' ? next : '')}
+      onInputValueChange={setQuery}
       disabled={disabled}
     >
-      <SelectTrigger id={id} data-invalid={invalid ? '' : undefined}>
-        <SelectValue className="truncate font-mono text-xs" />
-      </SelectTrigger>
-      <SelectContent>
-        {GROUPS.map(({ kind, label, icon: Icon }) => {
-          const group = refs.filter((ref) => ref.kind === kind)
-          if (group.length === 0) return null
+      <ComboboxTrigger id={id} data-invalid={invalid ? '' : undefined}>
+        {/* The trigger is as narrow as the field, so the full name lives in a
+            `title` for the times the user only wants to read it. */}
+        <span className="min-w-0 truncate font-mono text-xs" title={value || undefined}>
+          <ComboboxValue placeholder="Pick a ref" />
+        </span>
+      </ComboboxTrigger>
 
-          return (
-            <SelectGroup key={kind}>
-              <SelectGroupLabel>{label}</SelectGroupLabel>
-              {group.map((ref) => (
-                <SelectItem key={ref.fullName} value={ref.name}>
-                  <span className="flex min-w-0 items-center gap-2">
-                    <Icon className="size-3.5 shrink-0 text-muted-foreground" />
-                    <span className="truncate font-mono text-xs">{ref.name}</span>
-                    {ref.hasUncommittedChanges && (
-                      <span
-                        className="flex shrink-0 items-center gap-1 text-[0.6875rem] font-medium text-warning"
-                        title={`Uncommitted changes in ${ref.checkedOutAt ?? 'its worktree'}`}
-                      >
-                        <CircleDot className="size-3" />
-                        uncommitted
+      <ComboboxContent minWidth="26rem" aria-label="Select a branch or tag">
+        <ComboboxInput placeholder="Search branches and tags" />
+        <ComboboxEmpty>No branch or tag matches that.</ComboboxEmpty>
+        <ComboboxList>
+          {(group: RefGroup) => (
+            <ComboboxGroup key={group.value} items={group.items}>
+              <ComboboxGroupLabel>{group.value}</ComboboxGroupLabel>
+              <ComboboxCollection>
+                {(name: string) => {
+                  const ref = byName.get(name)
+                  const Icon = iconFor(name)
+
+                  return (
+                    <ComboboxItem key={name} value={name}>
+                      <Icon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+                      {/* Wrapping rather than truncating: a branch name that
+                          does not fit runs onto a second line, so it is never
+                          half-shown. `HighlightedText` breaks it at its
+                          slashes rather than mid-segment. */}
+                      <span className="min-w-0 flex-1 break-words font-mono text-xs">
+                        <HighlightedText text={name} indices={marks.get(name) ?? []} />
                       </span>
-                    )}
-                  </span>
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          )
-        })}
-      </SelectContent>
-    </Select>
+                      {ref?.hasUncommittedChanges && (
+                        <span
+                          className="mt-0.5 flex shrink-0 items-center gap-1 text-[0.6875rem] font-medium text-warning"
+                          title={`Uncommitted changes in ${ref.checkedOutAt ?? 'its worktree'}`}
+                        >
+                          <CircleDot className="size-3" />
+                          uncommitted
+                        </span>
+                      )}
+                    </ComboboxItem>
+                  )
+                }}
+              </ComboboxCollection>
+            </ComboboxGroup>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
   )
 }

--- a/src/renderer/src/features/reviews/review-detail.tsx
+++ b/src/renderer/src/features/reviews/review-detail.tsx
@@ -33,6 +33,7 @@ import { plural } from '@/lib/format'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
 import { navigate, replace, REVIEW_TABS, type DiffFocus, type ReviewTab } from '@/lib/router'
 import { useReviewComments } from '../comments/use-comments'
+import { RefChip } from './ref-chip'
 import { ReviewCommitsTab } from './review-commits-tab'
 import { ReviewConversationTab } from './review-conversation-tab'
 import { ReviewFilesTab } from './review-files-tab'
@@ -213,12 +214,12 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
                   committed on main yet. */}
               {!selfReview && (
                 <>
-                  <span className="rounded bg-muted px-1.5 py-0.5">{review.baseRef}</span>
+                  <RefChip name={review.baseRef} role="base ref" />
                   <UpstreamDrift endpoint={commits.data?.base} role="base" />
                   <ArrowRight className="size-3" />
                 </>
               )}
-              <span className="rounded bg-muted px-1.5 py-0.5">{review.headRef}</span>
+              <RefChip name={review.headRef} role={selfReview ? 'ref' : 'compare ref'} />
               <UpstreamDrift endpoint={commits.data?.head} role="head" />
               {workingTree?.isDirty && (
                 <Badge

--- a/src/renderer/src/features/reviews/review-form-dialog.tsx
+++ b/src/renderer/src/features/reviews/review-form-dialog.tsx
@@ -58,7 +58,10 @@ export function ReviewFormDialog({
 }: ReviewFormDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      {/* Wider than the other dialogs on purpose: the two ref fields sit side
+          by side, and at `max-w-lg` each one is too narrow to show a branch
+          name of any realistic length. */}
+      <DialogContent className="max-w-2xl">
         {open && (
           <ReviewForm
             key={review?.id ?? 'new'}

--- a/src/renderer/src/features/reviews/review-list.tsx
+++ b/src/renderer/src/features/reviews/review-list.tsx
@@ -189,11 +189,18 @@ function ReviewCard({ review }: { review: Review }) {
           {/* One endpoint, not two, when the review is a ref against itself. */}
           {!isSelfReview(review) && (
             <>
-              <span className="truncate">{review.baseRef}</span>
+              {/* The row is a navigation target, so the refs cannot be copied
+                  from here - that lives on the review itself. A `title` at
+                  least means a name the card cut off is still readable. */}
+              <span className="truncate" title={review.baseRef}>
+                {review.baseRef}
+              </span>
               <ArrowRight className="size-3 shrink-0" />
             </>
           )}
-          <span className="truncate">{review.headRef}</span>
+          <span className="truncate" title={review.headRef}>
+            {review.headRef}
+          </span>
         </p>
       </div>
 


### PR DESCRIPTION
Two complaints, one subject: the branch name on a review was impossible to get back out, and the picker you set it with was impossible to read.

## Copying it out

The app sets `user-select: none` on the body — it is chrome, not a document — which quietly made the one string a reviewer most often needs elsewhere unselectable. The header refs now render as a `RefChip`:

- the name is `data-selectable`, so a drag selects it the way it would anywhere else;
- a copy button sits beside it for the far more common case of wanting the whole name in one click.

The button is always rendered rather than revealed on hover — an affordance you have to find first is not much of an affordance.

## Reading it

`RefSelect` is a combobox now rather than a select, with the search field **inside** the popup so the closed control still reads as a value rather than as an empty text box.

- It scores against the same fuzzy matcher as the command palette — `kbdshort` finds `feat/keyboard-shortcuts` — and marks the characters that hit, so a result explains itself. `Highlighted` moves out of the palette into a shared `HighlightedText` for that.
- The popup takes a width of its own instead of inheriting the trigger's, because the trigger is half of a dialog and that is the whole problem.
- Rows **wrap** rather than truncate, so the one place a branch name is guaranteed legible is the place you pick it.
- The form dialog goes to `max-w-2xl` for the same reason.
- In the review list, where the row is a navigation target and cannot hold a copy button, a truncated ref at least gets a `title`.

## Rebased onto #22

`file-path.tsx` landed on main while this was open, and it settles two questions this branch had answered differently. Both are now aligned with it:

- **Wrapping.** A branch name is slash-separated like a path, so it breaks at its separators via `<wbr>` rather than with `break-all` cutting through the middle of a segment. The `<wbr>`-insertion is pulled out as a shared `Breakable`, which `HighlightedText` also uses — so a wrapped search result breaks sensibly too. `origin/feat/attachment-drag-and-drop-into-comments` now wraps after `into-`, not mid-word.
- **Redundant tooltips.** The chip's `title` is gone: the name is shown in full, and a tooltip repeating it would only shadow the more useful one on the copy button beside it.

`file-path.tsx` still carries its own `<wbr>` logic — it is entangled with the directory/name split and dimming, so I left it alone rather than widen this PR, but it could adopt `Breakable` later.

## Verification

Driven against a demo repository with 22 branches, 9 remotes and 6 tags, using the built app over CDP:

| check | result |
| --- | --- |
| unfiltered list | 37 rows, grouped Branches / Remote branches / Tags |
| `kbdshort` | 1 row — `feat/keyboard-shortcuts`, marks `k`,`b`,`d`,`short` |
| `searchable` | 2 rows — local and remote, each in its own group |
| `v01` | 6 tags |
| `zzzqqq` | 0 rows, empty state shown |
| popup vs trigger width | 416px vs 299px |
| long name wrapping | 2 lines, 2 `<wbr>`, breaks at separators |
| keyboard only | tab → Enter opens with focus in the search field → type → ArrowDown → Enter commits → focus returns to the trigger |
| Escape | closes the popup, leaves the dialog open |
| copy button | writes the ref to the clipboard, label flips to "copied" and back |
| ref name | `user-select: text` while surrounding chrome stays `none` |

`npm run typecheck`, `npm run lint` and `npm test` (217 passing) are clean after the rebase.

One deliberate call worth flagging: with a query, ranking is by fuzzy score *within* each group, but the groups keep their fixed order — so `orgmain` puts a local branch above `origin/main`. Branches-before-remotes seemed the right default for a branch picker, but say the word and I'll rank across groups instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gVojo25v35JAkEahF5oPo
