### PR TITLE
Mark a file reviewed, the way GitHub does

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,35 @@ decides where the hidden runs are and which line number each unfolded line gets;
 it is pure, and unit-tested against the shapes that get this wrong — a diff that
 does not start at line 1, and git's off-by-one convention for an empty range.
 
+### Marking a file reviewed
+
+Each file header carries a **Reviewed** checkbox, and `v` ticks off whichever
+file you are on. A ticked file folds away, the file tree marks it and dims it,
+and the header counts how many of them are done — so a long diff shrinks to what
+is still unread as you work through it.
+
+The mark has to stop being true when the file changes, or the list would claim
+someone had read code that did not exist when they looked at it. So what is
+stored is not a flag but a digest of the diff that was on screen at the time
+(`shared/diff-digest.ts`, a cyrb53 fingerprint of the path, the change status
+and every line of every hunk). A mark counts only while the file still hashes to
+the same value; when it does not, the tick clears itself and the file is
+labelled **Changed since reviewed** — which is more useful than silently
+unticking it, because it points at the one file that moved after being read.
+
+Two consequences fall out of that rather than needing code of their own. Flipping
+*include uncommitted* is a different diff, so a file read in one setting is not
+ticked in the other. And reverting a change restores the mark, because the file
+hashes the same way it did before.
+
+The comparison runs in the renderer, against the diff being rendered, and the
+main process only stores digests: the "include uncommitted" switch means one
+review has two diffs at once, and a mark resolved against the one you are not
+looking at would be answering a question nobody asked. The rows live in
+`reviewed_files`, keyed by review and path, and go with the review when it is
+deleted. There is no MCP tool for them — an agent claiming a human has read a
+file would make the only honest signal on the screen worthless.
+
 ### Opening a file in an editor
 
 `system.editors()` probes for VS Code, Cursor, Windsurf, Zed, Sublime Text and

