### PR TITLE
Record S3, S5 and S6 spike outcomes from the Mac

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -156,7 +156,29 @@ Record the outcome under each one.
   that builds them alongside a release, and confirmation that the
   Electron-binary-as-Node trick from `src/main/mcp-launch.ts` is *not* usable
   on a display-less box, so this is the only path.
-- **Outcome.** *(pending)*
+- **Outcome.** *Pass, 10 September 2026.* `scripts/spikes/s3-daemon-tarball.mjs`
+  builds `gitwarren-daemon-0.1.6-linux-{x64,arm64}.tar.gz`, 44 MB each with
+  gzip (xz would be about 28 MB but needs `xz` on the host; gzip is
+  everywhere). Contents: the official Node 24.20.0 binary, `server.cjs` from
+  `npm run build:mcp`, the one matching `better_sqlite3` prebuild — which
+  better-sqlite3 13 already ships in `node_modules/better-sqlite3/prebuilds/`
+  for both Linux arches, so nothing is compiled — the drizzle migrations, and
+  a `bin/gitwarren-mcp` launcher that sets `GITWARREN_MIGRATIONS_DIR`.
+
+  In a bare `ubuntu:24.04` container with no Node, arm64 natively and x64
+  under emulation on the Mac, `bin/gitwarren-mcp` answered an MCP
+  `initialize` and exited 0:
+
+  ```
+  [gitwarren-mcp] ready (database: /root/.config/GitWarren/gitwarren.db)
+  {"result":{"protocolVersion":"2025-06-18",…,"serverInfo":{"name":"gitwarren","version":"0.1.0"}},"jsonrpc":"2.0","id":1}
+  ```
+
+  So Node ran, the addon loaded, the database was created and migrated, and
+  the protocol answered. The daemon will run wherever this does. Two notes for
+  M2–M4: the Electron-binary-as-Node trick was not tried on Linux because the
+  tarball makes it moot; and the CI job is the same script per target,
+  attached to the release — not yet written.
 
 ### S4 — Editor deep links to remote files
 
@@ -210,7 +232,37 @@ Record the outcome under each one.
 - **Output.** A number per screen and the list of calls that could be one. Sets
   the coarse endpoints in M1. Target: opening a review costs at most three
   sequential round trips.
-- **Outcome.** *(pending)*
+- **Outcome.** *Target already met, 10 September 2026, macOS, the seeded demo
+  database (3 repositories, review 1 with 5 threads), driven over CDP.* Calls
+  per screen, with start offsets showing which ones wait on which:
+
+  | Screen | Calls | Sequential depth | Notes |
+  | --- | --- | --- | --- |
+  | Home, cold load | 3 | 1 | `repositories:list` (53 ms) plus two trivial `system`/`updates` reads |
+  | Review → conversation tab | 4 | 2 | `reviews:get`, `comments:list`, `reviews:commits` (93 ms), `reviews:diff` (105 ms); diff starts 29 ms after get |
+  | → commits tab | 0 | — | already fetched |
+  | → files tab | 3 | 1 | `reviewedFiles`, `system:editors`, `comments:list`; the diff is reused |
+  | Back to home | 2 | 1 | `repositories:list` again, as designed (nothing is cached) |
+  | Review files tab, cold load | 11 | 2 | `reviews:get`, `comments:list`, `system:editors` and `reviewedFiles` each fetched **twice** - a second wave 45 ms after the first, on the same keys |
+
+  The renderer is already coarse: the heavy calls are `commits` and `diff` at
+  ~100 ms each locally, and everything else is under 5 ms. A network carrier
+  adds one round trip per level of depth, so the two-deep review open costs
+  about 2 × RTT plus the git work, which is fine. What M1 should actually fix:
+
+  - the duplicated wave on a cold review load (same SWR keys fetched twice
+    within 45 ms - a remount or a key that is not stable across the first
+    render), which doubles the cost over a network for no benefit;
+  - `system:appInfo` and `system:editors` refetched on navigation, which are
+    static for the life of the process;
+  - fold `reviews:get` + `comments:list` + `reviewedFiles` into one
+    `reviews.open(id)`, taking the review open from depth 2 to depth 1; keep
+    `commits` and `diff` as their own calls, since they are heavy, independently
+    refreshed, and already run in parallel.
+
+  Not measured here: the 15-second comment poll, which over a network becomes
+  one request per open review per host every 15 s until M6 replaces it with
+  events.
 
 ### S6 — The fixed loopback port
 
@@ -218,7 +270,30 @@ Record the outcome under each one.
   on macOS, Windows and Ubuntu, and define behaviour when it is taken (the
   Agent Access panel warns; links are still emitted).
 - **Output.** One constant in `src/shared/` and a sentence for the README.
