### PR TITLE
Add a third view of a review's changes: uncommitted only

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,22 @@ Given the head's worktree, the diff is `git diff <merge-base>` run **inside it**
 with no second endpoint — which compares the merge base against the working tree,
 so committed, staged and unstaged changes all arrive in one patch.
 
+The files-changed tab offers three views of that, and the difference between
+them is only which commit the diff is taken against:
+
+| View | Command | What you see |
+| --- | --- | --- |
+| Committed | `git diff <merge-base> <head>` | the branch as it would arrive if pushed |
+| All | `git diff <merge-base>` in the worktree | that, plus everything uncommitted |
+| Uncommitted | `git diff <head>` in the worktree | only the edit being made right now |
+
+The third exists for the case where you are making a small change on top of a
+long-lived branch and want to see just that change. It is the same view a review
+of a ref against itself gives — the merge base of a ref with itself *is* its own
+tip — reached without repointing the review's endpoints and back again. It needs
+a worktree holding the head; without one it shows nothing rather than silently
+widening back out to the whole branch.
+
 Untracked files are handled separately: they are listed with
 `git ls-files --others --exclude-standard` (so `.gitignore` still applies) and
 rendered as whole-file additions. The tempting alternative — staging them into a
@@ -316,9 +332,9 @@ The unfolding costs one read of the whole file, taken the first time the
 reviewer asks and reused for every later expansion of the same file. It is
 deliberately not a line-range API: a range per click would be a git process per
 click, and reading the file once is also the only way to know where it *ends*,
-which no hunk header can say. The read follows the "include uncommitted" switch,
-because context taken from the other version of the file would not line up with
-the hunks it sits between. `src/shared/diff-gaps.ts` holds the arithmetic that
+which no hunk header can say. The read follows whichever view of the changes is
+on screen, because context taken from another version of the file would not line
+up with the hunks it sits between. `src/shared/diff-gaps.ts` holds the arithmetic that
 decides where the hidden runs are and which line number each unfolded line gets;
 it is pure, and unit-tested against the shapes that get this wrong — a diff that
 does not start at line 1, and git's off-by-one convention for an empty range.
@@ -762,8 +778,8 @@ the nearest to the original position wins; a near miss inside the right file
 beats losing the comment.
 
 The same function runs in both surfaces. The renderer anchors against the diff
-already on screen — which matters, because the *include uncommitted* switch
-produces a genuinely different diff with different line numbers — and
+already on screen — which matters, because each view of the changes is a
+genuinely different diff with different line numbers — and
 `list_review_comments` anchors against a diff it reads itself, so an agent and
 the screen never disagree about where a comment sits.
 

--- a/src/core/__tests__/reviews.test.ts
+++ b/src/core/__tests__/reviews.test.ts
@@ -132,9 +132,9 @@ test('a ref compared against itself reviews the uncommitted work on it', async (
   })
   assert.equal(review.title, 'Uncommitted work on feature')
 
-  const diff = await reviewsService.diff({ id: review.id, includeUncommitted: true })
+  const diff = await reviewsService.diff({ id: review.id, changes: 'all' })
   assert.equal(diff.error, null)
-  assert.equal(diff.includedUncommitted, true)
+  assert.equal(diff.changes, 'all')
 
   // The merge base of a ref with itself is its own tip, so nothing that has
   // been committed shows up - b.txt and the committed half of a.txt are gone,
@@ -165,7 +165,7 @@ test('a self-review with uncommitted work excluded is empty', async () => {
     headRef: 'feature'
   })
 
-  const diff = await reviewsService.diff({ id: review.id, includeUncommitted: false })
+  const diff = await reviewsService.diff({ id: review.id, changes: 'committed' })
   assert.equal(diff.error, null)
   assert.deepEqual(diff.files, [])
 })