--- a/drizzle/0006_reviewed_files.sql
+++ b/drizzle/0006_reviewed_files.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `reviewed_files` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`review_id` integer NOT NULL,
+	`file_path` text NOT NULL,
+	`content_digest` text NOT NULL,
+	`reviewed_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+	FOREIGN KEY (`review_id`) REFERENCES `reviews`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `reviewed_files_path_idx` ON `reviewed_files` (`review_id`,`file_path`);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,555 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "74c8cfc7-984e-4c9a-a717-a5d1484e2556",
+  "prevId": "db60dd60-e9e5-4bbf-b7a5-f196a5ffbc39",
+  "tables": {
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_threads": {
+      "name": "comment_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_text": {
+          "name": "anchor_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_sha": {
+          "name": "anchor_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_snapshot": {
+          "name": "anchor_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "comment_threads_review_idx": {
+          "name": "comment_threads_review_idx",
+          "columns": [
+            "review_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "comment_threads_file_idx": {
+          "name": "comment_threads_file_idx",
+          "columns": [
+            "review_id",
+            "file_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_threads_review_id_reviews_id_fk": {
+          "name": "comment_threads_review_id_reviews_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_label": {
+          "name": "author_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_session": {
+          "name": "author_session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "comments_thread_idx": {
+          "name": "comments_thread_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_thread_id_comment_threads_id_fk": {
+          "name": "comments_thread_id_comment_threads_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comment_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "repositories_path_unique": {
+          "name": "repositories_path_unique",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true
+        },
+        "repositories_name_idx": {
+          "name": "repositories_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviewed_files": {
+      "name": "reviewed_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_digest": {
+          "name": "content_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "reviewed_files_path_idx": {
+          "name": "reviewed_files_path_idx",
+          "columns": [
+            "review_id",
+            "file_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reviewed_files_review_id_reviews_id_fk": {
+          "name": "reviewed_files_review_id_reviews_id_fk",
+          "tableFrom": "reviewed_files",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reviews_repository_idx": {
+          "name": "reviews_repository_idx",
+          "columns": [
+            "repository_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_repository_id_repositories_id_fk": {
+          "name": "reviews_repository_id_repositories_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1788296212025,
       "tag": "0005_comment_ranges",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1788784787308,
+      "tag": "0006_reviewed_files",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/__tests__/reviewed-files.test.ts
+++ b/src/core/__tests__/reviewed-files.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Coverage for the store behind the "Reviewed" tick.
+ *
+ * The service itself is small, so what is worth testing is the part that is
+ * easy to get wrong and impossible to notice: a tick has to be one row per
+ * file, replaced in place when the file is read again. A second row for the
+ * same path would leave two answers to "has this been read", and whichever one
+ * the list happened to return first would win.
+ *
+ * The digest comparison deliberately lives in the renderer, not here - see
+ * `shared/diff-digest.ts` - so these tests are about storage, not staleness.
+ */
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, beforeEach, test } from 'node:test'
+
+import type { AppError as AppErrorInstance } from '../../shared/errors.js'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-reviewed-data-'))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+const { reviewedFilesService } = await import('../services/reviewed-files.js')
+const { getDatabase, closeDatabase } = await import('../db/client.js')
+const { repositories, reviews, reviewedFiles } = await import('../db/schema.js')
+const { AppError } = await import('../../shared/errors.js')
+const { eq } = await import('drizzle-orm')
+
+/** A review row and nothing else: this service never looks at git. */
+function makeReview(headRef = 'feature'): number {
+  const database = getDatabase()
+  const repository = database
+    .insert(repositories)
+    .values({ path: join(dataDir, `repo-${headRef}-${Math.random()}`), name: 'repo' })
+    .returning()
+    .get()
+
+  return database
+    .insert(reviews)
+    .values({ repositoryId: repository.id, title: 'A review', baseRef: 'main', headRef })
+    .returning()
+    .get().id
+}
+
+beforeEach(() => {
+  const database = getDatabase()
+  database.delete(reviewedFiles).run()
+  database.delete(reviews).run()
+  database.delete(repositories).run()
+})
+
+after(() => {
+  closeDatabase()
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+test('a file starts unmarked', async () => {
+  const reviewId = makeReview()
+  assert.deepEqual(await reviewedFilesService.list({ reviewId }), [])
+})
+
+test('marking a file records the digest it was marked against', async () => {
+  const reviewId = makeReview()
+  const mark = await reviewedFilesService.setReviewed({
+    reviewId,
+    filePath: 'src/app.ts',
+    contentDigest: 'abc123'
+  })
+
+  assert.equal(mark?.filePath, 'src/app.ts')
+  assert.equal(mark?.contentDigest, 'abc123')
+  assert.ok(mark && Date.parse(mark.reviewedAt) > 0)
+
+  assert.deepEqual(await reviewedFilesService.list({ reviewId }), [mark])
+})
+
+test('reading a changed file again replaces the mark rather than adding one', async () => {
+  const reviewId = makeReview()
+  await reviewedFilesService.setReviewed({
+    reviewId,
+    filePath: 'src/app.ts',
+    contentDigest: 'before'
+  })
+  await reviewedFilesService.setReviewed({
+    reviewId,
+    filePath: 'src/app.ts',
+    contentDigest: 'after'
+  })
+
+  const marks = await reviewedFilesService.list({ reviewId })
+  assert.equal(marks.length, 1)
+  assert.equal(marks[0]?.contentDigest, 'after')
+})
+
+test('a null digest takes the mark off', async () => {
+  const reviewId = makeReview()
+  await reviewedFilesService.setReviewed({
+    reviewId,
+    filePath: 'src/app.ts',
+    contentDigest: 'abc123'
+  })
+
+  const cleared = await reviewedFilesService.setReviewed({
+    reviewId,
+    filePath: 'src/app.ts',
+    contentDigest: null
+  })
+
+  assert.equal(cleared, null)
+  assert.deepEqual(await reviewedFilesService.list({ reviewId }), [])
+})
+
+test('clearing a file that was never marked is not an error', async () => {
+  const reviewId = makeReview()
+  assert.equal(
+    await reviewedFilesService.setReviewed({
+      reviewId,
+      filePath: 'src/never-read.ts',
+      contentDigest: null
+    }),
+    null
+  )
+})
+
+test('two reviews of the same file keep their own marks', async () => {
+  const first = makeReview('feature-a')
+  const second = makeReview('feature-b')
+
+  await reviewedFilesService.setReviewed({
+    reviewId: first,
+    filePath: 'src/app.ts',
+    contentDigest: 'abc123'
+  })
+
+  assert.equal((await reviewedFilesService.list({ reviewId: first })).length, 1)
+  assert.deepEqual(await reviewedFilesService.list({ reviewId: second }), [])
+})
+
+test('marks go when the review does', async () => {
+  const reviewId = makeReview()
+  await reviewedFilesService.setReviewed({
+    reviewId,
+    filePath: 'src/app.ts',
+    contentDigest: 'abc123'
+  })
+
+  getDatabase().delete(reviews).where(eq(reviews.id, reviewId)).run()
+
+  const left = getDatabase()
+    .select()
+    .from(reviewedFiles)
+    .where(eq(reviewedFiles.reviewId, reviewId))
+    .all()
+  assert.deepEqual(left, [])
+})
+
+test('a review that does not exist is rejected rather than silently stored', async () => {
+  const missing = 987654
+
+  for (const call of [
+    () => reviewedFilesService.list({ reviewId: missing }),
+    () =>
+      reviewedFilesService.setReviewed({
+        reviewId: missing,
+        filePath: 'src/app.ts',
+        contentDigest: 'abc123'
+      })
+  ]) {
+    let caught: AppErrorInstance | null = null
+    try {
+      await call()
+    } catch (error) {
+      assert.ok(error instanceof AppError, `expected AppError, got ${String(error)}`)
+      caught = error
+    }
+    assert.equal(caught?.code, 'NOT_FOUND')
+  }
+})
+
+test('a digest longer than the column allows is rejected', async () => {
+  const reviewId = makeReview()
+  await assert.rejects(
+    () =>
+      reviewedFilesService.setReviewed({
+        reviewId,
+        filePath: 'src/app.ts',
+        contentDigest: 'x'.repeat(1000)
+      }),
+    (error: unknown) => error instanceof AppError && error.code === 'INVALID_INPUT'
+  )
+})

--- a/src/core/db/schema.ts
+++ b/src/core/db/schema.ts
@@ -6,7 +6,7 @@
  * a branch name that stopped being true ten minutes ago.
  */
 import { sql } from 'drizzle-orm'
-import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
 export const repositories = sqliteTable(
   'repositories',
@@ -253,3 +253,42 @@ export const attachments = sqliteTable('attachments', {
 
 export type AttachmentRow = typeof attachments.$inferSelect
 export type NewAttachmentRow = typeof attachments.$inferInsert
+
+/**
+ * "I have read this file" - one row per file a reviewer has ticked off.
+ *
+ * The tick is not a boolean. A file marked reviewed and then changed has to
+ * lose its mark, or the list would quietly claim someone had read code that
+ * did not exist when they looked. `contentDigest` is what makes that automatic:
+ * it is a fingerprint of the diff as it was on screen at the moment of the
+ * tick (see `shared/diff-digest.ts`), and the mark counts only while the file
+ * still hashes to the same value. Rows are therefore left in place when a file
+ * changes rather than deleted - re-reading the new version is one write, and a
+ * mark that comes back if the change is reverted is the behaviour people
+ * already expect from GitHub's "Viewed".
+ *
+ * Kept out of the reviews table, and out of localStorage: it is per review and
+ * unbounded, and it is a real record of work done - the sort of thing that
+ * should survive a machine, not a browser profile.
+ */
+export const reviewedFiles = sqliteTable(
+  'reviewed_files',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    /** As everywhere else: the review going takes its marks with it. */
+    reviewId: integer('review_id')
+      .notNull()
+      .references(() => reviews.id, { onDelete: 'cascade' }),
+    /** Head-side path, the same key the diff and the file tree are keyed by. */
+    filePath: text('file_path').notNull(),
+    /** Fingerprint of the diff that was read. See the note above. */
+    contentDigest: text('content_digest').notNull(),
+    reviewedAt: text('reviewed_at')
+      .notNull()
+      .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`)
+  },
+  (table) => [uniqueIndex('reviewed_files_path_idx').on(table.reviewId, table.filePath)]
+)
+
+export type ReviewedFileRow = typeof reviewedFiles.$inferSelect
+export type NewReviewedFileRow = typeof reviewedFiles.$inferInsert

