### PR TITLE
Find in the diff from the files changed tab

### DIFF
--- a/src/renderer/src/features/reviews/__tests__/diff-search.test.ts
+++ b/src/renderer/src/features/reviews/__tests__/diff-search.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Coverage for find-in-diff.
+ *
+ * Two things matter here and neither is "does it find the word". One is that an
+ * offset can always be used to slice the line it came from, because the marks
+ * in the renderer are drawn from these numbers and a shifted one mangles the
+ * code it was meant to point at. The other is that hits come back in reading
+ * order, since that order *is* what Enter walks.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { findDiffMatches, matchOffsets, rowPosition } from '../diff-search.js'
+import type { DiffHunk, DiffLine, FileDiff } from '@shared/git'
+
+function line(content: string, oldNumber: number | null, newNumber: number | null): DiffLine {
+  return {
+    type: oldNumber === null ? 'insert' : newNumber === null ? 'delete' : 'context',
+    content,
+    oldNumber,
+    newNumber
+  }
+}
+
+function hunk(lines: DiffLine[]): DiffHunk {
+  return { header: '@@', oldStart: 1, oldLines: lines.length, newStart: 1, newLines: lines.length, lines }
+}
+
+function file(path: string, hunks: DiffHunk[]): FileDiff {
+  return {
+    path,
+    oldPath: null,
+    status: 'modified',
+    isBinary: false,
+    additions: 0,
+    deletions: 0,
+    hunks,
+    truncated: false,
+    isUntracked: false,
+    hasUncommittedChanges: false
+  }
+}
+
+test('finds every occurrence in a line, case-insensitively, without overlapping', () => {
+  assert.deepEqual(matchOffsets('Total total TOTAL', 'total'), [0, 6, 12])
+  assert.deepEqual(matchOffsets('aaaa', 'aa'), [0, 2])
+  assert.deepEqual(matchOffsets('nothing here', 'xyz'), [])
+})
+
+test('an empty query matches nothing rather than everything', () => {
+  assert.deepEqual(matchOffsets('anything', ''), [])
+  assert.deepEqual(findDiffMatches([file('a.ts', [hunk([line('anything', 1, 1)])])], ''), {
+    matches: [],
+    fileCount: 0,
+    truncated: false
+  })
+})
+
+test('offsets slice the original line, whatever case folding does to its length', () => {
+  // `İ` lowercases into two code units, so an offset measured against the
+  // folded string would land a character late in the original.
+  const content = 'İstanbul map'
+  const [offset] = matchOffsets(content, 'map')
+  assert.equal(offset !== undefined && content.slice(offset, offset + 3), 'map')
+})
+
+test('a hit is addressed to the side of the diff its row is on', () => {
+  assert.deepEqual(rowPosition(line('kept', 4, 7)), { side: 'head', number: 7 })
+  assert.deepEqual(rowPosition(line('added', null, 7)), { side: 'head', number: 7 })
+  assert.deepEqual(rowPosition(line('removed', 4, null)), { side: 'base', number: 4 })
+})
+
+test('hits come back in reading order, with the file they are in', () => {
+  const files = [
+    file('a.ts', [hunk([line('const total = 1', 1, 1), line('sum', 2, 2)])]),
+    file('b.ts', [hunk([line('total total', 9, null)])])
+  ]
+
+  assert.deepEqual(findDiffMatches(files, 'total'), {
+    matches: [
+      { filePath: 'a.ts', side: 'head', line: 1, occurrence: 0 },
+      { filePath: 'b.ts', side: 'base', line: 9, occurrence: 0 },
+      { filePath: 'b.ts', side: 'base', line: 9, occurrence: 1 }
+    ],
+    fileCount: 2,
+    truncated: false
+  })
+})
+
+test('stops at the ceiling and says so, still counting the file it stopped in', () => {
+  const files = [
+    file('a.ts', [hunk([line('x', 1, 1)])]),
+    file('b.ts', [hunk([line('x x x', 2, 2)])])
+  ]
+
+  const found = findDiffMatches(files, 'x', 2)
+  assert.equal(found.matches.length, 2)
+  assert.equal(found.truncated, true)
+  assert.equal(found.fileCount, 2)
+})
+
+test('rows the reader cannot be scrolled to are not offered as hits', () => {
+  const orphan: DiffLine = { type: 'context', content: 'total', oldNumber: null, newNumber: null }
+  assert.deepEqual(findDiffMatches([file('a.ts', [hunk([orphan])])], 'total').matches, [])
+})