-- **Outcome.** *(pending)*
+- **Outcome.** *Port 41427.* Chosen
+  because it is outside every default ephemeral range (Windows and macOS use
+  49152–65535, Linux 32768–60999), absent from `/etc/services`, not on
+  Chromium's restricted-port list (which would make a browser refuse the
+  loopback link), and unclaimed by any well-known service. Free on this Mac
+  and on a default Ubuntu, which listens on nothing in that range.
+
+  Windows is the one to check: Hyper-V and WSL reserve blocks of ports at
+  boot, and the blocks move. On the PC, in PowerShell:
+
+  ```
+  netsh interface ipv4 show excludedportrange protocol=tcp
+  ```
+
+  Checked on the PC the same day: the exclusions there are 5357, 49680 and
+  eighteen blocks between 50000 and 63520, so 41427 is clear. **41427 it is.**
+  If a user's machine reserves it anyway, the plan is unchanged and the port
+  is simply a different number for them — see the runtime behaviour below.
+
+  Behaviour when the port is taken at runtime: the app still starts, links are
+  still emitted (they are the same on every machine, so a link printed on
+  another host must not depend on this one's luck), and the Agent Access
+  panel says which process holds the port. The constant lands in
+  `src/shared/` with M2, where the link server first uses it.
 
 ## Milestones
 

--- a/scripts/spikes/s3-daemon-tarball.mjs
+++ b/scripts/spikes/s3-daemon-tarball.mjs
@@ -1,0 +1,102 @@
+/**
+ * Spike S3 from docs/across-hosts.md: can a self-contained tarball run the
+ * GitWarren core on a Linux box with nothing installed?
+ *
+ * There is no daemon yet, so the payload is the MCP server - the same bundle,
+ * the same native addon, the same migrations the daemon will need. If this
+ * answers an MCP `initialize` over stdio in a bare container, the daemon will
+ * run there too.
+ *
+ * The tarball is: the official Node binary for the target, `server.cjs` from
+ * `npm run build:mcp`, the matching `better_sqlite3.node` prebuild that
+ * better-sqlite3 already ships in node_modules, the drizzle migrations, and a
+ * `gitwarren-mcp` launcher script. Nothing is compiled here.
+ *
+ *   npm run build:mcp
+ *   node scripts/spikes/s3-daemon-tarball.mjs linux-x64
+ *   node scripts/spikes/s3-daemon-tarball.mjs linux-arm64
+ *
+ * Then prove it in a container that has no Node (Docker calls x64 "amd64"):
+ *
+ *   INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"s3","version":"0"}}}'
+ *   printf '%s\n' "$INIT" | docker run --rm -i --platform linux/arm64 \
+ *     -v "$PWD/out/daemon-tarball:/t:ro" ubuntu:24.04 \
+ *     sh -c 'tar xzf /t/gitwarren-daemon-*-linux-arm64.tar.gz -C /opt && HOME=/root /opt/gitwarren-daemon/bin/gitwarren-mcp'
+ *
+ * Pass: a JSON `result` with `serverInfo.name` comes back and the container
+ * exits cleanly. That means Node ran, the addon loaded, the database was
+ * created and migrated, and the protocol answered.
+ */
+import { chmodSync, cpSync, createWriteStream, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { pipeline } from 'node:stream/promises'
+import { execFileSync } from 'node:child_process'
+import { join, resolve } from 'node:path'
+
+const target = process.argv[2]
+if (!/^linux-(x64|arm64)$/.test(target ?? '')) {
+  console.error('usage: node scripts/spikes/s3-daemon-tarball.mjs linux-x64|linux-arm64')
+  process.exit(2)
+}
+
+const root = resolve(import.meta.dirname, '..', '..')
+const version = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version
+// The Node version to embed. Pinned to the major the app is built against; the
+// exact release is whatever nodejs.org lists as current for that line.
+const nodeVersion = process.env.NODE_TARBALL_VERSION ?? 'v24.20.0'
+const server = join(root, 'out', 'mcp', 'server.cjs')
+if (!existsSync(server)) {
+  console.error('out/mcp/server.cjs is missing - run `npm run build:mcp` first')
+  process.exit(2)
+}
+
+const work = join(root, 'out', 'daemon-tarball', 'work', target)
+const stage = join(work, 'gitwarren-daemon')
+rmSync(work, { recursive: true, force: true })
+mkdirSync(join(stage, 'bin'), { recursive: true })
+mkdirSync(join(stage, 'lib'), { recursive: true })
+
+// 1. Node itself, from the official distribution. Cached across runs.
+const nodeArchive = join(root, 'out', 'daemon-tarball', `node-${nodeVersion}-${target}.tar.xz`)
+if (!existsSync(nodeArchive)) {
+  const url = `https://nodejs.org/dist/${nodeVersion}/node-${nodeVersion}-${target}.tar.xz`
+  console.log(`downloading ${url}`)
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`${url}: ${response.status}`)
+  await pipeline(response.body, createWriteStream(nodeArchive))
+}
+execFileSync('tar', ['xJf', nodeArchive, '-C', work, '--strip-components=2', `node-${nodeVersion}-${target}/bin/node`])
+cpSync(join(work, 'node'), join(stage, 'bin', 'node'))
+chmodSync(join(stage, 'bin', 'node'), 0o755)
+
+// 2. The bundle, the addon and the migrations.
+cpSync(server, join(stage, 'lib', 'server.cjs'))
+const prebuild = join(root, 'node_modules', 'better-sqlite3', 'prebuilds', `${target}.node`)
+if (!existsSync(prebuild)) throw new Error(`no better-sqlite3 prebuild for ${target} at ${prebuild}`)
+// server.cjs does `require('better-sqlite3')`, whose lib/binding.js looks for a
+// prebuild at prebuilds/<platform>-<arch>.node relative to the package, which
+// is exactly how it ships in node_modules - so the package is reproduced with
+// only the one prebuild that matters.
+const pkg = join(stage, 'lib', 'node_modules', 'better-sqlite3')
+mkdirSync(join(pkg, 'prebuilds'), { recursive: true })
+cpSync(prebuild, join(pkg, 'prebuilds', `${target}.node`))
+cpSync(join(root, 'node_modules', 'better-sqlite3', 'lib'), join(pkg, 'lib'), { recursive: true })
+cpSync(join(root, 'node_modules', 'better-sqlite3', 'package.json'), join(pkg, 'package.json'))
+cpSync(join(root, 'drizzle'), join(stage, 'drizzle'), { recursive: true })
+
+// 3. The launcher an agent config points at.
+writeFileSync(
+  join(stage, 'bin', 'gitwarren-mcp'),
+  '#!/bin/sh\n' +
+    'here="$(cd "$(dirname "$0")/.." && pwd)"\n' +
+    // Outside Electron there is no resourcesPath and no project root to walk
+    // up to, so the migrations folder is named explicitly.
+    'export GITWARREN_MIGRATIONS_DIR="$here/drizzle"\n' +
+    'exec "$here/bin/node" "$here/lib/server.cjs" "$@"\n'
+)
+chmodSync(join(stage, 'bin', 'gitwarren-mcp'), 0o755)
+
+// 4. Pack.
+const out = join(root, 'out', 'daemon-tarball', `gitwarren-daemon-${version}-${target}.tar.gz`)
+execFileSync('tar', ['czf', out, '-C', work, 'gitwarren-daemon'])
+const size = execFileSync('du', ['-h', out], { encoding: 'utf8' }).split('\t')[0]
+console.log(`${out} (${size})`)

--- a/scripts/spikes/s5-ipc-per-screen.mjs
+++ b/scripts/spikes/s5-ipc-per-screen.mjs
@@ -1,0 +1,63 @@
+/**
+ * Spike S5 from docs/across-hosts.md: how many IPC calls does each screen
+ * make, and how many of them wait on each other?
+ *
+ * Drives a running app through its screens over CDP and, after each one,
+ * prints the calls the main process logged since the last screen. The
+ * `at` offsets show which calls started together and which waited for an
+ * earlier one to finish - the sequential depth is what a network carrier
+ * multiplies by its round trip.
+ *
+ * Seed a scratch database first (scripts/make-demo-repos.sh and
+ * scripts/seed-demo.ts), then start the app with tracing on and stderr in a
+ * file:
+ *
+ *   GITWARREN_TRACE_IPC=1 GITWARREN_DATA_DIR=/tmp/gw-demo \
+ *     ./node_modules/.bin/electron . --remote-debugging-port=9222 2>/tmp/gw-ipc.log
+ *   node scripts/spikes/s5-ipc-per-screen.mjs /tmp/gw-ipc.log 1
+ *
+ * The second argument is the review to open. Re-run after M1 to confirm the
+ * duplicated cold-load wave is gone and the review opens at depth 1.
+ */
+import { readFileSync } from 'node:fs'
+import { Cdp, settle, wait } from '../cdp.mjs'
+
+const [log, reviewId = '1'] = process.argv.slice(2)
+if (!log) {
+  console.error('usage: node scripts/spikes/s5-ipc-per-screen.mjs <stderr log> [review id]')
+  process.exit(2)
+}
+const cdp = await Cdp.attach(9222)
+
+function calls() {
+  return readFileSync(log, 'utf8')
+    .split('\n')
+    .filter((line) => line.startsWith('[ipc]'))
+}
+
+async function screen(name, action) {
+  const before = calls().length
+  await action()
+  await settle(cdp)
+  // Long enough for every fetch a screen triggers, short enough to stay clear
+  // of the 15-second comment poll.
+  await wait(2500)
+  const made = calls().slice(before)
+  console.log(`\n## ${name}: ${made.length} calls`)
+  for (const call of made) console.log('  ' + call.replace('[ipc] ', ''))
+}
+
+const go = (hash) => () => cdp.evaluate(`location.hash = ${JSON.stringify(hash)}`)
+const reload = (hash) => async () => {
+  await go(hash)()
+  await cdp.evaluate('location.reload()')
+  await wait(1500)
+}
+
+await screen('home, cold load', reload('#/'))
+await screen(`review ${reviewId}, conversation tab`, go(`#/reviews/${reviewId}/conversation`))
+await screen(`review ${reviewId}, commits tab`, go(`#/reviews/${reviewId}/commits`))
+await screen(`review ${reviewId}, files tab`, go(`#/reviews/${reviewId}/files`))
+await screen('back to home', go('#/'))
+await screen(`review ${reviewId}, files tab, cold load`, reload(`#/reviews/${reviewId}/files`))
+process.exit(0)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -36,14 +36,18 @@ const TRACE_IPC = process.env.GITWARREN_TRACE_IPC === '1'
  */
 function handle<T>(channel: string, handler: (payload: unknown) => Promise<T> | T): void {
   ipcMain.handle(channel, async (_event, payload: unknown): Promise<IpcResult<T>> => {
-    // Set GITWARREN_TRACE_IPC=1 to see every call with its duration. The point
-    // is to count round trips per screen before the core moves behind a
-    // network carrier - see docs/across-hosts.md, spike S5 - where each one
-    // stops being free.
+    // Set GITWARREN_TRACE_IPC=1 to see every call with when it started and how
+    // long it took. The point is to count round trips per screen, and how many
+    // of them wait on each other, before the core moves behind a network
+    // carrier - see docs/across-hosts.md, spike S5 - where each one stops
+    // being free.
     const startedAt = TRACE_IPC ? performance.now() : 0
     try {
       const data = await handler(payload)
-      if (TRACE_IPC) console.error(`[ipc] ${channel} ${(performance.now() - startedAt).toFixed(1)}ms`)
+      if (TRACE_IPC) {
+        const duration = performance.now() - startedAt
+        console.error(`[ipc] ${channel} at ${startedAt.toFixed(0)}ms took ${duration.toFixed(1)}ms`)
+      }
       return { ok: true, data }
     } catch (error) {
       const appError = AppError.from(error)


### PR DESCRIPTION
## What

The Mac half of the spikes in `docs/across-hosts.md`, recorded under each spike's **Outcome** line. All three pass; no plan fallbacks are needed.

- **S3 — self-contained daemon tarball: pass.** `scripts/spikes/s3-daemon-tarball.mjs` builds `gitwarren-daemon-<version>-linux-{x64,arm64}.tar.gz` (44 MB each) from the official Node 24.20.0 binary, `out/mcp/server.cjs`, the matching `better_sqlite3` prebuild that better-sqlite3 13 already ships for both Linux arches, the drizzle migrations, and a `bin/gitwarren-mcp` launcher. In a bare `ubuntu:24.04` container with no Node, arm64 natively and x64 under emulation, the launcher answered an MCP `initialize` and exited 0 — Node ran, the addon loaded, the database migrated, the protocol answered.
- **S5 — calls per screen: target already met.** A review opens at sequential depth 2 (target ≤ 3). Heavy calls are `commits` and `diff` at ~100 ms locally; everything else under 5 ms. What M1 should actually fix: a duplicated fetch wave on a cold review load (four keys fetched twice within 45 ms) and static `system:*` reads refetched on navigation. Full table in the doc. The IPC trace now prints start offsets so depth can be read off the log; `scripts/spikes/s5-ipc-per-screen.mjs` drives the screens over CDP so the measurement is repeatable after M1.
- **S6 — loopback port: 41427.** Outside every default ephemeral range, absent from `/etc/services`, off Chromium's restricted-port list, free on the Mac and Ubuntu, and clear of the Hyper-V/WSL exclusion ranges on the PC (checked with `netsh interface ipv4 show excludedportrange`). Runtime behaviour when taken is written down; the constant lands with M2.

## How checked

`npm run lint`, `npm run typecheck`, `npm test` (240 passing). Container runs and CDP measurement outputs are quoted in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcLb1tHwBnAmExFWeJ9GeS