@@ -202,10 +202,10 @@ test('the commits tab lists what head added, and finds the uncommitted work', as
 
 test('the diff folds uncommitted work in, and leaves ignored files out', async () => {
   const id = await createReview()
-  const diff = await reviewsService.diff({ id, includeUncommitted: true })
+  const diff = await reviewsService.diff({ id, changes: 'all' })
 
   assert.equal(diff.error, null)
-  assert.equal(diff.includedUncommitted, true)
+  assert.equal(diff.changes, 'all')
 
   const paths = diff.files.map((file) => file.path).sort()
   assert.deepEqual(paths, ['a.txt', 'b.txt', 'staged.txt', 'untracked.txt'])
@@ -234,9 +234,9 @@ test('the diff folds uncommitted work in, and leaves ignored files out', async (
 
 test('uncommitted work can be excluded, leaving the committed diff', async () => {
   const id = await createReview()
-  const diff = await reviewsService.diff({ id, includeUncommitted: false })
+  const diff = await reviewsService.diff({ id, changes: 'committed' })
 
-  assert.equal(diff.includedUncommitted, false)
+  assert.equal(diff.changes, 'committed')
   const paths = diff.files.map((file) => file.path).sort()
   assert.deepEqual(paths, ['a.txt', 'b.txt'])
 
@@ -252,9 +252,55 @@ test('uncommitted work can be excluded, leaving the committed diff', async () =>
   assert.equal(diff.workingTree?.isDirty, true)
 })
 
+test('the diff can be narrowed to only the uncommitted work on the branch', async () => {
+  const id = await createReview()
+  const diff = await reviewsService.diff({ id, changes: 'uncommitted' })
+
+  assert.equal(diff.error, null)
+  assert.equal(diff.changes, 'uncommitted')
+
+  // b.txt is committed on feature and is therefore *not* here, even though it
+  // is part of what this review is about. That is the whole point: what is on
+  // screen is the edit being made right now, not the branch it sits on.
+  const paths = diff.files.map((file) => file.path).sort()
+  assert.deepEqual(paths, ['a.txt', 'staged.txt', 'untracked.txt'])
+  assert.ok(diff.files.every((file) => file.hasUncommittedChanges))
+
+  const a = diff.files.find((file) => file.path === 'a.txt')
+  // Only the uncommitted line, not the committed edit that made TWO uppercase.
+  assert.equal(a?.additions, 1)
+  assert.equal(a?.deletions, 0)
+  assert.ok(
+    a?.hunks.some((hunk) =>
+      hunk.lines.some((line) => line.type === 'insert' && line.content.includes('uncommitted'))
+    )
+  )
+
+  // Same view a self-review gives, reached without repointing the endpoints.
+  const self = await reviewsService.create({
+    repositoryId,
+    baseRef: 'feature',
+    headRef: 'feature'
+  })
+  const selfDiff = await reviewsService.diff({ id: self.id, changes: 'all' })
+  assert.deepEqual(
+    selfDiff.files.map((file) => file.path).sort(),
+    paths
+  )
+})
+
+test('narrowing to uncommitted work reads files from the worktree', async () => {
+  const id = await createReview()
+  const content = await reviewsService.file({ id, path: 'a.txt', changes: 'uncommitted' })
+
+  assert.equal(content.error, null)
+  assert.equal(content.source, 'worktree')
+  assert.deepEqual(content.lines, ['one', 'TWO', 'three', 'four (uncommitted)'])
+})
+
 test('a file can be read whole, from the worktree, to expand the diff', async () => {
   const id = await createReview()
-  const content = await reviewsService.file({ id, path: 'a.txt', includeUncommitted: true })
+  const content = await reviewsService.file({ id, path: 'a.txt', changes: 'all' })
 
   assert.equal(content.error, null)
   assert.equal(content.source, 'worktree')
@@ -266,7 +312,7 @@ test('a file can be read whole, from the worktree, to expand the diff', async ()
 
 test('excluding uncommitted work reads the committed blob instead', async () => {
   const id = await createReview()
-  const content = await reviewsService.file({ id, path: 'a.txt', includeUncommitted: false })
+  const content = await reviewsService.file({ id, path: 'a.txt', changes: 'committed' })
 
   assert.equal(content.error, null)
   assert.equal(content.source, 'commit')

--- a/src/core/git-compare.ts
+++ b/src/core/git-compare.ts
@@ -21,6 +21,11 @@
  * base is that ref's own tip, so the diff reduces to exactly the uncommitted
  * work in its worktree. Nothing here special-cases it - it falls out of the
  * rules above - and reviews are allowed to be shaped that way on purpose.
+ *
+ * `DiffChanges` makes that view available without repointing a review at
+ * itself: diffing against the head commit instead of the merge base narrows any
+ * review down to the edit currently in the worktree, which is what you want
+ * while making a small change on top of a long branch.
  */
 import { readFile, stat } from 'node:fs/promises'
 import { join, resolve, sep } from 'node:path'
@@ -29,6 +34,7 @@ import { buildUntrackedFileDiff, parseUnifiedDiff } from './diff-parser.js'
 import { AppError } from '../shared/errors.js'
 import type {
   CompareEndpoint,
+  DiffChanges,
   FileContent,
   FileDiff,
   GitCommit,
@@ -542,10 +548,32 @@ export async function readReviewCommits(
 
 export interface ReadDiffOptions {
   /**
-   * Fold the head worktree's uncommitted work into the patch. Ignored when no
-   * worktree has the head branch checked out - there is nothing to fold in.
+   * Which changes the patch is made of - see `DiffChanges`. Asking for anything
+   * that needs the working tree when no worktree has the head branch checked
+   * out degrades to `committed` (`all`) or to nothing at all (`uncommitted`).
    */
-  includeUncommitted: boolean
+  changes: DiffChanges
+}
+
+/**
+ * What can actually be read, given where the head is - or is not - checked out.
+ *
+ * Split out because three call sites have to agree on it: the diff, the
+ * whole-file read that expands it, and the path handed to an editor. If they
+ * disagreed the expanded context would come from a different version of the
+ * file than the hunks it sits between.
+ */
+function effectiveChanges(
+  requested: DiffChanges,
+  compare: Pick<ReviewCompare, 'headWorktree' | 'workingTree'>
+): DiffChanges {
+  if (requested === 'committed') return 'committed'
+  const hasWorktree = compare.headWorktree !== null && compare.workingTree !== null
+  if (hasWorktree) return requested
+  // Nothing uncommitted to fold in: the whole-branch diff is still the honest
+  // answer for `all`, but `uncommitted` asked for the working tree specifically
+  // and must not quietly widen back out to the branch.
+  return requested === 'all' ? 'committed' : 'uncommitted'
 }
 
 export async function readReviewDiff(
@@ -555,17 +583,38 @@ export async function readReviewDiff(
   options: ReadDiffOptions
 ): Promise<ReviewDiff> {
   const compare = await resolveCompare(repositoryPath, baseRef, headRef)
-  const empty = { files: [], additions: 0, deletions: 0, includedUncommitted: false, truncated: false }
-  if (compare.error || !compare.mergeBase || !compare.head.sha) return { ...compare, ...empty }
+  const changes = effectiveChanges(options.changes, compare)
+  const empty = { files: [], additions: 0, deletions: 0, changes, truncated: false }
 
-  const includeUncommitted =
-    options.includeUncommitted && compare.headWorktree !== null && compare.workingTree !== null
+  if (!compare.head.sha) return { ...compare, ...empty }
+  // Only a diff measured against the base needs the merge base - and needs both
+  // endpoints to have resolved. Uncommitted work is measured against the head
+  // commit, so this function still reads it when the base ref cannot be
+  // resolved. (The review screen has its own opinion about showing a review
+  // whose endpoint is broken; that is not this function's call to make.)
+  if (changes !== 'uncommitted' && (compare.error || !compare.mergeBase)) {
+    return { ...compare, ...empty }
+  }
+  if (changes === 'uncommitted' && compare.workingTree === null) {
+    return { ...compare, ...empty }
+  }
 
-  // Inside the head's worktree, `git diff <merge-base>` with no second endpoint
-  // compares against the working tree, so committed and uncommitted changes
-  // arrive as one patch. With an explicit second endpoint it stays committed-only.
-  const cwd = includeUncommitted ? (compare.headWorktree as { path: string }).path : repositoryPath
-  const range = includeUncommitted ? [compare.mergeBase] : [compare.mergeBase, compare.head.sha]
+  // Non-null whenever `changes` is not `committed`: that is what
+  // `effectiveChanges` checked, and a bare worktree has no working tree to read.
+  const worktreePath = compare.workingTree?.worktreePath ?? repositoryPath
+
+  // Inside the head's worktree, `git diff <commit>` with no second endpoint
+  // compares against the working tree. Against the merge base that folds the
+  // branch's commits and its uncommitted work into one patch; against the head
+  // commit it leaves exactly the uncommitted work. With an explicit second
+  // endpoint nothing from the working tree is involved at all.
+  const cwd = changes === 'committed' ? repositoryPath : worktreePath
+  const range =
+    changes === 'committed'
+      ? [compare.mergeBase as string, compare.head.sha]
+      : changes === 'all'
+        ? [compare.mergeBase as string]
+        : [compare.head.sha]
 
   const result = await runGitRaw(
     [
@@ -589,14 +638,14 @@ export async function readReviewDiff(
 
   const files = parseUnifiedDiff(result.stdout)
 
-  if (includeUncommitted) {
+  if (changes !== 'committed') {
     files.push(...(await readUntrackedFiles(cwd)))
   }
 
   // Badge the files whose change is not (entirely) committed anywhere yet.
   const dirtyPaths = new Set(compare.workingTree?.paths ?? [])
   for (const file of files) {
-    if (!includeUncommitted) continue
+    if (changes === 'committed') continue
     if (file.isUntracked || dirtyPaths.has(file.path) || (file.oldPath !== null && dirtyPaths.has(file.oldPath))) {
       file.hasUncommittedChanges = true
     }
@@ -609,7 +658,7 @@ export async function readReviewDiff(
     files,
     additions: files.reduce((total, file) => total + file.additions, 0),
     deletions: files.reduce((total, file) => total + file.deletions, 0),
-    includedUncommitted: includeUncommitted,
+    changes,
     truncated: files.some((file) => file.truncated)
   }
 }
@@ -699,11 +748,11 @@ export async function readReviewFile(
   const compare = await resolveCompare(repositoryPath, baseRef, headRef)
   if (compare.error) return emptyContent(filePath, compare.error)
 
-  // Same rule as the diff: with uncommitted work folded in, the head side *is*
-  // the worktree, so the file has to be read from disk or the expanded context
-  // would not line up with the hunks around it.
+  // Same rule as the diff: with the working tree involved at all, the head side
+  // *is* the worktree, so the file has to be read from disk or the expanded
+  // context would not line up with the hunks around it.
   const worktree =
-    options.includeUncommitted && compare.workingTree !== null ? compare.headWorktree : null
+    effectiveChanges(options.changes, compare) === 'committed' ? null : compare.headWorktree
 
   if (worktree) {
     const absolute = join(worktree.path, filePath)
@@ -762,7 +811,7 @@ export async function resolveReviewFilePath(
   }
 
   const compare = await resolveCompare(repositoryPath, baseRef, headRef)
-  const worktree = options.includeUncommitted ? compare.headWorktree : null
+  const worktree = options.changes === 'committed' ? null : compare.headWorktree
   const roots = [...new Set([worktree?.path, compare.headWorktree?.path, repositoryPath])].filter(
     (root): root is string => typeof root === 'string'
   )

--- a/src/core/services/comments.ts
+++ b/src/core/services/comments.ts
@@ -36,6 +36,7 @@ import {
   type AnchorState,
   type DiffSide
 } from '../../shared/comment-anchors.js'
+import type { DiffChanges } from '../../shared/git.js'
 import { contextForRange, snippetAt } from '../../shared/comment-snippets.js'
 import { parseWithSchema as parse } from '../../shared/validation.js'
 import {
@@ -251,11 +252,10 @@ async function captureAnchor(
   filePath: string,
   side: DiffSide,
   line: number,
-  startLine: number | null
+  startLine: number | null,
+  changes: DiffChanges
 ): Promise<{ anchorText: string | null; anchorSha: string | null; snapshot: AnchorSnapshot | null }> {
-  const diff = await readReviewDiff(repositoryPath, review.baseRef, review.headRef, {
-    includeUncommitted: true
-  })
+  const diff = await readReviewDiff(repositoryPath, review.baseRef, review.headRef, { changes })
 
   const file = findAnchorFile(diff.files, filePath)
   const found = file?.hunks
@@ -355,7 +355,7 @@ export const commentsService = {
 
     const repository = requireRepository(review.repositoryId)
     const diff = await readReviewDiff(repository.path, review.baseRef, review.headRef, {
-      includeUncommitted: true
+      changes: 'all'
     })
 
     return threads.map((thread) => {
@@ -388,7 +388,8 @@ export const commentsService = {
       filePath,
       side,
       line,
-      startLine: requestedStart
+      startLine: requestedStart,
+      changes
     } = parse(createThreadInputSchema, input)
     const review = requireReview(reviewId)
     const repositoryPath = requireRepository(review.repositoryId).path
@@ -407,7 +408,15 @@ export const commentsService = {
     let anchorSha: string | null = null
     let anchorSnapshot: string | null = null
     if (filePath !== undefined && line !== undefined) {
-      const captured = await captureAnchor(repositoryPath, review, filePath, side, line, startLine)
+      const captured = await captureAnchor(
+        repositoryPath,
+        review,
+        filePath,
+        side,
+        line,
+        startLine,
+        changes
+      )
       anchorText = captured.anchorText
       anchorSha = captured.anchorSha
       anchorSnapshot = captured.snapshot === null ? null : JSON.stringify(captured.snapshot)

--- a/src/core/services/reviews.ts
+++ b/src/core/services/reviews.ts
@@ -220,26 +220,26 @@ export const reviewsService = {
     return readReviewCommits(repository.path, row.baseRef, row.headRef)
   },
 
-  /** The merge-base diff, optionally including uncommitted work. */
+  /** The diff, made of whichever changes `changes` asks for. */
   async diff(input: unknown): Promise<ReviewDiff> {
-    const { id, includeUncommitted } = parse(reviewDiffInputSchema, input)
+    const { id, changes } = parse(reviewDiffInputSchema, input)
     const row = requireReview(id)
     const repository = requireRepository(row.repositoryId)
-    return readReviewDiff(repository.path, row.baseRef, row.headRef, { includeUncommitted })
+    return readReviewDiff(repository.path, row.baseRef, row.headRef, { changes })
   },
 
   /**
    * One file's head-side text, so the UI can expand the lines the diff hid.
    *
    * Read against the same version of the file the diff was taken from, which is
-   * what `includeUncommitted` selects - expanded context from the other version
-   * would silently disagree with the hunks it sits between.
+   * what `changes` selects - expanded context from the other version would
+   * silently disagree with the hunks it sits between.
    */
   async file(input: unknown): Promise<FileContent> {
-    const { id, path, includeUncommitted } = parse(reviewFileInputSchema, input)
+    const { id, path, changes } = parse(reviewFileInputSchema, input)
     const row = requireReview(id)
     const repository = requireRepository(row.repositoryId)
-    return readReviewFile(repository.path, row.baseRef, row.headRef, path, { includeUncommitted })
+    return readReviewFile(repository.path, row.baseRef, row.headRef, path, { changes })
   },
 
   /**
@@ -250,12 +250,10 @@ export const reviewsService = {
    * checked out somewhere other than the repository path.
    */
   async absolutePath(input: unknown): Promise<string> {
-    const { id, path, includeUncommitted } = parse(reviewFileInputSchema, input)
+    const { id, path, changes } = parse(reviewFileInputSchema, input)
     const row = requireReview(id)
     const repository = requireRepository(row.repositoryId)
-    return resolveReviewFilePath(repository.path, row.baseRef, row.headRef, path, {
-      includeUncommitted
-    })
+    return resolveReviewFilePath(repository.path, row.baseRef, row.headRef, path, { changes })
   }
 }
 

--- a/src/renderer/src/features/commands/command-palette.tsx
+++ b/src/renderer/src/features/commands/command-palette.tsx
@@ -90,8 +90,8 @@ function toPaletteItem(command: Command): PaletteItem {
 /**
  * The changed files of the open review, if some tab has already read them.
  *
- * Both settings of "include uncommitted" are checked because either may be the
- * one on screen, and a file list is a file list - the switch changes the line
+ * Every setting of "changes shown" is checked because any of them may be the
+ * one on screen, and a file list is a file list - the setting changes the line
  * numbers, not which files are in play.
  */
 function useCachedDiffFiles(reviewId: number | null): string[] {
@@ -99,8 +99,8 @@ function useCachedDiffFiles(reviewId: number | null): string[] {
 
   return useMemo(() => {
     if (reviewId === null) return []
-    for (const includeUncommitted of [true, false]) {
-      const entry = cache.get(CACHE_KEYS.reviewDiff(reviewId, includeUncommitted)) as
+    for (const changes of ['all', 'uncommitted', 'committed'] as const) {
+      const entry = cache.get(CACHE_KEYS.reviewDiff(reviewId, changes)) as
         | { data?: ReviewDiff }
         | undefined
       const files = entry?.data?.files

--- a/src/renderer/src/features/reviews/diff-view.tsx
+++ b/src/renderer/src/features/reviews/diff-view.tsx
@@ -64,7 +64,7 @@ import {
   type GapSegment
 } from '@shared/diff-gaps'
 import { errorMessage } from '@/lib/errors'
-import type { DiffHunk, DiffLine, FileChangeStatus, FileDiff } from '@shared/git'
+import type { DiffChanges, DiffHunk, DiffLine, FileChangeStatus, FileDiff } from '@shared/git'
 import type { CommentThread } from '@shared/schemas'
 
 /** Files longer than this arrive collapsed; see the note above. */
@@ -134,19 +134,24 @@ export interface DiffComments {
   /** Only the threads for the file being rendered. */
   threads: AnchoredThread[]
   mutations: CommentMutations
+  /**
+   * The view the line numbers on screen came from, sent with a new thread so
+   * its anchor is captured from the diff the commenter was actually reading.
+   */
+  changes: DiffChanges
 }
 
 /**
  * What the card needs to read more of the file than the patch contains, and to
  * hand it to an editor.
  *
- * `includeUncommitted` has to be the setting the diff on screen was read with:
- * unfolded context from the other version of the file would not line up with
- * the hunks it sits between.
+ * `changes` has to be the setting the diff on screen was read with: unfolded
+ * context from another version of the file would not line up with the hunks it
+ * sits between.
  */
 export interface DiffFileSource {
   reviewId: number
-  includeUncommitted: boolean
+  changes: DiffChanges
   /** Editor to open in, from `system.editors()`. Null uses the default. */
   editorId?: string | null
   /** Named in the button's tooltip, so the click holds no surprises. */
@@ -262,11 +267,7 @@ export function FileDiffCard({
   }, [isReviewed])
 
   const canExpand = source !== undefined && isExpandable(file)
-  const text = useReviewFile(
-    canExpand ? source.reviewId : null,
-    file.path,
-    source?.includeUncommitted ?? true
-  )
+  const text = useReviewFile(canExpand ? source.reviewId : null, file.path, source?.changes ?? 'all')
 
   const reveal = useCallback(
     (from: number, to: number) => {
@@ -1121,6 +1122,7 @@ function LineRow({
                     filePath,
                     side,
                     line: number,
+                    changes: comments.changes,
                     ...(composingOn.startLine < number
                       ? { startLine: composingOn.startLine }
                       : {})

--- a/src/renderer/src/features/reviews/review-conversation-tab.tsx
+++ b/src/renderer/src/features/reviews/review-conversation-tab.tsx
@@ -81,7 +81,7 @@ export function ReviewConversationTab({ review, onEdit }: ReviewConversationTabP
   const mutations = useCommentMutations(review.id)
 
   // Matches the Files changed tab's default, so the two share one cached diff.
-  const { data: diff, isLoading: diffLoading } = useReviewDiff(review.id, true)
+  const { data: diff, isLoading: diffLoading } = useReviewDiff(review.id, 'all')
 
   const timeline = useMemo(() => buildTimeline(threads, diff?.files), [threads, diff?.files])
 

--- a/src/renderer/src/features/reviews/review-files-tab.tsx
+++ b/src/renderer/src/features/reviews/review-files-tab.tsx
@@ -5,10 +5,10 @@
  * than differences base picked up in the meantime - the same thing a pull
  * request shows.
  *
- * The "include uncommitted changes" switch is view state, not part of the
- * review. Whether you want to read the branch as it stands on disk or as it
- * would arrive if pushed is a question you ask per visit, and each answer is
- * cached under its own SWR key so flipping back is instant.
+ * Which changes are shown is view state, not part of the review. Whether you
+ * want the branch as it stands on disk, as it would arrive if pushed, or just
+ * the edit you are making right now is a question you ask per visit, and each
+ * answer is cached under its own SWR key so switching back is instant.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
@@ -32,7 +32,6 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Switch } from '@/components/ui/switch'
 import { api } from '@/lib/api'
 import { errorMessage } from '@/lib/errors'
 import { plural } from '@/lib/format'
@@ -51,7 +50,7 @@ import { useEditors, useReviewDiff, useReviewedFiles } from './use-reviews'
 import { fileDiffDigest } from '@shared/diff-digest'
 import { findAnchorFile, isInlineAnchor, resolveAnchor } from '@shared/comment-anchors'
 import { threadSnippet } from '@shared/comment-snippets'
-import type { FileDiff as FileDiffData } from '@shared/git'
+import type { DiffChanges, FileDiff as FileDiffData } from '@shared/git'
 import { isSelfReview } from '@shared/schemas'
 import type { CommentThread, Review } from '@shared/schemas'
 
@@ -67,6 +66,36 @@ import type { CommentThread, Review } from '@shared/schemas'
  * below the height of any card to be unambiguous, and it does.
  */
 const TOP_EDGE_SLACK = 24
+
+/**
+ * The three views of a review's changes, in the order `u` steps through them.
+ *
+ * `all` first because it is the default and the one most visits want; then the
+ * narrow view, which is the one you reach for repeatedly while making a small
+ * edit on a long branch; then the committed-only view, which is the rarest.
+ */
+const CHANGES_CYCLE = ['all', 'uncommitted', 'committed'] as const
+
+/** Left to right in the toggle: widening from the commits to the working tree. */
+const CHANGES_OPTIONS = ['committed', 'all', 'uncommitted'] as const satisfies readonly DiffChanges[]
+
+const CHANGES_LABELS: Record<DiffChanges, string> = {
+  committed: 'Committed',
+  all: 'All',
+  uncommitted: 'Uncommitted'
+}
+
+/** Said in full wherever there is room for it - a tooltip, a command palette row. */
+const CHANGES_DESCRIPTIONS: Record<DiffChanges, string> = {
+  committed: 'Only what is committed on the head branch',
+  all: 'Committed work with the worktree’s uncommitted changes folded in',
+  uncommitted: 'Only the uncommitted changes in the worktree, against the head commit'
+}
+
+function nextChangesAfter(current: DiffChanges): DiffChanges {
+  const index = CHANGES_CYCLE.indexOf(current)
+  return CHANGES_CYCLE[(index + 1) % CHANGES_CYCLE.length] ?? 'all'
+}
 
 /**
  * The element a card actually scrolls inside.
@@ -101,9 +130,9 @@ const STEP_CHAIN_MS = 800
  * Place every line comment against the diff that is actually on screen.
  *
  * This runs here rather than in the main process on purpose. The reviewer can
- * flip "include uncommitted" at any moment, which produces a genuinely
- * different diff with different line numbers, and a comment resolved against
- * the other one would be pinned to a line the reader is not looking at. Doing
+ * switch which changes are shown at any moment, and each of those is a
+ * genuinely different diff with different line numbers; a comment resolved
+ * against another one would be pinned to a line the reader is not seeing. Doing
  * it against the rendered diff makes that impossible by construction - and it
  * reuses the same `resolveAnchor` the MCP server runs, so an agent and the
  * screen never disagree about where a comment sits.
@@ -231,14 +260,11 @@ function useFocusScroll(focus: DiffFocus | undefined, ready: boolean): DiffFocus
 }
 
 export function ReviewFilesTab({ review, focus }: { review: Review; focus?: DiffFocus }) {
-  const [includeUncommitted, setIncludeUncommitted] = useState(true)
+  const [changes, setChanges] = useState<DiffChanges>('all')
   const [treeOpen, setTreeOpen] = useStoredFlag('files-tree', true)
   const [editorId, setEditorId] = useStoredPreference('editor', null)
   const [openError, setOpenError] = useState<unknown>(null)
-  const { data, error, isLoading, isRefreshing, refresh } = useReviewDiff(
-    review.id,
-    includeUncommitted
-  )
+  const { data, error, isLoading, isRefreshing, refresh } = useReviewDiff(review.id, changes)
   const { threads } = useReviewComments(review.id)
   const mutations = useCommentMutations(review.id)
   const editors = useEditors()
@@ -262,8 +288,8 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
    * reviewed mark is checked against.
    *
    * Computed here rather than in the main process because the diff on screen is
-   * the only thing anyone can claim to have read - and flipping "include
-   * uncommitted" produces a different one. See `shared/diff-digest.ts`.
+   * the only thing anyone can claim to have read - and each view of the changes
+   * produces a different one. See `shared/diff-digest.ts`.
    */
   const digestByPath = useMemo(
     () => new Map((data?.files ?? []).map((file) => [file.path, fileDiffDigest(file)])),
@@ -324,13 +350,13 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
         .openInEditor({
           id: review.id,
           path,
-          includeUncommitted,
+          changes,
           line,
           ...(editorId === null ? {} : { editorId })
         })
         .catch(setOpenError)
     },
-    [review.id, includeUncommitted, editorId]
+    [review.id, changes, editorId]
   )
 
   const marked = useFocusScroll(focus, !isLoading && data !== undefined)
@@ -396,7 +422,8 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
     markReviewed(path, !reviewedPaths.has(path))
   }, [paths, currentFile, markReviewed, reviewedPaths])
 
-  const canIncludeUncommitted = data?.workingTree != null
+  const canReadWorktree = data?.workingTree != null
+  const nextChanges = nextChangesAfter(changes)
 
   useRegisterCommands(
     useMemo<Command[]>(
@@ -433,16 +460,15 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
         },
         {
           id: 'files:uncommitted',
-          label: includeUncommitted
-            ? 'Exclude uncommitted changes'
-            : 'Include uncommitted changes',
+          label: `Show ${CHANGES_LABELS[nextChanges].toLowerCase()} changes`,
           group: 'Files changed',
           keys: 'u',
-          keywords: 'working tree dirty staged unstaged untracked',
+          keywords: 'working tree dirty staged unstaged untracked committed only',
           icon: GitCompareArrows,
-          // Nothing to fold in when no worktree has this branch checked out.
-          disabled: !canIncludeUncommitted,
-          run: () => setIncludeUncommitted(!includeUncommitted)
+          // Two of the three views need a worktree; without one there is only
+          // the committed diff, and stepping between identical views is noise.
+          disabled: !canReadWorktree,
+          run: () => setChanges(nextChanges)
         },
         {
           id: 'files:reviewed',
@@ -472,8 +498,8 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
         stepFile,
         treeOpen,
         setTreeOpen,
-        includeUncommitted,
-        canIncludeUncommitted,
+        nextChanges,
+        canReadWorktree,
         refresh,
         activePath,
         reviewedPaths,
@@ -568,25 +594,13 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
             </Select>
           )}
 
-          <label
-            className="flex items-center gap-2 text-xs text-muted-foreground"
-            title={
-              !hasWorktree
-                ? `No worktree has ${review.headRef} checked out, so there is nothing uncommitted to include`
-                : selfReview
-                  ? // Turning it off on a self-review leaves an empty diff; the
-                    // switch stays usable, but say so rather than let it look broken.
-                    'This review is uncommitted work only — turning this off leaves nothing to show'
-                  : 'Fold the head worktree’s staged, unstaged and untracked changes into the diff'
-            }
-          >
-            <Switch
-              checked={includeUncommitted}
-              onCheckedChange={setIncludeUncommitted}
-              disabled={!hasWorktree}
-            />
-            Include uncommitted
-          </label>
+          <ChangesToggle
+            changes={changes}
+            onChange={setChanges}
+            hasWorktree={hasWorktree}
+            headRef={review.headRef}
+            selfReview={selfReview}
+          />
 
           <Button variant="ghost" size="sm" onClick={() => void refresh()} title="Re-read from disk">
             <RefreshCw className={isRefreshing ? 'animate-spin' : undefined} />
@@ -595,13 +609,19 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
         </div>
       </div>
 
-      {includeUncommitted && data.workingTree?.isDirty && (
+      {changes !== 'committed' && data.workingTree?.isDirty && (
         <WorkingTreeBanner workingTree={data.workingTree} />
       )}
       {!hasWorktree && <NoWorktreeNotice headRef={review.headRef} />}
-      {hasWorktree && !includeUncommitted && data.workingTree?.isDirty && (
+      {changes === 'uncommitted' && hasWorktree && (
         <p className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-xs text-muted-foreground">
-          Uncommitted changes are being left out of this diff. Turn the switch back on to include
+          Measured against <span className="font-mono">{review.headRef}</span>, so everything
+          already committed on the branch is hidden.
+        </p>
+      )}
+      {changes === 'committed' && hasWorktree && data.workingTree?.isDirty && (
+        <p className="rounded-lg border border-border bg-muted/40 px-4 py-3 text-xs text-muted-foreground">
+          Uncommitted changes are being left out of this diff. Switch to All or Uncommitted to see
           them.
         </p>
       )}
@@ -657,26 +677,31 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
             <FileDiff className="size-6" />
           </div>
           <h3 className="font-medium">No changes</h3>
-          {selfReview ? (
-            <p className="mx-auto max-w-sm text-sm text-muted-foreground">
-              {includeUncommitted ? (
-                <>
-                  Nothing is uncommitted on <span className="font-mono">{review.headRef}</span>{' '}
-                  right now. Edit a file and refresh — it will show up here.
-                </>
-              ) : (
-                <>
-                  This review is <span className="font-mono">{review.headRef}</span> against itself,
-                  so it holds only uncommitted work. Turn the switch back on to see it.
-                </>
-              )}
-            </p>
-          ) : (
-            <p className="mx-auto max-w-sm text-sm text-muted-foreground">
-              <span className="font-mono">{review.headRef}</span> has nothing that{' '}
-              <span className="font-mono">{review.baseRef}</span> does not already have.
-            </p>
-          )}
+          <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+            {changes === 'uncommitted' && !hasWorktree ? (
+              <>
+                No worktree has <span className="font-mono">{review.headRef}</span> checked out, so
+                there is no uncommitted work to show.
+              </>
+            ) : changes === 'uncommitted' || (selfReview && changes === 'all') ? (
+              // A self-review has no committed range at all, so "all" and
+              // "uncommitted" are the same view of it and read the same way.
+              <>
+                Nothing is uncommitted on <span className="font-mono">{review.headRef}</span> right
+                now. Edit a file and refresh — it will show up here.
+              </>
+            ) : selfReview ? (
+              <>
+                This review is <span className="font-mono">{review.headRef}</span> against itself, so
+                it holds only uncommitted work. Switch to All or Uncommitted to see it.
+              </>
+            ) : (
+              <>
+                <span className="font-mono">{review.headRef}</span> has nothing that{' '}
+                <span className="font-mono">{review.baseRef}</span> does not already have.
+              </>
+            )}
+          </p>
         </Card>
       ) : (
         // `items-start` so the tree can stick to the top of the viewport while
@@ -711,10 +736,10 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
                 className="scroll-mt-2"
               >
                 <FileDiffCard
-                  // Remounted when the switch flips: that is a different diff
+                  // Remounted when the view changes: that is a different diff
                   // with different line numbers, so anything unfolded against
                   // the old one has to go.
-                  key={includeUncommitted ? 'with-uncommitted' : 'committed-only'}
+                  key={changes}
                   file={file}
                   // Only the card that owns the line hears about it, so one
                   // arriving link cannot light up the same number in every file.
@@ -728,11 +753,12 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
                   comments={{
                     reviewId: review.id,
                     threads: threadsByFile.get(file.path) ?? [],
-                    mutations
+                    mutations,
+                    changes
                   }}
                   source={{
                     reviewId: review.id,
-                    includeUncommitted,
+                    changes,
                     editorId,
                     editorLabel:
                       editors?.editors.find(
@@ -752,6 +778,72 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
           {errorMessage(openError)}
         </p>
       )}
+    </div>
+  )
+}
+
+/**
+ * Which of the three views of the changes is on screen.
+ *
+ * A segmented control rather than the switch this replaced: the three views are
+ * one question with three answers, and a switch can only ask a question with
+ * two. All three stay visible so the narrow view is discoverable - the whole
+ * point of it is that you reach for it mid-edit, without having gone looking
+ * through a menu first.
+ *
+ * With no worktree holding the head there is only ever the committed diff, so
+ * the other two are disabled rather than hidden: a control that changes shape
+ * between reviews is harder to learn than one that greys out and says why.
+ */
+function ChangesToggle({
+  changes,
+  onChange,
+  hasWorktree,
+  headRef,
+  selfReview
+}: {
+  changes: DiffChanges
+  onChange: (next: DiffChanges) => void
+  hasWorktree: boolean
+  headRef: string
+  selfReview: boolean
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Which changes to show"
+      className="flex items-center rounded-md border border-border p-0.5"
+    >
+      {CHANGES_OPTIONS.map((option) => {
+        const needsWorktree = option !== 'committed'
+        const disabled = needsWorktree && !hasWorktree
+        // A self-review's committed range is empty by construction, so say that
+        // rather than let the button look broken when it shows nothing.
+        const title = disabled
+          ? `No worktree has ${headRef} checked out, so there is nothing uncommitted to show`
+          : option === 'committed' && selfReview
+            ? `This review is ${headRef} against itself, so it holds no committed changes`
+            : CHANGES_DESCRIPTIONS[option]
+
+        return (
+          <button
+            key={option}
+            type="button"
+            onClick={() => onChange(option)}
+            disabled={disabled}
+            aria-pressed={changes === option}
+            title={title}
+            className={
+              'rounded px-2 py-1 text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-40 ' +
+              (changes === option
+                ? 'bg-accent font-medium text-accent-foreground'
+                : 'text-muted-foreground hover:text-foreground')
+            }
+          >
+            {CHANGES_LABELS[option]}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/src/renderer/src/features/reviews/use-reviews.ts
+++ b/src/renderer/src/features/reviews/use-reviews.ts
@@ -16,7 +16,13 @@ import useSWR, { useSWRConfig } from 'swr'
 import { useCallback, useMemo, useState } from 'react'
 import { api, CACHE_KEYS, CACHE_PREFIXES } from '@/lib/api'
 import type { EditorList } from '@shared/api'
-import type { FileContent, RepositoryRefs, ReviewCommits, ReviewDiff } from '@shared/git'
+import type {
+  DiffChanges,
+  FileContent,
+  RepositoryRefs,
+  ReviewCommits,
+  ReviewDiff
+} from '@shared/git'
 import type {
   CreateReviewInput,
   Review,
@@ -90,11 +96,11 @@ export function useReviewCommits(reviewId: number): ListState<ReviewCommits> {
   )
 }
 
-export function useReviewDiff(reviewId: number, includeUncommitted: boolean): ListState<ReviewDiff> {
+export function useReviewDiff(reviewId: number, changes: DiffChanges): ListState<ReviewDiff> {
   return toState(
     useSWR<ReviewDiff, unknown>(
-      CACHE_KEYS.reviewDiff(reviewId, includeUncommitted),
-      () => api.reviews.diff({ id: reviewId, includeUncommitted }),
+      CACHE_KEYS.reviewDiff(reviewId, changes),
+      () => api.reviews.diff({ id: reviewId, changes }),
       LIVE_READ_OPTIONS
     )
   )
@@ -121,14 +127,12 @@ export function useReviewFile(
   /** Null for a file that cannot be expanded at all - binary, deleted, clipped. */
   reviewId: number | null,
   path: string,
-  includeUncommitted: boolean
+  changes: DiffChanges
 ): FileContentState {
   const [requested, setRequested] = useState(false)
   const result = useSWR<FileContent, unknown>(
-    requested && reviewId !== null
-      ? CACHE_KEYS.reviewFile(reviewId, path, includeUncommitted)
-      : null,
-    () => api.reviews.file({ id: reviewId as number, path, includeUncommitted }),
+    requested && reviewId !== null ? CACHE_KEYS.reviewFile(reviewId, path, changes) : null,
+    () => api.reviews.file({ id: reviewId as number, path, changes }),
     LIVE_READ_OPTIONS
   )
 

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -6,6 +6,7 @@
  * README on why this app talks over IPC rather than a local HTTP server.
  */
 import type { GitWarrenApi } from '@shared/api'
+import type { DiffChanges } from '@shared/git'
 
 if (typeof window.gitwarren === 'undefined') {
   throw new Error(
@@ -31,14 +32,13 @@ export const CACHE_KEYS = {
     `reviews:${repositoryId ?? 'all'}:${status ?? 'any'}`,
   review: (reviewId: number) => `review:${reviewId}`,
   reviewCommits: (reviewId: number) => `review-commits:${reviewId}`,
-  reviewDiff: (reviewId: number, includeUncommitted: boolean) =>
-    `review-diff:${reviewId}:${includeUncommitted ? 'with-uncommitted' : 'committed-only'}`,
+  reviewDiff: (reviewId: number, changes: DiffChanges) => `review-diff:${reviewId}:${changes}`,
   /**
-   * Keyed by the same switch as the diff: expanded context read from the other
+   * Keyed by the same setting as the diff: expanded context read from another
    * version of the file would not line up with the hunks it sits between.
    */
-  reviewFile: (reviewId: number, path: string, includeUncommitted: boolean) =>
-    `review-file:${reviewId}:${includeUncommitted ? 'with-uncommitted' : 'committed-only'}:${path}`,
+  reviewFile: (reviewId: number, path: string, changes: DiffChanges) =>
+    `review-file:${reviewId}:${changes}:${path}`,
   /** Installed code editors. Probed once per run; see `main/editors.ts`. */
   editors: 'editors',
   /**

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -180,8 +180,8 @@ export interface GitWarrenApi {
     diff(input: ReviewDiffInput): Promise<ReviewDiff>
     /**
      * One file's head-side text, whole. This is what lets the diff show the
-     * lines between its hunks; `includeUncommitted` must match the diff on
-     * screen so the expanded context comes from the same version of the file.
+     * lines between its hunks; `changes` must match the diff on screen so the
+     * expanded context comes from the same version of the file.
      */
     file(input: ReviewFileInput): Promise<FileContent>
     /** Open a file of this review in the reviewer's editor, at a line. */

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -214,12 +214,31 @@ export interface ReviewCommits extends ReviewCompare {
   truncated: boolean
 }
 
+/**
+ * Which changes a diff is made of.
+ *
+ * - `committed` - the merge-base diff of the two refs and nothing else.
+ * - `all` - that, with the head worktree's uncommitted work folded in.
+ * - `uncommitted` - *only* what is uncommitted in the head worktree, measured
+ *   against the head commit rather than against the base ref. On a long-lived
+ *   branch that is the small edit being made right now, without the rest of the
+ *   branch in the way; it is what a review of a ref against itself shows, but
+ *   available without repointing the review's endpoints.
+ *
+ * `uncommitted` needs a worktree with the head checked out. Without one there
+ * is nothing to show, and the diff comes back empty rather than quietly
+ * widening back out to the whole branch.
+ */
+export type DiffChanges = 'committed' | 'all' | 'uncommitted'
+
 export interface ReviewDiff extends ReviewCompare {
   files: FileDiff[]
   additions: number
   deletions: number
-  /** Whether uncommitted work was actually folded into this diff. */
-  includedUncommitted: boolean
+  /** What this diff ended up being made of - see `DiffChanges`. Not always
+   *  what was asked for: with no head worktree there is nothing to fold in, so
+   *  `all` reports `committed`. */
+  changes: DiffChanges
   /** True when at least one file's patch was clipped. */
   truncated: boolean
 }

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -12,7 +12,7 @@
  */
 import { z } from 'zod'
 import { DIGEST_MAX_LENGTH } from './diff-digest.js'
-import type { DiffLine } from './git.js'
+import type { DiffChanges, DiffLine } from './git.js'
 
 export const MAX_NAME_LENGTH = 120
 
@@ -195,25 +195,31 @@ export const getReviewInputSchema = z.object({ id: reviewIdSchema })
 export const removeReviewInputSchema = z.object({ id: reviewIdSchema })
 export const reviewCommitsInputSchema = z.object({ id: reviewIdSchema })
 
+/**
+ * Which changes to read - see `DiffChanges`. `all` by default: reviewing work
+ * before it is committed is the reason this app exists.
+ *
+ * Listed as a constant rather than inline so the enum and the type it mirrors
+ * are checked against each other at compile time.
+ */
+const DIFF_CHANGES = ['committed', 'all', 'uncommitted'] as const satisfies readonly DiffChanges[]
+
+export const diffChangesSchema = z.enum(DIFF_CHANGES).optional().default('all')
+
 export const reviewDiffInputSchema = z.object({
   id: reviewIdSchema,
-  /**
-   * Fold the head worktree's uncommitted work into the diff. On by default:
-   * reviewing work before it is committed is the reason this app exists. Has no
-   * effect when no worktree has the head branch checked out.
-   */
-  includeUncommitted: z.boolean().optional().default(true)
+  changes: diffChangesSchema
 })
 
 /**
  * One file of a review, read whole so the diff can be expanded past its hunks.
- * `includeUncommitted` has to match the diff on screen, or the expanded context
- * would come from a different version of the file than the hunks around it.
+ * `changes` has to match the diff on screen, or the expanded context would come
+ * from a different version of the file than the hunks around it.
  */
 export const reviewFileInputSchema = z.object({
   id: reviewIdSchema,
   path: z.string().min(1).max(4096),
-  includeUncommitted: z.boolean().optional().default(true)
+  changes: diffChangesSchema
 })
 
 /**
@@ -467,7 +473,14 @@ export const createThreadInputSchema = z
      * a single line. Omit for one line. Must be on the same side and no later
      * than `line`.
      */
-    startLine: z.number().int().positive().optional()
+    startLine: z.number().int().positive().optional(),
+    /**
+     * Which diff the line numbers were read off - see `DiffChanges`. The base
+     * side of a `uncommitted` diff numbers the head commit, not the merge base,
+     * so the anchor has to be captured from the same diff the commenter was
+     * looking at or it would be taken from a different line entirely.
+     */
+    changes: diffChangesSchema
   })
   .refine((value) => (value.filePath === undefined) === (value.line === undefined), {
     message: 'A line comment needs both a file and a line number.',


### PR DESCRIPTION
The files-changed tab could show the branch with uncommitted work folded in, or without it. Neither answers the question you have while making a small edit on top of a long-lived branch: *what am I changing right now*. The only way to see that was to repoint the review at its own ref and back again.

So the boolean becomes three views, chosen by a segmented control in the tab header and cycled with `u`. The difference between them is only which commit the diff is taken against:

| View | Command | What you see |
| --- | --- | --- |
| Committed | `git diff <merge-base> <head>` | the branch as it would arrive if pushed |
| All | `git diff <merge-base>` in the worktree | that, plus everything uncommitted |
| Uncommitted | `git diff <head>` in the worktree | only the edit being made right now |

`Uncommitted` needs a worktree holding the head; without one it shows nothing rather than quietly widening back out to the whole branch. It is the same view a review of a ref against itself gives, reached without repointing the endpoints.

### Threading

`includeUncommitted` is now `changes` everywhere it was threaded — the IPC schemas, the SWR cache keys, the whole-file read that expands a diff past its hunks, and the path handed to an editor — so all of them keep agreeing about which version of a file is on screen. `ReviewDiff.includedUncommitted` becomes `changes`, reporting what the diff was actually made of.

New comment threads carry it too: the base side of an uncommitted diff numbers the head commit rather than the merge base, so the anchor has to be captured from the diff the commenter was reading, not from a differently-numbered one.

### Checks

`npm run typecheck`, `npm run lint`, `npm test` (199 pass), `npm run build` — all green. Two integration tests added against a linked worktree: the narrowed diff drops work already committed on the branch and matches what a self-review shows, and file expansion in that view reads from the worktree.

Not verified by running the app — the UI change is the segmented control replacing the switch, plus the notices and empty states around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHFUaowBZZ3ktRSWvE4KdS