--- a/src/renderer/src/features/reviews/diff-find-bar.tsx
+++ b/src/renderer/src/features/reviews/diff-find-bar.tsx
@@ -1,0 +1,277 @@
+/**
+ * Find in the diff: the bar, and the state behind it.
+ *
+ * Modelled on the browser's own find rather than on a filter. Nothing is hidden
+ * and no file is dropped from the page - the hits are marked where they are and
+ * Enter walks them - because a reviewer reading a diff wants to see the change
+ * around the word they were looking for, not the word on its own.
+ *
+ * The hook lives beside the bar rather than inside it because the tab needs the
+ * same state twice over: to draw the bar, and to tell each file card which of
+ * its lines is the one being pointed at.
+ */
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent
+} from 'react'
+import { ChevronDown, ChevronUp, Search, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { plural } from '@/lib/format'
+import { formatStep } from '@/lib/keys'
+import { revealElement } from '@/lib/reveal'
+import { cn } from '@/lib/utils'
+import { findDiffMatches, type DiffMatch, type DiffSearch } from './diff-search'
+import { ACTIVE_MATCH_ID } from './dom-ids'
+import type { FileDiff } from '@shared/git'
+
+export interface DiffFind {
+  open: boolean
+  /** What is in the field, which is what the field must render. */
+  query: string
+  setQuery: (query: string) => void
+  /**
+   * The query the hits below were found with - a beat behind `query` while
+   * someone is still typing. What the bar says about the results has to be said
+   * about this one, or a fast typist is told "no matches" about a query that
+   * has not been run yet.
+   */
+  term: string
+  matches: DiffMatch[]
+  fileCount: number
+  truncated: boolean
+  /** Position of the current hit in `matches`, or -1 when there are none. */
+  index: number
+  /** Open the bar, or bring the focus back to a bar that is already open. */
+  show: () => void
+  close: () => void
+  /** Move to the next hit (`1`) or the previous one (`-1`), wrapping. */
+  step: (delta: number) => void
+  /**
+   * Handed to the field as its `ref`. A callback rather than the ref object
+   * itself: the hook is the only thing that ever reaches for the element - to
+   * put the focus in it - and the bar is left with nothing to hold.
+   */
+  bindInput: (input: HTMLInputElement | null) => void
+  /** What to hand a file card, or undefined when no search is running. */
+  searchFor: (path: string) => DiffSearch | undefined
+}
+
+export function useDiffFind(files: readonly FileDiff[]): DiffFind {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [index, setIndex] = useState(0)
+  const input = useRef<HTMLInputElement | null>(null)
+  const bindInput = useCallback((node: HTMLInputElement | null) => {
+    input.current = node
+  }, [])
+
+  /**
+   * Matching runs against the settled query rather than the one being typed.
+   * Every keystroke otherwise re-scans the whole diff and re-renders every row
+   * before the next character can appear, which is exactly the moment the app
+   * must not stutter. The field itself stays on `query`, so typing looks
+   * instant even while the marks are a beat behind.
+   */
+  const applied = useDeferredValue(query)
+  const term = open ? applied : ''
+
+  const { matches, fileCount, truncated } = useMemo(
+    () => findDiffMatches(files, term),
+    [files, term]
+  )
+
+  // A new query is a new set of hits, so the walk restarts at the first one.
+  // Adjusted during render the way the palette adjusts its highlight: React
+  // re-runs this pass before painting, so the first frame of a new query is
+  // already pointing at that query's first hit.
+  const [termAtIndex, setTermAtIndex] = useState(term)
+  if (termAtIndex !== term) {
+    setTermAtIndex(term)
+    setIndex(0)
+  }
+
+  // Clamped rather than stored: the diff can be refreshed underneath a search,
+  // and an index left past the end would point at nothing.
+  const current = matches.length === 0 ? -1 : Math.min(index, matches.length - 1)
+  const active = current === -1 ? null : (matches[current] ?? null)
+
+  const show = useCallback(() => {
+    setOpen(true)
+    // Already open: the effect below will not fire, so take the focus here.
+    // Selecting rather than appending is what makes a second ⌘F mean "search
+    // for something else" instead of "carry on typing this".
+    input.current?.select()
+  }, [])
+
+  useEffect(() => {
+    if (open) input.current?.select()
+  }, [open])
+
+  const close = useCallback(() => setOpen(false), [])
+
+  const step = useCallback(
+    (delta: number) => {
+      const count = matches.length
+      if (count === 0) return
+      setIndex((previous) => (Math.min(previous, count - 1) + delta + count) % count)
+    },
+    [matches.length]
+  )
+
+  /**
+   * Bring the current hit into view.
+   *
+   * `revealElement` retries across a few frames, which is what makes this work
+   * on a hit inside a collapsed file: the card opens on this same render, and
+   * the mark appears a frame or two later.
+   */
+  const activeKey =
+    active === null ? null : `${active.filePath}:${active.side}:${active.line}:${active.occurrence}`
+
+  useEffect(() => {
+    if (active === null) return
+    return revealElement(ACTIVE_MATCH_ID, {
+      block: 'center',
+      // The code scrolls sideways in a container of its own, so a hit past the
+      // right edge has to be scrolled to there as well as down the page.
+      // `nearest` rather than `center`: centring a mark that was already on
+      // screen drags the line-number gutters off the left of it for nothing.
+      inline: 'nearest',
+      behavior: 'smooth'
+    })
+    // `activeKey` stands in for the match, which is a fresh object each search.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeKey])
+
+  const searchFor = useCallback(
+    (path: string): DiffSearch | undefined =>
+      term === ''
+        ? undefined
+        : {
+            query: term,
+            active:
+              active !== null && active.filePath === path
+                ? { side: active.side, line: active.line, occurrence: active.occurrence }
+                : null
+          },
+    [term, active]
+  )
+
+  return {
+    open,
+    query,
+    setQuery,
+    term,
+    matches,
+    fileCount,
+    truncated,
+    index: current,
+    show,
+    close,
+    step,
+    bindInput,
+    searchFor
+  }
+}
+
+export function DiffFindBar({ find }: { find: DiffFind }) {
+  const { matches, index, query, term, truncated, fileCount, bindInput } = find
+  const searching = term !== ''
+  const none = searching && matches.length === 0
+
+  function onKeyDown(event: ReactKeyboardEvent<HTMLInputElement>): void {
+    switch (event.key) {
+      case 'Enter':
+        event.preventDefault()
+        find.step(event.shiftKey ? -1 : 1)
+        break
+      case 'Escape':
+        event.preventDefault()
+        // The global layer would not see this anyway - React's own handler runs
+        // first - but saying so here keeps the bar's keys in one place.
+        event.stopPropagation()
+        find.close()
+        break
+      default:
+        break
+    }
+  }
+
+  return (
+    // Sticky, so the count and the arrows stay reachable while the diff scrolls
+    // past underneath them - which is the whole time a search is being used.
+    <div className="sticky top-0 z-20 flex items-center gap-2 rounded-lg border border-border bg-card/95 px-2 py-1.5 shadow-sm backdrop-blur">
+      <Search className="ml-1 size-4 shrink-0 text-muted-foreground" />
+
+      <Input
+        ref={bindInput}
+        value={query}
+        onChange={(event) => find.setQuery(event.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="Find in the diff"
+        aria-label="Find in the diff"
+        spellCheck={false}
+        autoComplete="off"
+        className="h-7 border-0 bg-transparent px-0 shadow-none focus-visible:outline-none"
+      />
+
+      {/* Announced rather than merely drawn: someone stepping through hits with
+          the keyboard never looks at this line, and still needs to hear it. */}
+      <span
+        role="status"
+        aria-live="polite"
+        className={cn(
+          'shrink-0 whitespace-nowrap text-xs tabular-nums',
+          none ? 'text-warning' : 'text-muted-foreground'
+        )}
+      >
+        {!searching
+          ? ''
+          : none
+            ? 'No matches'
+            : `${index + 1} of ${matches.length}${truncated ? '+' : ''} in ${plural(fileCount, 'file')}`}
+      </span>
+
+      <div className="flex shrink-0 items-center">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={() => find.step(-1)}
+          disabled={matches.length === 0}
+          title={`Previous match (${formatStep('shift+enter')})`}
+          aria-label="Previous match"
+        >
+          <ChevronUp />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={() => find.step(1)}
+          disabled={matches.length === 0}
+          title={`Next match (${formatStep('enter')})`}
+          aria-label="Next match"
+        >
+          <ChevronDown />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7"
+          onClick={() => find.close()}
+          title={`Close the find bar (${formatStep('escape')})`}
+          aria-label="Close the find bar"
+        >
+          <X />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/features/reviews/diff-search.ts
+++ b/src/renderer/src/features/reviews/diff-search.ts
@@ -1,0 +1,144 @@
+/**
+ * Finding text inside the diff that is on screen.
+ *
+ * Kept apart from the rendering for two reasons. The tab needs the hits in
+ * order - to count them, and to walk them with the keyboard - while each row
+ * needs only its own, and a row that decided for itself where the highlights go
+ * could disagree with the counter above it. Both ask `matchOffsets`, so they
+ * cannot.
+ *
+ * The search runs over the patch: the lines git produced for this comparison.
+ * Context a reviewer has unfolded is highlighted like anything else, because
+ * text that is plainly on screen and not marked reads as a broken search - but
+ * it is not counted and Enter does not stop on it. What "12 matches" means then
+ * stays a fact about the diff rather than about which gaps happen to be open.
+ *
+ * DOM-free on purpose, like `lib/keys`: it is the part worth testing, and the
+ * tests here are node programs.
+ */
+import type { DiffSide } from '@shared/comment-anchors'
+import type { DiffLine, FileDiff } from '@shared/git'
+
+/** One hit, addressed the way the diff addresses a row. */
+export interface DiffMatch {
+  filePath: string
+  side: DiffSide
+  line: number
+  /** Which hit within that row, so a line holding the query twice can be walked. */
+  occurrence: number
+}
+
+export interface DiffMatches {
+  matches: DiffMatch[]
+  /** Files holding at least one hit. */
+  fileCount: number
+  /** True when the ceiling below was reached and there are more hits than these. */
+  truncated: boolean
+}
+
+/**
+ * What a file card needs in order to draw the search that is running.
+ *
+ * Declared here rather than beside the card's other props because it is shared
+ * by the three parties - the bar that owns the query, the card, and the row -
+ * and this is the module none of them can avoid importing.
+ */
+export interface DiffSearch {
+  /** The text being looked for. Never empty when a search is on. */
+  query: string
+  /** The current hit, when it is in this file. */
+  active: { side: DiffSide; line: number; occurrence: number } | null
+}
+
+/**
+ * As many hits as are worth collecting.
+ *
+ * A one-letter query against a large diff matches tens of thousands of times,
+ * and neither the counter nor anyone pressing Enter has a use for the tail of
+ * that. Stopping keeps typing responsive and is reported rather than hidden.
+ */
+export const MAX_MATCHES = 1000
+
+/**
+ * Which side of the diff a row belongs to, and its number on that side.
+ *
+ * Head where the line still exists, base for a line the change deleted - the
+ * same choice GitHub makes, and the only one that lets a reviewer remark on
+ * removed code at all. The renderer reads it from here too, so a hit and the
+ * row it is meant to land on can never be addressed differently.
+ */
+export function rowPosition(line: DiffLine): { side: DiffSide; number: number | null } {
+  return line.newNumber !== null
+    ? { side: 'head', number: line.newNumber }
+    : { side: 'base', number: line.oldNumber }
+}
+
+/**
+ * Where `query` occurs in `content`, case-insensitively, without overlaps.
+ *
+ * Case folding is done on a copy and only trusted while it leaves the length
+ * alone. A handful of characters grow when lowercased - `İ` becomes two code
+ * units - and an offset measured against the folded string would then slice the
+ * original in the wrong place, mangling the line it was supposed to mark. Those
+ * rare lines fall back to an exact search, which is right more often than a
+ * shifted highlight is.
+ */
+export function matchOffsets(content: string, query: string): number[] {
+  if (query === '' || content === '') return []
+
+  const folded = content.toLowerCase()
+  const aligned = folded.length === content.length
+  const haystack = aligned ? folded : content
+  const needle = aligned ? query.toLowerCase() : query
+  if (needle === '') return []
+
+  const offsets: number[] = []
+  for (
+    let at = haystack.indexOf(needle);
+    at !== -1;
+    at = haystack.indexOf(needle, at + needle.length)
+  ) {
+    offsets.push(at)
+  }
+  return offsets
+}
+
+/** Every hit in the diff, in reading order: file by file, top to bottom. */
+export function findDiffMatches(
+  files: readonly FileDiff[],
+  query: string,
+  limit: number = MAX_MATCHES
+): DiffMatches {
+  if (query === '') return { matches: [], fileCount: 0, truncated: false }
+
+  const matches: DiffMatch[] = []
+  let fileCount = 0
+
+  for (const file of files) {
+    let counted = false
+
+    for (const hunk of file.hunks) {
+      for (const line of hunk.lines) {
+        const { side, number } = rowPosition(line)
+        // A row with no number on either side is not a row anything can be
+        // scrolled to, so it is not a place a hit can be reported.
+        if (number === null) continue
+
+        const offsets = matchOffsets(line.content, query)
+        // Counted as soon as the file is known to hold something, so the tally
+        // is right even when the ceiling below stops the walk mid-file.
+        if (offsets.length > 0 && !counted) {
+          counted = true
+          fileCount += 1
+        }
+
+        for (let occurrence = 0; occurrence < offsets.length; occurrence += 1) {
+          if (matches.length >= limit) return { matches, fileCount, truncated: true }
+          matches.push({ filePath: file.path, side, line: number, occurrence })
+        }
+      }
+    }
+  }
+
+  return { matches, fileCount, truncated: false }
+}

--- a/src/renderer/src/features/reviews/diff-view.tsx
+++ b/src/renderer/src/features/reviews/diff-view.tsx
@@ -52,7 +52,7 @@ import { CommentThreadCard } from '../comments/comment-thread-card'
 import { DiffSnippet } from './diff-snippet'
 import { FilePath } from './file-path'
 import { ImageDiff } from './image-diff'
-import { lineDomId } from './dom-ids'
+import { ACTIVE_MATCH_ID, lineDomId } from './dom-ids'
 import { useReviewFile } from './use-reviews'
 import type { CommentMutations } from '../comments/use-comments'
 import { threadSnippet } from '@shared/comment-snippets'
@@ -65,6 +65,7 @@ import {
   type GapSegment
 } from '@shared/diff-gaps'
 import { errorMessage } from '@/lib/errors'
+import { matchOffsets, rowPosition, type DiffSearch } from './diff-search'
 import { imageMediaType } from '@shared/git'
 import type { DiffChanges, DiffHunk, DiffLine, FileChangeStatus, FileDiff } from '@shared/git'
 import type { CommentThread } from '@shared/schemas'
@@ -211,7 +212,8 @@ export function FileDiffCard({
   source,
   focus,
   marked,
-  reviewed
+  reviewed,
+  search
 }: {
   file: FileDiff
   comments?: DiffComments
@@ -222,6 +224,8 @@ export function FileDiffCard({
   marked?: { side: DiffSide; line: number }
   /** Omitted where there is nothing to mark against - a card shown on its own. */
   reviewed?: ReviewedMark
+  /** The find running over the whole diff, as it applies to this file. */
+  search?: DiffSearch
 }) {
   const lineCount = file.hunks.reduce((total, hunk) => total + hunk.lines.length, 0)
   /** Null until the reviewer opens or closes the card themselves. */
@@ -241,11 +245,16 @@ export function FileDiffCard({
    * by hand stays closed.
    */
   const expanded =
-    toggled ??
-    // A file already ticked off arrives folded: the list of what is left to
-    // read is the point of the mark, and a read file taking up a screen of
-    // space works against it.
-    (focus !== undefined || (!isReviewed && lineCount <= COLLAPSE_ABOVE_LINES))
+    // A hit the reader is being walked to wins over a card they closed by hand,
+    // or ticked off: "12 matches" that stops on a file showing nothing would be
+    // a lie. It is only for as long as the hit is the current one - move on, and
+    // the card goes back to however the reader left it.
+    search?.active != null ||
+    (toggled ??
+      // A file already ticked off arrives folded: the list of what is left to
+      // read is the point of the mark, and a read file taking up a screen of
+      // space works against it.
+      (focus !== undefined || (!isReviewed && lineCount <= COLLAPSE_ABOVE_LINES)))
   const setExpanded = setToggled
 
   /**
@@ -401,7 +410,8 @@ export function FileDiffCard({
       : composingOn,
     covered,
     marked: marked ?? null,
-    filePath: file.path
+    filePath: file.path,
+    search: search ?? null
   }
 
   const orphans = threads.filter((thread) => thread.anchor.line === null)
@@ -958,6 +968,8 @@ interface RowContext {
   /** The line arrived at from a conversation thread, marked briefly. */
   marked: { side: DiffSide; line: number } | null
   filePath: string
+  /** The find in progress, so a row can pick its own hits out. */
+  search: DiffSearch | null
 }
 
 function HunkRows({
@@ -991,15 +1003,12 @@ function LineRow({
   selection,
   covered,
   marked,
-  filePath
+  filePath,
+  search
 }: { line: DiffLine } & RowContext) {
-  /**
-   * Which side a comment on this row belongs to. Head where the line still
-   * exists, base for a line the change deleted - the same choice GitHub makes,
-   * and the only one that lets a reviewer remark on removed code at all.
-   */
-  const side: DiffSide = line.newNumber !== null ? 'head' : 'base'
-  const number = side === 'head' ? line.newNumber : line.oldNumber
+  // Which side a comment on this row belongs to, and the number it carries
+  // there. Shared with the search, so a hit is addressed to the row it is on.
+  const { side, number } = rowPosition(line)
 
   const threads = number === null ? [] : (placed.get(`${side}:${number}`) ?? [])
   // The composer opens under the *last* line of the range, where the eye is
@@ -1095,7 +1104,18 @@ function LineRow({
           <span aria-hidden className="select-none opacity-60">
             {line.type === 'insert' ? '+' : line.type === 'delete' ? '-' : ' '}
           </span>
-          {line.content}
+          <LineText
+            content={line.content}
+            query={search?.query ?? null}
+            activeOccurrence={
+              number !== null &&
+              search?.active != null &&
+              search.active.side === side &&
+              search.active.line === number
+                ? search.active.occurrence
+                : null
+            }
+          />
         </span>
       </div>
 
@@ -1149,6 +1169,55 @@ function LineRow({
       )}
     </>
   )
+}
+
+/**
+ * One row's code, with the search hits picked out of it.
+ *
+ * The scan happens here, per rendered row, rather than being handed down from
+ * the search: only the rows actually on screen pay for it, and a file the
+ * reader never opened costs nothing. `matchOffsets` is the same function the
+ * counter walks, so what is marked and what is counted cannot drift.
+ */
+function LineText({
+  content,
+  query,
+  activeOccurrence
+}: {
+  content: string
+  query: string | null
+  /** Index of the hit *in this row* that the reader is being pointed at. */
+  activeOccurrence: number | null
+}) {
+  const offsets = query === null ? [] : matchOffsets(content, query)
+  if (query === null || offsets.length === 0) return <>{content}</>
+
+  const parts: ReactNode[] = []
+  let cursor = 0
+
+  for (const [index, offset] of offsets.entries()) {
+    if (offset > cursor) parts.push(content.slice(cursor, offset))
+    const end = offset + query.length
+    const isActive = index === activeOccurrence
+    parts.push(
+      <mark
+        key={offset}
+        id={isActive ? ACTIVE_MATCH_ID : undefined}
+        className={cn(
+          'rounded-[2px] text-inherit',
+          // The current hit is the one the page just scrolled to, so it has to
+          // be findable at a glance among the others on the same screen.
+          isActive ? 'bg-warning/60 shadow-[0_0_0_1px_var(--color-warning)]' : 'bg-warning/25'
+        )}
+      >
+        {content.slice(offset, end)}
+      </mark>
+    )
+    cursor = end
+  }
+
+  if (cursor < content.length) parts.push(content.slice(cursor))
+  return <>{parts}</>
 }
 
 function Gutter({ value }: { value: number | null }) {

--- a/src/renderer/src/features/reviews/dom-ids.ts
+++ b/src/renderer/src/features/reviews/dom-ids.ts
@@ -20,3 +20,14 @@ export function fileDomId(path: string): string {
 export function lineDomId(path: string, side: DiffSide, line: number): string {
   return `line-${encodeURIComponent(path)}-${side}-${line}`
 }
+
+/**
+ * The one search hit the reader is currently being pointed at.
+ *
+ * A fixed id rather than one per hit, because only ever one of them is current.
+ * The find bar scrolls to the mark rather than to the row holding it, so a hit
+ * sitting a long way along a long line is brought into view sideways as well -
+ * the code scrolls horizontally inside its own container, and a row scrolled to
+ * vertically can still be showing the wrong end of itself.
+ */
+export const ACTIVE_MATCH_ID = 'diff-find-active-match'

--- a/src/renderer/src/features/reviews/review-files-tab.tsx
+++ b/src/renderer/src/features/reviews/review-files-tab.tsx
@@ -16,11 +16,15 @@ import {
   ArrowDown,
   ArrowUp,
   CheckCheck,
+  ChevronDown,
+  ChevronUp,
   FileDiff,
   GitCompareArrows,
   PanelLeft,
   PanelLeftClose,
-  RefreshCw
+  RefreshCw,
+  Search,
+  X
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -34,6 +38,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton'
 import { api } from '@/lib/api'
 import { errorMessage } from '@/lib/errors'
+import { formatStep } from '@/lib/keys'
 import { plural } from '@/lib/format'
 import { useStoredFlag, useStoredPreference } from '@/lib/preferences'
 import { revealElement } from '@/lib/reveal'
@@ -42,6 +47,7 @@ import type { DiffFocus } from '@/lib/router'
 import { CommentThreadCard } from '../comments/comment-thread-card'
 import { useCommentMutations, useReviewComments } from '../comments/use-comments'
 import { ChangedFilesTree } from './changed-files-tree'
+import { DiffFindBar, useDiffFind } from './diff-find-bar'
 import { CompareErrorCard, NoWorktreeNotice, WorkingTreeBanner } from './compare-notices'
 import { fileDomId, lineDomId } from './dom-ids'
 import { DiffSnippet } from './diff-snippet'
@@ -280,8 +286,12 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
     return [...threadsByFile].filter(([path]) => !present.has(path))
   }, [data?.files, threadsByFile])
 
-  const paths = useMemo(() => (data?.files ?? []).map((file) => file.path), [data?.files])
+  // One array identity per diff, so the search below is not re-run against a
+  // freshly built list on every keystroke elsewhere on the screen.
+  const files = useMemo(() => data?.files ?? [], [data?.files])
+  const paths = useMemo(() => files.map((file) => file.path), [files])
   const activePath = useActiveFile(paths)
+  const find = useDiffFind(files)
 
   /**
    * The fingerprint of every file *as it is being shown*, which is what a
@@ -484,6 +494,54 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
           run: toggleCurrentReviewed
         },
         {
+          id: 'files:find',
+          label: 'Find in the diff',
+          group: 'Files changed',
+          keys: 'mod+f',
+          keywords: 'search text highlight grep locate',
+          icon: Search,
+          disabled: paths.length === 0,
+          run: find.show
+        },
+        // Only while the bar is up. The help sheet lists what works here, and
+        // "next match" with nothing being searched for is not one of them.
+        ...(find.open
+          ? [
+              {
+                id: 'files:find-next',
+                label: 'Next match',
+                group: 'Files changed',
+                keys: 'mod+g',
+                keywords: 'search find again forward',
+                icon: ChevronDown,
+                disabled: find.matches.length === 0,
+                run: () => find.step(1)
+              } satisfies Command,
+              {
+                id: 'files:find-previous',
+                label: 'Previous match',
+                group: 'Files changed',
+                keys: 'mod+shift+g',
+                keywords: 'search find again back',
+                icon: ChevronUp,
+                disabled: find.matches.length === 0,
+                run: () => find.step(-1)
+              } satisfies Command,
+              {
+                id: 'files:find-close',
+                label: 'Close the find bar',
+                group: 'Files changed',
+                keys: 'escape',
+                icon: X,
+                // Escape is answered by the field itself while it has the
+                // focus; this is for the reader who has clicked back into the
+                // diff and still expects it to put the search away.
+                hidden: true,
+                run: find.close
+              } satisfies Command
+            ]
+          : []),
+        {
           id: 'files:refresh',
           label: 'Refresh the diff',
           group: 'Files changed',
@@ -503,7 +561,8 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
         refresh,
         activePath,
         reviewedPaths,
-        toggleCurrentReviewed
+        toggleCurrentReviewed,
+        find
       ]
     )
   )
@@ -559,6 +618,19 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
             <Button
               variant="ghost"
               size="sm"
+              onClick={find.show}
+              title={`Find in the diff (${formatStep('mod+f')})`}
+              aria-expanded={find.open}
+            >
+              <Search />
+              Find
+            </Button>
+          )}
+
+          {data.files.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => setTreeOpen(!treeOpen)}
               title={treeOpen ? 'Hide the file list' : 'Show the file list'}
               aria-pressed={treeOpen}
@@ -608,6 +680,8 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
           </Button>
         </div>
       </div>
+
+      {find.open && <DiffFindBar find={find} />}
 
       {changes !== 'committed' && data.workingTree?.isDirty && (
         <WorkingTreeBanner workingTree={data.workingTree} />
@@ -744,6 +818,7 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
                   // Only the card that owns the line hears about it, so one
                   // arriving link cannot light up the same number in every file.
                   focus={focus?.filePath === file.path ? focus : undefined}
+                  search={find.searchFor(file.path)}
                   marked={marked?.filePath === file.path ? marked : undefined}
                   reviewed={{
                     isReviewed: reviewedPaths.has(file.path),

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -31,6 +31,8 @@
     "src/renderer/src/lib/fuzzy.ts",
     "src/renderer/src/lib/__tests__/keys.test.ts",
     "src/renderer/src/lib/__tests__/fuzzy.test.ts",
+    "src/renderer/src/features/reviews/diff-search.ts",
+    "src/renderer/src/features/reviews/__tests__/diff-search.test.ts",
     "electron.vite.config.ts",
     "vite.mcp.config.ts",
     "drizzle.config.ts",


### PR DESCRIPTION
Reading a diff is mostly looking for something, and the app is an Electron window — the browser's own find is not in it. This adds one.

`⌘F` (`Ctrl+F`) opens a bar over the diff. Hits are marked where they are, the counter reads `3 of 18 in 4 files`, and Enter / Shift+Enter walk them, scrolling each hit into the middle of the page. A hit inside a collapsed file opens that card for as long as it is the current one, so a count of twelve cannot be pointing at a file showing nothing. Esc closes the bar and clears the marks; there is a **Find** button in the toolbar for the mouse.

| Key | |
| --- | --- |
| `mod+f` | Find in the diff |
| `mod+g` / `mod+shift+g` | Next / previous match |
| `Enter` / `Shift+Enter` | Same, from inside the field |
| `Esc` | Close the bar |

They are declared as commands like every other shortcut here, so the palette and the `?` sheet list them without being told twice — and "next match" only exists while there is a search to have a next match in.

### What is where

- `diff-search.ts` — the matching, as a DOM-free module: `matchOffsets`, `findDiffMatches`, `rowPosition`. Tested like `lib/keys`.
- `diff-find-bar.tsx` — the bar and `useDiffFind`. Matching runs off a `useDeferredValue`, so typing does not stutter on a large diff.
- `diff-view.tsx` — `FileDiffCard` takes a `search` prop; rows render through a new `LineText` that marks their own hits with the same function the counter walks, so highlight and count cannot drift. `LineRow` now takes its side and number from `rowPosition`, which the search uses too.
- `review-files-tab.tsx`, `dom-ids.ts` — wiring, the commands, and the id of the current mark.

### Decisions worth arguing with

- **Context unfolded between hunks is highlighted but not counted**, and Enter does not stop on it. Text plainly on screen and left unmarked reads as a broken search; a count that changed with which gaps happen to be open would be worse.
- **Plain case-insensitive substring** — no regex, no case toggle.
- **File paths are not searched.** The tree and the palette's "Jump to file" already do that.
- **Hits stop at 1000** and the counter says `1000+`. A one-letter query against a large diff has no useful tail.

### Checks

`typecheck`, `lint`, `test` (204, 7 of them new) and `build` all pass. Driven in the real app over CDP as well: `⌘F`, typing, Enter, Shift+Enter, a query with no hits, a second `⌘F` replacing the first query, and Esc clearing every mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFtd6W3YpqbwbDySxfvwn