--- a/src/core/services/reviewed-files.ts
+++ b/src/core/services/reviewed-files.ts
@@ -1,0 +1,89 @@
+/**
+ * The reviewed-files service: which files someone has ticked off, and against
+ * which version of them.
+ *
+ * Same contract as the other services - every function re-parses its own input
+ * with the shared zod schema rather than trusting the caller.
+ *
+ * Deliberately thin. This service stores and returns digests; it never decides
+ * whether a mark is still valid. That comparison belongs to whoever is looking
+ * at a diff, because only they know which diff that is - the "include
+ * uncommitted" switch means the same review has two of them, and a file can be
+ * up to date in one and stale in the other. See `shared/diff-digest.ts`.
+ */
+import { and, eq } from 'drizzle-orm'
+import { getDatabase } from '../db/client.js'
+import { reviewedFiles, reviews, type ReviewedFileRow } from '../db/schema.js'
+import { AppError } from '../../shared/errors.js'
+import { parseWithSchema as parse } from '../../shared/validation.js'
+import {
+  listReviewedFilesInputSchema,
+  setFileReviewedInputSchema,
+  type ReviewedFile
+} from '../../shared/schemas.js'
+
+function toReviewedFile(row: ReviewedFileRow): ReviewedFile {
+  return {
+    reviewId: row.reviewId,
+    filePath: row.filePath,
+    contentDigest: row.contentDigest,
+    reviewedAt: row.reviewedAt
+  }
+}
+
+function requireReview(id: number): void {
+  const row = getDatabase().select({ id: reviews.id }).from(reviews).where(eq(reviews.id, id)).get()
+  if (!row) throw new AppError('NOT_FOUND', `No review with id ${id}.`)
+}
+
+export const reviewedFilesService = {
+  /** Every mark on a review. Small enough to hand over whole - one per file. */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async list(input: unknown): Promise<ReviewedFile[]> {
+    const { reviewId } = parse(listReviewedFilesInputSchema, input)
+    requireReview(reviewId)
+
+    return getDatabase()
+      .select()
+      .from(reviewedFiles)
+      .where(eq(reviewedFiles.reviewId, reviewId))
+      .all()
+      .map(toReviewedFile)
+  },
+
+  /**
+   * Tick a file off against a digest, or clear the tick when given null.
+   *
+   * Re-marking an already-marked file overwrites the digest and the timestamp
+   * rather than failing: that is what happens every time a file changes and is
+   * read again, which is the ordinary case rather than an edge one.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async setReviewed(input: unknown): Promise<ReviewedFile | null> {
+    const { reviewId, filePath, contentDigest } = parse(setFileReviewedInputSchema, input)
+    requireReview(reviewId)
+    const db = getDatabase()
+
+    if (contentDigest === null) {
+      db.delete(reviewedFiles)
+        .where(and(eq(reviewedFiles.reviewId, reviewId), eq(reviewedFiles.filePath, filePath)))
+        .run()
+      return null
+    }
+
+    const reviewedAt = new Date().toISOString()
+    const row = db
+      .insert(reviewedFiles)
+      .values({ reviewId, filePath, contentDigest, reviewedAt })
+      .onConflictDoUpdate({
+        target: [reviewedFiles.reviewId, reviewedFiles.filePath],
+        set: { contentDigest, reviewedAt }
+      })
+      .returning()
+      .get()
+
+    return toReviewedFile(row)
+  }
+}
+
+export type ReviewedFilesService = typeof reviewedFilesService

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -11,6 +11,7 @@ import { BrowserWindow, dialog, ipcMain, shell, app } from 'electron'
 import { attachmentsService } from '../core/services/attachments.js'
 import { commentsService } from '../core/services/comments.js'
 import { repositoriesService } from '../core/services/repositories.js'
+import { reviewedFilesService } from '../core/services/reviewed-files.js'
 import { reviewsService } from '../core/services/reviews.js'
 import { getDataDirectory, getDatabasePath } from '../core/paths.js'
 import { HUMAN_AUTHOR } from '../shared/actors.js'
@@ -73,6 +74,13 @@ export function registerIpcHandlers(): void {
     const absolute = await reviewsService.absolutePath(input)
     await openInEditor(absolute, line, editorId)
   })
+
+  // Reviewed marks are a record of what the person at the keyboard has read,
+  // so they are reachable from the UI and from nowhere else. There is
+  // deliberately no MCP tool for them: an agent claiming a human has reviewed
+  // a file would make the one honest signal on the screen worthless.
+  handle(IPC_CHANNELS.reviewsReviewedFiles, (input) => reviewedFilesService.list(input))
+  handle(IPC_CHANNELS.reviewsSetFileReviewed, (input) => reviewedFilesService.setReviewed(input))
 
   // Every comment write passes HUMAN_AUTHOR, and there is no way to reach these
   // channels except by typing into the app - the renderer has no other route to

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -40,8 +40,11 @@ import type {
   Review,
   ReviewCommitsInput,
   ReviewDiffInput,
+  ReviewedFile,
   ReviewFileInput,
   ReviewWithRepository,
+  ListReviewedFilesInput,
+  SetFileReviewedInput,
   SetThreadResolvedInput,
   UpdateCommentInput,
   UpdateRepositoryInput,
@@ -80,7 +83,11 @@ const api: GitWarrenApi = {
     diff: (input: ReviewDiffInput) => invoke<ReviewDiff>(IPC_CHANNELS.reviewsDiff, input),
     file: (input: ReviewFileInput) => invoke<FileContent>(IPC_CHANNELS.reviewsFile, input),
     openInEditor: (input: OpenReviewFileInput) =>
-      invoke<void>(IPC_CHANNELS.reviewsOpenInEditor, input)
+      invoke<void>(IPC_CHANNELS.reviewsOpenInEditor, input),
+    reviewedFiles: (input: ListReviewedFilesInput) =>
+      invoke<ReviewedFile[]>(IPC_CHANNELS.reviewsReviewedFiles, input),
+    setFileReviewed: (input: SetFileReviewedInput) =>
+      invoke<ReviewedFile | null>(IPC_CHANNELS.reviewsSetFileReviewed, input)
   },
   comments: {
     list: (input: ListCommentsInput) => invoke<CommentThread[]>(IPC_CHANNELS.commentsList, input),

--- a/src/renderer/src/components/ui/checkbox.tsx
+++ b/src/renderer/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+/**
+ * Checkbox on Base UI's Checkbox primitive.
+ *
+ * The sibling of `switch.tsx`, and the difference between them is what they
+ * mean rather than how they look: a switch changes what the screen is showing,
+ * a checkbox records something about the thing on it. "Reviewed" is the second
+ * kind - it is a note the reviewer leaves behind, not a view setting.
+ */
+import { Checkbox as BaseCheckbox } from '@base-ui/react/checkbox'
+import { Check } from 'lucide-react'
+import type { ComponentProps } from 'react'
+import { cn } from '@/lib/utils'
+
+export function Checkbox({ className, ...props }: ComponentProps<typeof BaseCheckbox.Root>) {
+  return (
+    <BaseCheckbox.Root
+      className={cn(
+        'flex size-4 shrink-0 cursor-pointer items-center justify-center rounded border border-border',
+        'bg-background transition-colors data-[checked]:border-primary data-[checked]:bg-primary',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <BaseCheckbox.Indicator className="flex text-primary-foreground">
+        <Check className="size-3" strokeWidth={3} />
+      </BaseCheckbox.Indicator>
+    </BaseCheckbox.Root>
+  )
+}

--- a/src/renderer/src/features/reviews/changed-files-tree.tsx
+++ b/src/renderer/src/features/reviews/changed-files-tree.tsx
@@ -12,7 +12,7 @@
  * Everything else stays in the file card.
  */
 import { useMemo, useState } from 'react'
-import { ChevronDown, ChevronRight } from 'lucide-react'
+import { Check, ChevronDown, ChevronRight, History } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { FileStatusIcon } from './diff-view'
 import type { FileDiff } from '@shared/git'
@@ -92,13 +92,19 @@ export interface ChangedFilesTreeProps {
   onSelect: (path: string) => void
   /** Unresolved comment count per file path. */
   unresolvedByFile: Map<string, number>
+  /** Files ticked off against the version currently on screen. */
+  reviewedPaths: ReadonlySet<string>
+  /** Files ticked off against an older version of themselves. */
+  changedSincePaths: ReadonlySet<string>
 }
 
 export function ChangedFilesTree({
   files,
   activePath,
   onSelect,
-  unresolvedByFile
+  unresolvedByFile,
+  reviewedPaths,
+  changedSincePaths
 }: ChangedFilesTreeProps) {
   const tree = useMemo(() => buildTree(files), [files])
 
@@ -112,6 +118,8 @@ export function ChangedFilesTree({
           activePath={activePath}
           onSelect={onSelect}
           unresolvedByFile={unresolvedByFile}
+          reviewedPaths={reviewedPaths}
+          changedSincePaths={changedSincePaths}
         />
       ))}
     </nav>
@@ -123,7 +131,9 @@ function TreeRows({
   depth,
   activePath,
   onSelect,
-  unresolvedByFile
+  unresolvedByFile,
+  reviewedPaths,
+  changedSincePaths
 }: {
   node: TreeNode
   depth: number
@@ -161,6 +171,8 @@ function TreeRows({
               activePath={activePath}
               onSelect={onSelect}
               unresolvedByFile={unresolvedByFile}
+              reviewedPaths={reviewedPaths}
+              changedSincePaths={changedSincePaths}
             />
           ))}
       </>
@@ -169,6 +181,8 @@ function TreeRows({
 
   const unresolved = unresolvedByFile.get(node.path) ?? 0
   const isActive = node.path === activePath
+  const isReviewed = reviewedPaths.has(node.path)
+  const hasChangedSince = changedSincePaths.has(node.path)
 
   return (
     <button
@@ -178,11 +192,25 @@ function TreeRows({
       aria-current={isActive ? 'true' : undefined}
       className={cn(
         'flex w-full items-center gap-1.5 rounded py-1 pr-1 text-left transition-colors',
-        isActive ? 'bg-accent text-accent-foreground' : 'hover:bg-muted'
+        isActive ? 'bg-accent text-accent-foreground' : 'hover:bg-muted',
+        // Read files stay legible but recede, so what is left to do stands out.
+        isReviewed && !isActive && 'text-muted-foreground'
       )}
-      title={node.path}
+      title={
+        hasChangedSince
+          ? `${node.path} - changed since you reviewed it`
+          : isReviewed
+            ? `${node.path} - reviewed`
+            : node.path
+      }
     >
-      <FileStatusIcon status={node.file.status} className="size-3 shrink-0" />
+      {isReviewed ? (
+        <Check className="size-3 shrink-0 text-success" />
+      ) : hasChangedSince ? (
+        <History className="size-3 shrink-0 text-warning" />
+      ) : (
+        <FileStatusIcon status={node.file.status} className="size-3 shrink-0" />
+      )}
       <span className="min-w-0 flex-1 truncate font-mono text-[0.6875rem]">{node.name}</span>
       {unresolved > 0 && (
         <span

--- a/src/renderer/src/features/reviews/diff-view.tsx
+++ b/src/renderer/src/features/reviews/diff-view.tsx
@@ -24,7 +24,7 @@
  * shown slightly out of place. A file with a collapsed body still shows its
  * comment count, so a discussion is never hidden behind a fold.
  */
-import { Fragment, useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import {
   Check,
   ChevronDown,
@@ -44,6 +44,7 @@ import {
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Tooltip } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { CommentComposer } from '../comments/comment-composer'
@@ -152,6 +153,27 @@ export interface DiffFileSource {
   onOpenInEditor?: (path: string, line: number) => void
 }
 
+/**
+ * The reviewer's "I have read this" mark on one file.
+ *
+ * Whether the mark still holds is decided by the caller, which is the only
+ * place that knows both what was stored and which diff is on screen - see
+ * `shared/diff-digest.ts`. The card is told the answer, not asked to work it
+ * out, so the checkbox and the file tree can never disagree.
+ */
+export interface ReviewedMark {
+  /** True while the mark matches the diff being shown. */
+  isReviewed: boolean
+  /**
+   * True when this file was ticked off against an older version of itself.
+   * The tick is gone - it has to be - but saying so is more useful than
+   * silently clearing it, because it points at the one file in the list that
+   * was read and then changed under the reviewer.
+   */
+  hasChangedSince: boolean
+  onChange: (reviewed: boolean) => void
+}
+
 export function DiffStat({ additions, deletions }: { additions: number; deletions: number }) {
   return (
     <span className="flex shrink-0 items-center gap-1.5 font-mono text-xs tabular-nums">
@@ -180,7 +202,8 @@ export function FileDiffCard({
   comments,
   source,
   focus,
-  marked
+  marked,
+  reviewed
 }: {
   file: FileDiff
   comments?: DiffComments
@@ -189,6 +212,8 @@ export function FileDiffCard({
   focus?: { side: DiffSide; line: number }
   /** The same line while it is still worth pointing at. */
   marked?: { side: DiffSide; line: number }
+  /** Omitted where there is nothing to mark against - a card shown on its own. */
+  reviewed?: ReviewedMark
 }) {
   const lineCount = file.hunks.reduce((total, hunk) => total + hunk.lines.length, 0)
   /** Null until the reviewer opens or closes the card themselves. */
@@ -200,13 +225,40 @@ export function FileDiffCard({
   /** Head-side line numbers unfolded out of the gaps between the hunks. */
   const [revealed, setRevealed] = useState<ReadonlySet<number>>(() => new Set())
 
+  const isReviewed = reviewed?.isReviewed ?? false
+
   /**
    * Derived rather than stored, so arriving at a line inside a folded file just
    * opens it - no effect, no second render, and a card the reviewer has closed
    * by hand stays closed.
    */
-  const expanded = toggled ?? (focus !== undefined || lineCount <= COLLAPSE_ABOVE_LINES)
+  const expanded =
+    toggled ??
+    // A file already ticked off arrives folded: the list of what is left to
+    // read is the point of the mark, and a read file taking up a screen of
+    // space works against it.
+    (focus !== undefined || (!isReviewed && lineCount <= COLLAPSE_ABOVE_LINES))
   const setExpanded = setToggled
+
+  /**
+   * Fold the card when the file gets ticked off, unfold it when it stops being
+   * ticked off.
+   *
+   * Driven by the mark changing rather than by the checkbox being clicked, so
+   * the keyboard shortcut in the files tab does exactly what the checkbox does
+   * - and so does the mark lapsing when a refresh brings in a new version of a
+   * file that had been read. Folding on the way in is the reason the mark is
+   * worth setting: the page shrinks to what is still unread. On the way out the
+   * card is handed back its default behaviour rather than forced open, so a
+   * file that would have arrived folded for its sheer size still does.
+   */
+  const wasReviewed = useRef(isReviewed)
+
+  useEffect(() => {
+    if (isReviewed === wasReviewed.current) return
+    wasReviewed.current = isReviewed
+    setToggled(isReviewed ? false : null)
+  }, [isReviewed])
 
   const canExpand = source !== undefined && isExpandable(file)
   const text = useReviewFile(
@@ -436,6 +488,28 @@ export function FileDiffCard({
         {file.truncated && <Badge variant="outline">clipped</Badge>}
 
         {!file.isBinary && <DiffStat additions={file.additions} deletions={file.deletions} />}
+
+        {/* Sits between the file's facts and the actions on it, because it is
+            neither: it is what the reviewer has done about this file. */}
+        {reviewed && (
+          <label
+            className="flex shrink-0 cursor-pointer select-none items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+            title={
+              reviewed.hasChangedSince
+                ? 'You marked this file reviewed, and it has changed since. Read it again to mark it.'
+                : reviewed.isReviewed
+                  ? 'Marked as reviewed. The mark clears itself if the file changes.'
+                  : 'Mark this file as reviewed. The mark clears itself if the file changes.'
+            }
+          >
+            <Checkbox checked={isReviewed} onCheckedChange={reviewed.onChange} />
+            {reviewed.hasChangedSince ? (
+              <span className="text-warning">Changed since reviewed</span>
+            ) : (
+              'Reviewed'
+            )}
+          </label>
+        )}
 
         <FileActions
           file={file}

--- a/src/renderer/src/features/reviews/review-files-tab.tsx
+++ b/src/renderer/src/features/reviews/review-files-tab.tsx
@@ -15,6 +15,7 @@ import {
   AlertCircle,
   ArrowDown,
   ArrowUp,
+  CheckCheck,
   FileDiff,
   GitCompareArrows,
   PanelLeft,
@@ -46,7 +47,8 @@ import { CompareErrorCard, NoWorktreeNotice, WorkingTreeBanner } from './compare
 import { fileDomId, lineDomId } from './dom-ids'
 import { DiffSnippet } from './diff-snippet'
 import { DiffStat, FileDiffCard, type AnchoredThread } from './diff-view'
-import { useEditors, useReviewDiff } from './use-reviews'
+import { useEditors, useReviewDiff, useReviewedFiles } from './use-reviews'
+import { fileDiffDigest } from '@shared/diff-digest'
 import { findAnchorFile, isInlineAnchor, resolveAnchor } from '@shared/comment-anchors'
 import { threadSnippet } from '@shared/comment-snippets'
 import type { FileDiff as FileDiffData } from '@shared/git'
@@ -255,6 +257,56 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
   const paths = useMemo(() => (data?.files ?? []).map((file) => file.path), [data?.files])
   const activePath = useActiveFile(paths)
 
+  /**
+   * The fingerprint of every file *as it is being shown*, which is what a
+   * reviewed mark is checked against.
+   *
+   * Computed here rather than in the main process because the diff on screen is
+   * the only thing anyone can claim to have read - and flipping "include
+   * uncommitted" produces a different one. See `shared/diff-digest.ts`.
+   */
+  const digestByPath = useMemo(
+    () => new Map((data?.files ?? []).map((file) => [file.path, fileDiffDigest(file)])),
+    [data?.files]
+  )
+
+  const { digests: reviewedDigests, setReviewed } = useReviewedFiles(review.id)
+
+  /** Marks that still describe the code on screen. */
+  const reviewedPaths = useMemo(() => {
+    const marked = new Set<string>()
+    for (const [path, digest] of digestByPath) {
+      if (reviewedDigests.get(path) === digest) marked.add(path)
+    }
+    return marked
+  }, [digestByPath, reviewedDigests])
+
+  /**
+   * Marks that no longer do: the file was read, and then it changed.
+   *
+   * Kept apart from the plain unread files rather than folded in with them,
+   * because it is the more useful of the two states - these are the files where
+   * something arrived after the reviewer had already been through them.
+   */
+  const changedSincePaths = useMemo(() => {
+    const stale = new Set<string>()
+    for (const [path, digest] of digestByPath) {
+      const stored = reviewedDigests.get(path)
+      if (stored !== undefined && stored !== digest) stale.add(path)
+    }
+    return stale
+  }, [digestByPath, reviewedDigests])
+
+  const markReviewed = useCallback(
+    (path: string, next: boolean): void => {
+      const digest = digestByPath.get(path)
+      // A file that is not in this diff cannot be marked against it.
+      if (digest === undefined) return
+      void setReviewed(path, next ? digest : null)
+    },
+    [digestByPath, setReviewed]
+  )
+
   /** What the tree shows next to a file: comments still waiting on someone. */
   const unresolvedByFile = useMemo(() => {
     const counts = new Map<string, number>()
@@ -295,37 +347,54 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
    */
   const lastStep = useRef<{ index: number; at: number } | null>(null)
 
+  /**
+   * The last card whose top edge has passed the top of the scroller is the one
+   * being read; everything after it is still below.
+   *
+   * Shared by stepping and by the reviewed shortcut, so "the file you are on"
+   * means the same thing whichever key is pressed.
+   */
+  const currentFile = useCallback((): number => {
+    let current = 0
+    let edge: number | null = null
+    for (const [index, path] of paths.entries()) {
+      const element = document.getElementById(fileDomId(path))
+      if (element === null) continue
+      edge ??= scrollParent(element).getBoundingClientRect().top
+      if (element.getBoundingClientRect().top - edge > TOP_EDGE_SLACK) break
+      current = index
+    }
+    return current
+  }, [paths])
+
   const stepFile = useCallback(
     (delta: number): void => {
       if (paths.length === 0) return
 
       const now = Date.now()
       const pending = lastStep.current
-      let current: number
-
-      if (pending !== null && now - pending.at < STEP_CHAIN_MS) {
-        current = pending.index
-      } else {
-        // The last card whose top edge has passed the top of the scroller is
-        // the one being read; everything after it is still below.
-        current = 0
-        let edge: number | null = null
-        for (const [index, path] of paths.entries()) {
-          const element = document.getElementById(fileDomId(path))
-          if (element === null) continue
-          edge ??= scrollParent(element).getBoundingClientRect().top
-          if (element.getBoundingClientRect().top - edge > TOP_EDGE_SLACK) break
-          current = index
-        }
-      }
+      const current =
+        pending !== null && now - pending.at < STEP_CHAIN_MS ? pending.index : currentFile()
 
       const next = Math.min(paths.length - 1, Math.max(0, current + delta))
       lastStep.current = { index: next, at: now }
       const path = paths[next]
       if (path !== undefined) revealElement(fileDomId(path))
     },
-    [paths]
+    [paths, currentFile]
   )
+
+  /**
+   * Tick the file being read off, or take the tick back.
+   *
+   * `v` because that is the key GitHub uses for the same gesture, and muscle
+   * memory is most of the value of a shortcut like this one.
+   */
+  const toggleCurrentReviewed = useCallback((): void => {
+    const path = paths[currentFile()]
+    if (path === undefined) return
+    markReviewed(path, !reviewedPaths.has(path))
+  }, [paths, currentFile, markReviewed, reviewedPaths])
 
   const canIncludeUncommitted = data?.workingTree != null
 
@@ -376,6 +445,19 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
           run: () => setIncludeUncommitted(!includeUncommitted)
         },
         {
+          id: 'files:reviewed',
+          label:
+            activePath !== null && reviewedPaths.has(activePath)
+              ? 'Clear the reviewed mark on this file'
+              : 'Mark this file as reviewed',
+          group: 'Files changed',
+          keys: 'v',
+          keywords: 'viewed read seen done tick check off',
+          icon: CheckCheck,
+          disabled: paths.length === 0,
+          run: toggleCurrentReviewed
+        },
+        {
           id: 'files:refresh',
           label: 'Refresh the diff',
           group: 'Files changed',
@@ -385,7 +467,18 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
           run: () => void refresh()
         }
       ],
-      [paths.length, stepFile, treeOpen, setTreeOpen, includeUncommitted, canIncludeUncommitted, refresh]
+      [
+        paths.length,
+        stepFile,
+        treeOpen,
+        setTreeOpen,
+        includeUncommitted,
+        canIncludeUncommitted,
+        refresh,
+        activePath,
+        reviewedPaths,
+        toggleCurrentReviewed
+      ]
     )
   )
 
@@ -422,6 +515,17 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
             {plural(data.files.length, 'file')} changed
           </p>
           <DiffStat additions={data.additions} deletions={data.deletions} />
+          {/* Only once there is progress to report; "0 of 12 reviewed" is a
+              statement of the obvious taking up room next to the file count. */}
+          {reviewedPaths.size > 0 && (
+            <p
+              className="flex items-center gap-1.5 text-sm text-muted-foreground"
+              title="Files you have marked as reviewed. A mark clears itself when its file changes."
+            >
+              <CheckCheck className="size-4 text-success" />
+              {reviewedPaths.size} of {data.files.length} reviewed
+            </p>
+          )}
         </div>
 
         <div className="flex items-center gap-3">
@@ -584,6 +688,8 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
                 files={data.files}
                 activePath={activePath}
                 unresolvedByFile={unresolvedByFile}
+                reviewedPaths={reviewedPaths}
+                changedSincePaths={changedSincePaths}
                 onSelect={(path) => {
                   document
                     .getElementById(fileDomId(path))
@@ -611,6 +717,11 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
                   // arriving link cannot light up the same number in every file.
                   focus={focus?.filePath === file.path ? focus : undefined}
                   marked={marked?.filePath === file.path ? marked : undefined}
+                  reviewed={{
+                    isReviewed: reviewedPaths.has(file.path),
+                    hasChangedSince: changedSincePaths.has(file.path),
+                    onChange: (next) => markReviewed(file.path, next)
+                  }}
                   comments={{
                     reviewId: review.id,
                     threads: threadsByFile.get(file.path) ?? [],

--- a/src/renderer/src/features/reviews/use-reviews.ts
+++ b/src/renderer/src/features/reviews/use-reviews.ts
@@ -13,13 +13,14 @@
  * which is honest about when the app looks at the disk.
  */
 import useSWR, { useSWRConfig } from 'swr'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { api, CACHE_KEYS, CACHE_PREFIXES } from '@/lib/api'
 import type { EditorList } from '@shared/api'
 import type { FileContent, RepositoryRefs, ReviewCommits, ReviewDiff } from '@shared/git'
 import type {
   CreateReviewInput,
   Review,
+  ReviewedFile,
   ReviewStatus,
   ReviewWithRepository,
   UpdateReviewInput
@@ -160,6 +161,69 @@ export function useRepositoryRefs(repositoryId: number | null): ListState<Reposi
       LIVE_READ_OPTIONS
     )
   )
+}
+
+const NO_REVIEWED_FILES: ReviewedFile[] = []
+
+export interface ReviewedFilesState {
+  /**
+   * The digest stored for each ticked-off file, keyed by path.
+   *
+   * Digests rather than booleans, because a mark only counts while the file
+   * still hashes to the same value - see `shared/diff-digest.ts`. The caller
+   * compares them against the diff it is rendering, which is the only diff
+   * anyone can claim to have read.
+   */
+  digests: Map<string, string>
+  isLoading: boolean
+  /** Tick a file off against a digest, or clear the tick with a null one. */
+  setReviewed: (filePath: string, contentDigest: string | null) => Promise<void>
+}
+
+/**
+ * Which files of a review have been read, and the writer that changes it.
+ *
+ * Marking is optimistic. Ticking a file off happens in the middle of reading a
+ * diff, often from the keyboard, and waiting a round trip for the tick to
+ * appear - or worse, for the card to fold - would make the gesture feel
+ * broken. The write is one indexed upsert against a local SQLite file, so the
+ * optimistic state is almost always the state that lands; a failure rolls back
+ * and revalidates, which is the same read the screen already trusts.
+ */
+export function useReviewedFiles(reviewId: number): ReviewedFilesState {
+  const { data, isLoading, mutate } = useSWR<ReviewedFile[], unknown>(
+    CACHE_KEYS.reviewedFiles(reviewId),
+    () => api.reviews.reviewedFiles({ reviewId })
+  )
+
+  const files = data ?? NO_REVIEWED_FILES
+
+  const digests = useMemo(
+    () => new Map(files.map((file) => [file.filePath, file.contentDigest])),
+    [files]
+  )
+
+  const setReviewed = useCallback(
+    async (filePath: string, contentDigest: string | null) => {
+      const next = (current: ReviewedFile[] = NO_REVIEWED_FILES): ReviewedFile[] => {
+        const others = current.filter((file) => file.filePath !== filePath)
+        return contentDigest === null
+          ? others
+          : [...others, { reviewId, filePath, contentDigest, reviewedAt: new Date().toISOString() }]
+      }
+
+      await mutate(
+        async () => {
+          await api.reviews.setFileReviewed({ reviewId, filePath, contentDigest })
+          return next(data)
+        },
+        { optimisticData: next, revalidate: false, rollbackOnError: true }
+      )
+    },
+    [data, mutate, reviewId]
+  )
+
+  return { digests, isLoading, setReviewed }
 }
 
 export interface ReviewMutations {

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -48,7 +48,13 @@ export const CACHE_KEYS = {
    * resolution differs between them, and that is computed in the component
    * from whichever diff it is showing.
    */
-  reviewComments: (reviewId: number) => `review-comments:${reviewId}`
+  reviewComments: (reviewId: number) => `review-comments:${reviewId}`,
+  /**
+   * Reviewed marks, keyed per review for the same reason as comments: they are
+   * a plain database read, and which of them still count is worked out in the
+   * component from whichever diff it is showing.
+   */
+  reviewedFiles: (reviewId: number) => `review-reviewed:${reviewId}`
 } as const
 
 /** Prefixes used by the family-wide invalidation above. */
@@ -58,5 +64,6 @@ export const CACHE_PREFIXES = {
   reviewCommits: 'review-commits:',
   reviewDiff: 'review-diff:',
   reviewFile: 'review-file:',
-  reviewComments: 'review-comments:'
+  reviewComments: 'review-comments:',
+  reviewedFiles: 'review-reviewed:'
 } as const

--- a/src/shared/__tests__/diff-digest.test.ts
+++ b/src/shared/__tests__/diff-digest.test.ts
@@ -1,0 +1,107 @@
+import { deepStrictEqual, notStrictEqual, ok, strictEqual } from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { DIGEST_MAX_LENGTH, fileDiffDigest } from '../diff-digest.js'
+import type { DiffLine, FileDiff } from '../git.js'
+
+function line(type: DiffLine['type'], content: string, oldNumber: number | null, newNumber: number | null): DiffLine {
+  return { type, content, oldNumber, newNumber }
+}
+
+function fileDiff(overrides: Partial<FileDiff> = {}): FileDiff {
+  return {
+    path: 'src/app.ts',
+    oldPath: null,
+    status: 'modified',
+    isBinary: false,
+    additions: 1,
+    deletions: 1,
+    truncated: false,
+    isUntracked: false,
+    hasUncommittedChanges: false,
+    hunks: [
+      {
+        header: '@@ -1,3 +1,3 @@',
+        oldStart: 1,
+        oldLines: 3,
+        newStart: 1,
+        newLines: 3,
+        lines: [
+          line('context', 'const a = 1', 1, 1),
+          line('delete', 'const b = 2', 2, null),
+          line('insert', 'const b = 3', null, 2)
+        ]
+      }
+    ],
+    ...overrides
+  }
+}
+
+describe('fileDiffDigest', () => {
+  it('is stable for the same diff', () => {
+    strictEqual(fileDiffDigest(fileDiff()), fileDiffDigest(fileDiff()))
+  })
+
+  it('fits the column it is stored in', () => {
+    ok(fileDiffDigest(fileDiff()).length <= DIGEST_MAX_LENGTH)
+  })
+
+  it('changes when a line of code changes', () => {
+    const edited = fileDiff()
+    edited.hunks[0]!.lines[2] = line('insert', 'const b = 4', null, 2)
+    notStrictEqual(fileDiffDigest(fileDiff()), fileDiffDigest(edited))
+  })
+
+  it('changes when a line is added to the diff', () => {
+    const grown = fileDiff()
+    grown.hunks[0]!.lines.push(line('insert', 'const c = 5', null, 3))
+    notStrictEqual(fileDiffDigest(fileDiff()), fileDiffDigest(grown))
+  })
+
+  it('changes when the same lines move, so a mark does not survive an edit above', () => {
+    const moved = fileDiff({
+      hunks: [{ ...fileDiff().hunks[0]!, header: '@@ -8,3 +9,3 @@' }]
+    })
+    notStrictEqual(fileDiffDigest(fileDiff()), fileDiffDigest(moved))
+  })
+
+  it('changes when a line is only reclassified', () => {
+    const staged = fileDiff()
+    staged.hunks[0]!.lines[0] = line('insert', 'const a = 1', null, 1)
+    notStrictEqual(fileDiffDigest(fileDiff()), fileDiffDigest(staged))
+  })
+
+  it('changes when the file is renamed', () => {
+    notStrictEqual(
+      fileDiffDigest(fileDiff()),
+      fileDiffDigest(fileDiff({ status: 'renamed', oldPath: 'src/old.ts' }))
+    )
+  })
+
+  it('tells two files with identical content apart', () => {
+    notStrictEqual(fileDiffDigest(fileDiff()), fileDiffDigest(fileDiff({ path: 'src/other.ts' })))
+  })
+
+  it('notices a binary file changing, which has no hunks to compare', () => {
+    const before = fileDiff({ isBinary: true, hunks: [], additions: 0, deletions: 0 })
+    const after = fileDiff({ isBinary: true, hunks: [], additions: 4, deletions: 2 })
+    notStrictEqual(fileDiffDigest(before), fileDiffDigest(after))
+  })
+
+  it('ignores state that is not part of the diff being read', () => {
+    // Whether the change happens to be committed yet does not alter a single
+    // line on screen, so a mark should survive committing the work.
+    strictEqual(
+      fileDiffDigest(fileDiff()),
+      fileDiffDigest(fileDiff({ hasUncommittedChanges: true }))
+    )
+  })
+
+  it('cannot be fooled by content that runs across field boundaries', () => {
+    const digests = [
+      fileDiffDigest(fileDiff({ path: 'a b', oldPath: null })),
+      fileDiffDigest(fileDiff({ path: 'a', oldPath: 'b' })),
+      fileDiffDigest(fileDiff({ path: 'a', oldPath: null }))
+    ]
+    deepStrictEqual(new Set(digests).size, digests.length)
+  })
+})

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -30,8 +30,11 @@ import type {
   Review,
   ReviewCommitsInput,
   ReviewDiffInput,
+  ReviewedFile,
   ReviewFileInput,
   ReviewWithRepository,
+  ListReviewedFilesInput,
+  SetFileReviewedInput,
   SetThreadResolvedInput,
   UpdateCommentInput,
   UpdateRepositoryInput,
@@ -54,6 +57,8 @@ export const IPC_CHANNELS = {
   reviewsDiff: 'reviews:diff',
   reviewsFile: 'reviews:file',
   reviewsOpenInEditor: 'reviews:openInEditor',
+  reviewsReviewedFiles: 'reviews:reviewedFiles',
+  reviewsSetFileReviewed: 'reviews:setFileReviewed',
   commentsList: 'comments:list',
   commentsCreateThread: 'comments:createThread',
   commentsReply: 'comments:reply',
@@ -181,6 +186,14 @@ export interface GitWarrenApi {
     file(input: ReviewFileInput): Promise<FileContent>
     /** Open a file of this review in the reviewer's editor, at a line. */
     openInEditor(input: OpenReviewFileInput): Promise<void>
+    /**
+     * Files the reviewer has ticked off, each with the fingerprint of the diff
+     * they read. Whether a mark still applies is decided in the renderer,
+     * against the diff on screen - see `shared/diff-digest.ts`.
+     */
+    reviewedFiles(input: ListReviewedFilesInput): Promise<ReviewedFile[]>
+    /** Tick a file off against a digest, or clear the tick with a null one. */
+    setFileReviewed(input: SetFileReviewedInput): Promise<ReviewedFile | null>
   }
   /**
    * Comments carry no author field in either direction. Anything sent over this

--- a/src/shared/diff-digest.ts
+++ b/src/shared/diff-digest.ts
@@ -1,0 +1,88 @@
+/**
+ * A short fingerprint of one file's diff, used to expire a "Reviewed" mark.
+ *
+ * Marking a file reviewed is a statement about a particular piece of code -
+ * "I have read this" - and it has to stop being true the moment that code
+ * changes. Storing a flag alone could not express that: the next commit would
+ * leave a tick next to work nobody has looked at, which is worse than no tick
+ * at all. So what gets stored is this digest of what the reviewer actually saw,
+ * and the mark counts only while the file still hashes to the same value.
+ *
+ * Not a cryptographic hash, deliberately. The comparison happens in the
+ * renderer, against the diff already on screen, so it has to be synchronous -
+ * and `crypto.subtle` is async-only. Nothing here defends against an adversary;
+ * the job is to notice that a file changed, and 106 bits of cyrb53 does that
+ * with collisions far rarer than the git operations around it failing.
+ *
+ * The digest covers everything the card renders: the path, how the file
+ * changed, and every line of every hunk including the `@@` headers. Anything
+ * that alters the diff therefore clears the mark - including flipping "include
+ * uncommitted", which genuinely does show different code and so should not
+ * inherit a tick earned against the committed version.
+ */
+import type { FileDiff } from './git.js'
+
+/**
+ * cyrb53, a well-known non-cryptographic string hash. Two multiply-xor lanes
+ * mixed at the end; returns 53 bits, the most a JS number carries exactly.
+ */
+function cyrb53(text: string, seed: number): number {
+  let h1 = 0xdeadbeef ^ seed
+  let h2 = 0x41c6ce57 ^ seed
+
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index)
+    h1 = Math.imul(h1 ^ code, 2654435761)
+    h2 = Math.imul(h2 ^ code, 1597334677)
+  }
+
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507)
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507)
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909)
+
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0)
+}
+
+/**
+ * Everything about the file the reviewer could have read, as one string.
+ *
+ * Line numbers ride along inside the hunk headers rather than being written
+ * per row: a change above shifts the header, which is exactly when the file
+ * below it deserves a second look anyway.
+ */
+function canonical(file: FileDiff): string {
+  const parts: string[] = [
+    file.path,
+    file.oldPath ?? '',
+    file.status,
+    file.isBinary ? 'binary' : 'text',
+    file.isUntracked ? 'untracked' : 'tracked',
+    file.truncated ? 'clipped' : 'whole',
+    // A binary file has no hunks to hash, so its byte counts are the only
+    // evidence it changed at all.
+    `${file.additions},${file.deletions}`
+  ]
+
+  for (const hunk of file.hunks) {
+    parts.push(hunk.header)
+    for (const line of hunk.lines) parts.push(`${line.type[0]}${line.content}`)
+  }
+
+  // NUL as the separator: it cannot occur in a path or in a line of a text
+  // diff, so no two different files can canonicalise to the same string by
+  // having their fields run together.
+  return parts.join('\u0000')
+}
+
+/** Length of what `fileDiffDigest` returns, at most. Sizes the stored column. */
+export const DIGEST_MAX_LENGTH = 32
+
+/**
+ * The fingerprint of a file's diff: two independently seeded passes, hex, so a
+ * collision needs both lanes to agree.
+ */
+export function fileDiffDigest(file: FileDiff): string {
+  const text = canonical(file)
+  return `${cyrb53(text, 0).toString(16)}-${cyrb53(text, 0x9e3779b9).toString(16)}`
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -11,6 +11,7 @@
  * UI and the agent surface from drifting apart.
  */
 import { z } from 'zod'
+import { DIGEST_MAX_LENGTH } from './diff-digest.js'
 import type { DiffLine } from './git.js'
 
 export const MAX_NAME_LENGTH = 120
@@ -240,6 +241,44 @@ export type ReviewDiffInput = z.input<typeof reviewDiffInputSchema>
 export type ReviewFileInput = z.input<typeof reviewFileInputSchema>
 export type OpenReviewFileInput = z.input<typeof openReviewFileInputSchema>
 export type RepositoryRefsInput = z.input<typeof repositoryRefsInputSchema>
+
+/* -------------------------------------------------------------------------- */
+/* Reviewed files                                                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A file the reviewer has ticked off, and the fingerprint of what they read.
+ *
+ * The digest is handed back to the UI rather than compared in the service on
+ * purpose. Only the renderer knows which diff is actually on screen - the
+ * "include uncommitted" switch changes it - and a mark checked against any
+ * other version of the file would be answering a question nobody asked.
+ */
+export const reviewedFileSchema = z.object({
+  reviewId: reviewIdSchema,
+  filePath: z.string(),
+  contentDigest: z.string(),
+  reviewedAt: z.string()
+})
+
+export const listReviewedFilesInputSchema = z.object({ reviewId: reviewIdSchema })
+
+/**
+ * Tick a file off, or take the tick back.
+ *
+ * One nullable field rather than a `reviewed` boolean beside an optional
+ * digest, because those two can contradict each other and this cannot: a
+ * digest is a mark on that exact diff, and null is no mark at all.
+ */
+export const setFileReviewedInputSchema = z.object({
+  reviewId: reviewIdSchema,
+  filePath: z.string().min(1).max(4096),
+  contentDigest: z.string().min(1).max(DIGEST_MAX_LENGTH).nullable()
+})
+
+export type ReviewedFile = z.infer<typeof reviewedFileSchema>
+export type ListReviewedFilesInput = z.input<typeof listReviewedFilesInputSchema>
+export type SetFileReviewedInput = z.input<typeof setFileReviewedInputSchema>
 
 /* -------------------------------------------------------------------------- */
 /* Comments                                                                   */


### PR DESCRIPTION
Files changed gets a **Reviewed** checkbox per file, like GitHub's *Viewed* — and, as asked, the mark resets itself when the file changes.

### What it does

- A checkbox in every file header; `v` ticks off whichever file you are on.
- Ticking a file folds its card away, marks and dims its row in the file tree, and bumps a *N of M reviewed* counter next to the file count.
- When a marked file changes, the tick clears itself and the card is labelled **Changed since reviewed** in amber — silently unticking it would lose the one fact worth knowing, that this is the file that moved after you read it.

### How the reset works

A flag could not express "I read *this*", so what is stored is a digest of the diff that was on screen at the time (`shared/diff-digest.ts` — a cyrb53 fingerprint of the path, change status and every line of every hunk, including the `@@` headers, so a shift from an edit above counts too). A mark holds only while the file still hashes the same.

Two behaviours fall out of that with no code of their own:

- Flipping *include uncommitted* is a genuinely different diff, so a file read in one setting is not ticked in the other.
- Reverting a change brings the mark back, because the file hashes as it did before.

The comparison runs in the renderer against the diff being rendered; the service only stores digests. One review has two diffs at once, and a mark resolved against the one nobody is looking at would answer a question nobody asked.

### Storage

New `reviewed_files` table (migration `0006`), unique on `(review_id, file_path)`, cascading with the review. Re-reading a changed file replaces the row rather than adding one. Reachable over IPC only — deliberately no MCP tool, because an agent claiming a human has read a file would make the only honest signal on the screen worthless.

### Verified

- 217 tests pass (9 new for the store, 11 for the digest), lint and typecheck clean, full build green.
- Driven in the real app over CDP against a throwaway database: a mark survives a reload, `v` toggles the current file, editing a marked file on disk and refreshing lapses the mark to *Changed since reviewed*, and undoing that edit restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNbAkbJSGzX7H23HPPTpoL
