### PR TITLE
M0 - Foundations: instance id, principals, host-scoped repositories

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -242,13 +242,25 @@ milestone assumes these.
   MCP-derived identity (`src/shared/actors.ts`, `src/mcp/identity.ts`).
 - **Repository identity.** `repositories.host_id` (nullable, null = this
   instance); `UNIQUE(path)` becomes `UNIQUE(host_id, path)`
-  (`src/core/db/schema.ts`, `npm run db:generate`).
+  (`src/core/db/schema.ts`, `npm run db:generate`). That index alone is not
+  enough: SQLite treats NULLs in a unique index as distinct from one another,
+  and NULL is how a local row is spelled, so `(NULL, '/work/app')` twice would
+  satisfy it and local repositories would silently lose the duplicate guard
+  they have today. A second, partial index — `UNIQUE(path) WHERE host_id IS
+  NULL` — is what keeps that guard, and the two together say what `UNIQUE(path)`
+  used to say, once per host.
 - **Routes with a host segment.** `src/shared/routes.ts` accepts
   `h/<instance>/review/4/…`; the segment is optional and omitted for local, so
   every existing link keeps working.
-- **Git hygiene.** `--` before user-supplied refs and paths at every `runGit`
-  call site in `src/core/git.ts` and `git-compare.ts`; refs validated with
+- **Git hygiene.** Refs and paths separated at every `runGit` call site in
+  `src/core/git.ts` and `git-compare.ts`; refs validated with
   `git check-ref-format`; worktree file reads confined to the worktree root.
+  Note which way round the `--` goes: for a command that takes a revision it
+  means "everything after this is a *path*", so `git rev-parse -- main` reads
+  the ref as a filename and answers the wrong question instead of failing. `--`
+  therefore goes before pathspecs only, and refs are validated instead —
+  suffixes like `HEAD~3` and `main^{commit}` peeled off first, so nothing that
+  works today starts being refused.
 
 **Verify:** existing test suite green; a pre-M0 database opens, shows the same
 reviews and comments, and new comments carry the local principal.

--- a/drizzle/0007_hosts_and_principals.sql
+++ b/drizzle/0007_hosts_and_principals.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `principals` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`kind` text NOT NULL,
+	`identifier` text NOT NULL,
+	`display_name` text NOT NULL,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `principals_identity_idx` ON `principals` (`kind`,`identifier`);--> statement-breakpoint
+DROP INDEX `repositories_path_unique`;--> statement-breakpoint
+ALTER TABLE `repositories` ADD `host_id` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `repositories_host_path_idx` ON `repositories` (`host_id`,`path`);--> statement-breakpoint
+CREATE UNIQUE INDEX `repositories_local_path_idx` ON `repositories` (`path`) WHERE "repositories"."host_id" is null;--> statement-breakpoint
+ALTER TABLE `comments` ADD `author_id` integer REFERENCES principals(id);

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,646 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "23340602-c612-4c96-97ac-111f749d7e6d",
+  "prevId": "74c8cfc7-984e-4c9a-a717-a5d1484e2556",
+  "tables": {
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_threads": {
+      "name": "comment_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_text": {
+          "name": "anchor_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_sha": {
+          "name": "anchor_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_snapshot": {
+          "name": "anchor_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "comment_threads_review_idx": {
+          "name": "comment_threads_review_idx",
+          "columns": [
+            "review_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "comment_threads_file_idx": {
+          "name": "comment_threads_file_idx",
+          "columns": [
+            "review_id",
+            "file_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_threads_review_id_reviews_id_fk": {
+          "name": "comment_threads_review_id_reviews_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_label": {
+          "name": "author_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_session": {
+          "name": "author_session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "comments_thread_idx": {
+          "name": "comments_thread_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_thread_id_comment_threads_id_fk": {
+          "name": "comments_thread_id_comment_threads_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comment_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_author_id_principals_id_fk": {
+          "name": "comments_author_id_principals_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "principals": {
+      "name": "principals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "principals_identity_idx": {
+          "name": "principals_identity_idx",
+          "columns": [
+            "kind",
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "repositories_name_idx": {
+          "name": "repositories_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repositories_host_path_idx": {
+          "name": "repositories_host_path_idx",
+          "columns": [
+            "host_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "repositories_local_path_idx": {
+          "name": "repositories_local_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true,
+          "where": "\"repositories\".\"host_id\" is null"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviewed_files": {
+      "name": "reviewed_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_digest": {
+          "name": "content_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "reviewed_files_path_idx": {
+          "name": "reviewed_files_path_idx",
+          "columns": [
+            "review_id",
+            "file_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reviewed_files_review_id_reviews_id_fk": {
+          "name": "reviewed_files_review_id_reviews_id_fk",
+          "tableFrom": "reviewed_files",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reviews_repository_idx": {
+          "name": "reviews_repository_idx",
+          "columns": [
+            "repository_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_repository_id_repositories_id_fk": {
+          "name": "reviews_repository_id_repositories_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1788784787308,
       "tag": "0006_reviewed_files",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1789030274674,
+      "tag": "0007_hosts_and_principals",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/__tests__/git-hygiene.test.ts
+++ b/src/core/__tests__/git-hygiene.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Refs are refs, and paths stay inside the checkout.
+ *
+ * Neither of these is a security boundary today - every caller of this app is
+ * its owner - and the tests are written accordingly: they check that a value
+ * which is not a ref is *refused* rather than handed to git, and that a path
+ * which addresses its way out of a worktree reads nothing. The point is that
+ * both hold before refs and paths start arriving over a carrier from another
+ * machine, which is when they stop being hygiene.
+ *
+ * The other half of the job is the one that is easy to forget: none of this may
+ * reject anything that works today. `HEAD~1`, `feature/x` and a raw sha are all
+ * things a user or an agent can legitimately have put in a review, and each has
+ * a case below.
+ */
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, test } from 'node:test'
+
+const workDir = mkdtempSync(join(tmpdir(), 'gitwarren-hygiene-'))
+
+const { resolveCompare, readReviewFile, readReviewImage, resolveReviewFilePath } = await import(
+  '../git-compare.js'
+)
+const { isValidRef, resetRefValidationCache } = await import('../git-refs.js')
+const { AppError } = await import('../../shared/errors.js')
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}
+
+let checkout: string
+let headSha: string
+
+before(() => {
+  checkout = join(workDir, 'project')
+  mkdirSync(checkout, { recursive: true })
+  git(checkout, 'init', '-b', 'main')
+  git(checkout, 'config', 'user.email', 'test@example.com')
+  git(checkout, 'config', 'user.name', 'Test')
+
+  writeFileSync(join(checkout, 'app.ts'), 'const a = 1\n')
+  git(checkout, 'add', '.')
+  git(checkout, 'commit', '-m', 'first')
+
+  writeFileSync(join(checkout, 'app.ts'), 'const a = 1\nconst b = 2\n')
+  git(checkout, 'commit', '-am', 'second')
+  headSha = git(checkout, 'rev-parse', 'HEAD')
+
+  git(checkout, 'branch', 'feature/x')
+
+  // A file the app has no business reading, one level above the checkout.
+  writeFileSync(join(workDir, 'secret.txt'), 'not part of any repository\n')
+})
+
+after(() => rmSync(workDir, { recursive: true, force: true }))
+
+// ---------------------------------------------------------------------------
+// What a ref may be
+// ---------------------------------------------------------------------------
+
+test('the refs people actually use are all accepted', async () => {
+  for (const ref of [
+    'main',
+    'HEAD',
+    'feature/x',
+    'HEAD~1',
+    'main^',
+    'main^2',
+    'HEAD~2^{commit}',
+    'main@{upstream}',
+    headSha,
+    headSha.slice(0, 8),
+    'refs/heads/main'
+  ]) {
+    assert.equal(await isValidRef(ref, checkout), true, ref)
+  }
+})
+
+test('a value that is not a ref name is refused', async () => {
+  for (const ref of [
+    '',
+    ' ',
+    '-oops',
+    '--upload-pack=touch /tmp/pwned',
+    'main..other',
+    'main~~..',
+    'a ref with spaces',
+    'refs/heads/main.lock',
+    'refs/heads/.hidden',
+    'has\ttab',
+    'has\u0000nul',
+    'has\nnewline',
+    '~1',
+    '^'
+  ]) {
+    assert.equal(await isValidRef(ref, checkout), false, JSON.stringify(ref))
+  }
+})
+
+test('the answer is cached, and clearing the cache does not change it', async () => {
+  assert.equal(await isValidRef('main', checkout), true)
+  assert.equal(await isValidRef('main', checkout), true)
+
+  resetRefValidationCache()
+  assert.equal(await isValidRef('main', checkout), true)
+  assert.equal(await isValidRef('-oops', checkout), false)
+})
+
+// ---------------------------------------------------------------------------
+// What that means for a review
+// ---------------------------------------------------------------------------
+
+test('a review on ordinary refs still resolves', async () => {
+  const compare = await resolveCompare(checkout, 'main', 'feature/x')
+
+  assert.equal(compare.error, null)
+  assert.equal(compare.base.sha, headSha)
+  assert.equal(compare.head.sha, headSha)
+})
+
+test('a relative revision still resolves, because it always did', async () => {
+  const compare = await resolveCompare(checkout, 'HEAD~1', 'main')
+
+  assert.equal(compare.base.error, null)
+  assert.equal(compare.base.sha, git(checkout, 'rev-parse', 'HEAD~1'))
+})
+
+test('an option pretending to be a ref is reported, not run', async () => {
+  const compare = await resolveCompare(checkout, '--upload-pack=touch /tmp/pwned', 'main')
+
+  assert.match(compare.base.error ?? '', /not a valid ref name/)
+  assert.equal(compare.base.sha, null)
+  // The other endpoint is unaffected: one bad ref does not poison the review.
+  assert.equal(compare.head.error, null)
+})
+
+test('a ref that no longer exists is still reported as missing, not as invalid', async () => {
+  // The distinction matters to a user: a deleted branch is a normal state and
+  // reads differently from a typo that was never a name at all.
+  const compare = await resolveCompare(checkout, 'main', 'branch-that-went-away')
+
+  assert.match(compare.head.error ?? '', /does not resolve to a commit/)
+})
+
+// ---------------------------------------------------------------------------
+// Where a file may come from
+// ---------------------------------------------------------------------------
+
+test('a file in the checkout reads normally', async () => {
+  const content = await readReviewFile(checkout, 'main', 'main', 'app.ts', { changes: 'all' })
+
+  assert.equal(content.error, null)
+  assert.deepEqual(content.lines, ['const a = 1', 'const b = 2'])
+})
+
+test('a path that climbs out of the worktree reads nothing', async () => {
+  for (const path of ['../secret.txt', '../../secret.txt', 'src/../../secret.txt']) {
+    const content = await readReviewFile(checkout, 'main', 'main', path, { changes: 'all' })
+    assert.equal(content.lines.length, 0, path)
+    assert.match(content.error ?? '', /not a path inside this repository/, path)
+  }
+})
+
+test('an absolute path is not a path inside the repository either', async () => {
+  const content = await readReviewFile(checkout, 'main', 'main', join(workDir, 'secret.txt'), {
+    changes: 'all'
+  })
+
+  assert.equal(content.lines.length, 0)
+  assert.match(content.error ?? '', /not a path inside this repository/)
+})
+
+test('the same rule applies to images', async () => {
+  const image = await readReviewImage(checkout, 'main', 'main', '../secret.png', 'head', {
+    changes: 'all'
+  })
+
+  assert.equal(image.dataUrl, null)
+  assert.match(image.error ?? '', /not a path inside this repository/)
+})
+
+test('and to the path handed to an editor', async () => {
+  await assert.rejects(
+    () => resolveReviewFilePath(checkout, 'main', 'main', '../secret.txt', { changes: 'all' }),
+    (error: unknown) => error instanceof AppError && error.code === 'INVALID_INPUT'
+  )
+})

--- a/src/core/__tests__/instance.test.ts
+++ b/src/core/__tests__/instance.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Coverage for the instance id.
+ *
+ * The id is about to be stamped on principals, repositories and links, so the
+ * property that matters is not that it exists but that it never changes: a new
+ * id after an upgrade or a crash would orphan every row that named the old one.
+ * Hence the tests below are all about persistence and about what happens when
+ * the file on disk is not what this code wrote.
+ */
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, test } from 'node:test'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-instance-'))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+const { getInstanceId, resetInstanceIdCache } = await import('../instance.js')
+const { getInstanceIdPath } = await import('../paths.js')
+const { isInstanceId } = await import('../../shared/instance-id.js')
+
+after(() => rmSync(dataDir, { recursive: true, force: true }))
+
+test('the id is a uuid, written to the data directory on first read', () => {
+  const id = getInstanceId()
+
+  assert.ok(isInstanceId(id), `${id} is not shaped like an instance id`)
+  assert.equal(readFileSync(getInstanceIdPath(), 'utf8').trim(), id)
+})
+
+test('it is the same on every call, and across processes', () => {
+  const first = getInstanceId()
+
+  // Same process, cache warm.
+  assert.equal(getInstanceId(), first)
+
+  // A fresh process is a cold cache reading the same file.
+  resetInstanceIdCache()
+  assert.equal(getInstanceId(), first)
+})
+
+test('a file that is not an instance id is replaced rather than trusted', () => {
+  writeFileSync(getInstanceIdPath(), 'not-a-uuid\n', 'utf8')
+  resetInstanceIdCache()
+
+  const id = getInstanceId()
+  assert.ok(isInstanceId(id))
+  assert.equal(readFileSync(getInstanceIdPath(), 'utf8').trim(), id)
+})
+
+test('trailing whitespace in the file is not part of the id', () => {
+  const id = getInstanceId()
+  writeFileSync(getInstanceIdPath(), `  ${id}  \n\n`, 'utf8')
+  resetInstanceIdCache()
+
+  assert.equal(getInstanceId(), id)
+})

--- a/src/core/__tests__/pre-m0-database.test.ts
+++ b/src/core/__tests__/pre-m0-database.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Opening a database that was written before M0 existed.
+ *
+ * This is the milestone's acceptance test, and it is deliberately not a unit
+ * test of the migration. M0 adds a table, two columns and a data step that no
+ * SQL file could contain, and the only claim worth checking is the one a user
+ * would make: their reviews and their comments are still there afterwards, they
+ * still say who wrote them, and what they write next is attributed to them.
+ *
+ * The "before" database is built by running the migrations *as they stood at
+ * 0006* rather than by committing a binary fixture. A fixture would be opaque -
+ * nobody reviews a .db file in a diff - and would rot silently; this way the
+ * starting point is the real schema history, and rebuilding it is one loop.
+ */
+import assert from 'node:assert/strict'
+import Database from 'better-sqlite3'
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, test } from 'node:test'
+
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
+
+/** The last migration that shipped before M0. */
+const LAST_PRE_M0_MIGRATION = 6
+
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-pre-m0-data-'))
+const migrationsDir = mkdtempSync(join(tmpdir(), 'gitwarren-pre-m0-migrations-'))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+const { getDatabasePath } = await import('../paths.js')
+const { getInstanceId } = await import('../instance.js')
+const { HUMAN_NAME, HUMAN_AUTHOR } = await import('../../shared/actors.js')
+
+/**
+ * A second connection on the same file, for asking the database what it holds
+ * without going through the code being tested.
+ */
+let raw: Database.Database
+
+after(() => {
+  raw?.close()
+  rmSync(dataDir, { recursive: true, force: true })
+  rmSync(migrationsDir, { recursive: true, force: true })
+})
+
+/**
+ * A copy of the migrations folder with everything after M0's predecessor cut
+ * out - the schema exactly as an installed 0.1.6 would have it.
+ */
+function buildPreM0Migrations(): void {
+  cpSync('drizzle', migrationsDir, { recursive: true })
+
+  const journalPath = join(migrationsDir, 'meta', '_journal.json')
+  const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as {
+    entries: { idx: number; tag: string }[]
+  }
+  const dropped = journal.entries.filter((entry) => entry.idx > LAST_PRE_M0_MIGRATION)
+  journal.entries = journal.entries.filter((entry) => entry.idx <= LAST_PRE_M0_MIGRATION)
+  writeFileSync(journalPath, JSON.stringify(journal, null, 2), 'utf8')
+
+  for (const entry of dropped) {
+    rmSync(join(migrationsDir, `${entry.tag}.sql`), { force: true })
+  }
+
+  assert.ok(dropped.length > 0, 'there is no post-0006 migration to test the upgrade of')
+}
+
+/** Rows a user would have had: one repository, one review, a discussion. */
+function seedPreM0Database(): void {
+  const sqlite = new Database(getDatabasePath())
+  sqlite.pragma('foreign_keys = ON')
+  migrate(drizzle(sqlite), { migrationsFolder: migrationsDir })
+
+  // The old schema has no `host_id` and no `author_id`, so naming the columns
+  // explicitly is both correct and a check that they really are absent.
+  sqlite
+    .prepare('INSERT INTO repositories (id, path, name) VALUES (?, ?, ?)')
+    .run(1, '/work/an-old-project', 'an-old-project')
+  sqlite
+    .prepare(
+      'INSERT INTO reviews (id, repository_id, title, base_ref, head_ref) VALUES (?, ?, ?, ?, ?)'
+    )
+    .run(1, 1, 'Something from before', 'main', 'feature')
+  sqlite.prepare('INSERT INTO comment_threads (id, review_id) VALUES (?, ?)').run(1, 1)
+
+  const insertComment = sqlite.prepare(
+    'INSERT INTO comments (id, thread_id, author_kind, author_name, author_label, author_session, body) VALUES (?, ?, ?, ?, ?, ?, ?)'
+  )
+  insertComment.run(1, 1, 'human', HUMAN_NAME, null, null, 'I wrote this before any of it existed.')
+  insertComment.run(2, 1, 'agent', 'Claude Code', 'auth-refactor', 'aaaa1111', 'And I replied.')
+
+  sqlite.close()
+}
+
+before(async () => {
+  buildPreM0Migrations()
+  seedPreM0Database()
+
+  // Opening through the app is what applies M0 and runs the data step.
+  const { getDatabase } = await import('../db/client.js')
+  getDatabase()
+  raw = new Database(getDatabasePath())
+})
+
+/**
+ * `rows[index]`, having first said that there is one.
+ *
+ * Index access is checked in this project, and a `?.` on every row read would
+ * bury what each test below is actually asserting under punctuation.
+ */
+function at<T>(rows: T[], index = 0): T {
+  const row = rows[index]
+  assert.ok(row !== undefined, `expected a row at index ${index}, got ${rows.length} rows`)
+  return row
+}
+
+function comments(): {
+  id: number
+  author_kind: string
+  author_name: string
+  author_session: string | null
+  author_id: number | null
+}[] {
+  return raw
+    .prepare(
+      'SELECT id, author_kind, author_name, author_session, author_id FROM comments ORDER BY id'
+    )
+    .all() as ReturnType<typeof comments>
+}
+
+function principals(): { id: number; kind: string; identifier: string; display_name: string }[] {
+  return raw
+    .prepare('SELECT id, kind, identifier, display_name FROM principals ORDER BY id')
+    .all() as ReturnType<typeof principals>
+}
+
+test('the old database opens, and the M0 schema arrives with it', () => {
+  const columns = (table: string): string[] =>
+    (raw.pragma(`table_info(${table})`) as { name: string }[]).map((row) => row.name)
+
+  assert.ok(columns('repositories').includes('host_id'))
+  assert.ok(columns('comments').includes('author_id'))
+  assert.ok(columns('principals').includes('identifier'))
+})
+
+test('the reviews and comments that were there are still there, unchanged', async () => {
+  const { repositoriesService } = await import('../services/repositories.js')
+  const { reviewsService } = await import('../services/reviews.js')
+  const { commentsService } = await import('../services/comments.js')
+
+  const tracked = await repositoriesService.list()
+  assert.equal(tracked.length, 1)
+  assert.equal(at(tracked).path, '/work/an-old-project')
+  assert.equal(at(tracked).name, 'an-old-project')
+
+  const reviews = await reviewsService.list({ repositoryId: 1 })
+  assert.equal(reviews.length, 1)
+  assert.equal(at(reviews).title, 'Something from before')
+
+  const threads = await commentsService.list({ reviewId: 1 })
+  assert.equal(threads.length, 1)
+  assert.deepEqual(
+    at(threads).comments.map((comment) => comment.body),
+    ['I wrote this before any of it existed.', 'And I replied.']
+  )
+})
+
+test('the repository is local, which is spelled as no host at all', () => {
+  const row = raw.prepare('SELECT host_id FROM repositories WHERE id = 1').get() as {
+    host_id: string | null
+  }
+  assert.equal(row.host_id, null)
+})
+
+test('the old human comment is adopted by the local principal', () => {
+  // Exactly one: this install's own. Opening the database twice must not mint
+  // a second, which is what the unique index over (kind, identifier) is for.
+  assert.equal(principals().length, 1)
+  const principal = at(principals())
+  assert.equal(principal.kind, 'local')
+  assert.equal(principal.identifier, getInstanceId())
+  assert.equal(principal.display_name, HUMAN_NAME)
+
+  const human = at(comments(), 0)
+  assert.equal(human.author_kind, 'human')
+  assert.equal(human.author_id, principal.id)
+
+  // The agent's comment keeps the identity it arrived with and gains no
+  // principal: a session is a process, not a person.
+  const agent = at(comments(), 1)
+  assert.equal(agent.author_kind, 'agent')
+  assert.equal(agent.author_name, 'Claude Code')
+  assert.equal(agent.author_session, 'aaaa1111')
+  assert.equal(agent.author_id, null)
+})
+
+test('a comment written now carries the local principal', async () => {
+  const { commentsService } = await import('../services/comments.js')
+
+  const thread = await commentsService.createThread(
+    { reviewId: 1, body: 'And this one is from after the upgrade.' },
+    HUMAN_AUTHOR
+  )
+
+  const written = raw
+    .prepare('SELECT author_id, author_kind FROM comments WHERE id = ?')
+    .get(at(thread.comments).id) as { author_id: number | null; author_kind: string }
+
+  assert.equal(written.author_kind, 'human')
+  assert.equal(written.author_id, at(principals()).id)
+})
+
+test('an agent writing now still carries no principal', async () => {
+  const { commentsService } = await import('../services/comments.js')
+
+  const comment = await commentsService.reply(
+    { threadId: 1, body: 'Noted.' },
+    { kind: 'agent', name: 'Codex', label: null, session: 'bbbb2222' }
+  )
+
+  const written = raw.prepare('SELECT author_id FROM comments WHERE id = ?').get(comment.id) as {
+    author_id: number | null
+  }
+  assert.equal(written.author_id, null)
+})
+
+test('reopening the database mints no second principal and rewrites nothing', async () => {
+  const { getDatabase, closeDatabase } = await import('../db/client.js')
+  const { resetInstanceIdCache } = await import('../instance.js')
+
+  const attributionBefore = comments().map((row) => [row.id, row.author_id])
+
+  closeDatabase()
+  resetInstanceIdCache()
+  getDatabase()
+
+  assert.equal(principals().length, 1)
+  assert.deepEqual(
+    comments().map((row) => [row.id, row.author_id]),
+    attributionBefore
+  )
+})

--- a/src/core/__tests__/repository-hosts.test.ts
+++ b/src/core/__tests__/repository-hosts.test.ts
@@ -1,0 +1,85 @@
+/**
+ * One repository per path, per host.
+ *
+ * `UNIQUE(path)` has always been the backstop that stops the same repository
+ * being tracked twice. M0 replaces it with a pair of indexes so that a path can
+ * repeat across hosts - the same string names different code inside a WSL
+ * distro than it does on the laptop - without local rows losing the guard they
+ * had. The pair is easy to get subtly wrong, because SQLite treats NULLs in a
+ * unique index as distinct from each other and NULL is exactly how a local row
+ * is spelled, so both halves are pinned here.
+ *
+ * The assertions go through a second connection opened on the same file rather
+ * than through the app's. What is being tested is the *database's* constraint,
+ * and asking the database directly is the only way to be sure it is the index
+ * answering rather than a check in a service.
+ */
+import assert from 'node:assert/strict'
+import Database from 'better-sqlite3'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, test } from 'node:test'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-hosts-'))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+const { getDatabase, closeDatabase } = await import('../db/client.js')
+const { getDatabasePath } = await import('../paths.js')
+
+let raw: Database.Database
+
+before(() => {
+  // Opening through the app first is what creates and migrates the file.
+  getDatabase()
+  raw = new Database(getDatabasePath())
+})
+
+after(() => {
+  raw.close()
+  closeDatabase()
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+function insert(hostId: string | null, path: string): void {
+  raw.prepare('INSERT INTO repositories (host_id, path, name) VALUES (?, ?, ?)').run(
+    hostId,
+    path,
+    path
+  )
+}
+
+function expectRejected(hostId: string | null, path: string): void {
+  assert.throws(
+    () => insert(hostId, path),
+    (error: { code?: string }) => String(error.code).startsWith('SQLITE_CONSTRAINT'),
+    `a second row for ${hostId ?? 'this host'}:${path} should have been refused`
+  )
+}
+
+test('a local path cannot be tracked twice', () => {
+  insert(null, '/work/app')
+  expectRejected(null, '/work/app')
+})
+
+test('the same path on another host is a different repository', () => {
+  insert('c0ffee00-0000-4000-8000-000000000001', '/work/app')
+  insert('c0ffee00-0000-4000-8000-000000000002', '/work/app')
+
+  const rows = raw
+    .prepare('SELECT host_id FROM repositories WHERE path = ? ORDER BY id')
+    .all('/work/app') as { host_id: string | null }[]
+
+  assert.deepEqual(
+    rows.map((row) => row.host_id),
+    [null, 'c0ffee00-0000-4000-8000-000000000001', 'c0ffee00-0000-4000-8000-000000000002']
+  )
+})
+
+test('nor can a path be tracked twice on the same remote host', () => {
+  expectRejected('c0ffee00-0000-4000-8000-000000000001', '/work/app')
+})
+
+test('a different path on a host that already has one is fine', () => {
+  insert('c0ffee00-0000-4000-8000-000000000001', '/work/other')
+})

--- a/src/core/db/client.ts
+++ b/src/core/db/client.ts
@@ -9,6 +9,7 @@ import { drizzle, type BetterSQLite3Database } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 import { ensureDataDirectory, getDatabasePath } from '../paths.js'
 import { resolveMigrationsFolder } from './migrations.js'
+import { ensureLocalPrincipal, resetLocalPrincipalCache } from './principals.js'
 import * as schema from './schema.js'
 
 export type AppDatabase = BetterSQLite3Database<typeof schema>
@@ -39,6 +40,11 @@ export function getDatabase(): AppDatabase {
 
   const db = drizzle(sqlite, { schema })
   migrate(db, { migrationsFolder: resolveMigrationsFolder() })
+  // Migrations move the schema; this moves the data that the new schema needs
+  // and that no SQL file could have known - see `db/principals.ts`. It runs
+  // before the connection is published so that no caller can observe a database
+  // that has the principals table but not this install's principal in it.
+  ensureLocalPrincipal(db)
 
   connection = sqlite
   instance = db
@@ -50,4 +56,5 @@ export function closeDatabase(): void {
   connection?.close()
   connection = null
   instance = null
+  resetLocalPrincipalCache()
 }

--- a/src/core/db/principals.ts
+++ b/src/core/db/principals.ts
@@ -1,0 +1,130 @@
+/**
+ * The local principal, and the one-time repair of the rows that predate it.
+ *
+ * Why this is not in the migration SQL: the local principal is identified by
+ * this install's instance id, which lives in a file in the data directory and
+ * is generated the first time anything asks for it. drizzle-kit writes its SQL
+ * at build time on a developer's machine and has no idea what that value will
+ * be. So the schema change ships as a migration and the *data* step runs here,
+ * on open, right after the migrations have been applied.
+ *
+ * Everything below therefore has to be safe to run on every open, in either
+ * process, in any order. It is idempotent twice over: the insert leans on the
+ * unique index over (kind, identifier) rather than on having looked first, and
+ * the backfill is guarded by a read that finds nothing on all but the very
+ * first open after the upgrade.
+ */
+import { and, eq, isNull } from 'drizzle-orm'
+import { comments, principals, type PrincipalRow } from './schema.js'
+import { getInstanceId } from '../instance.js'
+import { HUMAN_NAME } from '../../shared/actors.js'
+import type { AppDatabase } from './client.js'
+
+/** The authority behind "the person who owns this install". */
+export const LOCAL_PRINCIPAL_KIND = 'local' as const
+
+/**
+ * Resolved once per process by `ensureLocalPrincipal`, which the database
+ * client calls while opening. Cleared by `closeDatabase`, so a test that
+ * switches data directories does not carry the previous install's principal
+ * into the next one.
+ */
+let cached: PrincipalRow | null = null
+
+/**
+ * Seed the local principal and adopt the comments that were written before it
+ * existed.
+ *
+ * Takes the database as an argument rather than calling `getDatabase()`: this
+ * runs *during* the open, and reaching back into the client for a connection
+ * that has not been published yet would recurse.
+ */
+export function ensureLocalPrincipal(db: AppDatabase): PrincipalRow {
+  const identifier = getInstanceId()
+
+  const find = (): PrincipalRow | undefined =>
+    db
+      .select()
+      .from(principals)
+      .where(and(eq(principals.kind, LOCAL_PRINCIPAL_KIND), eq(principals.identifier, identifier)))
+      .get()
+
+  // Read first, so that every open after the first one is a single indexed
+  // lookup. This runs on the startup path of both processes, and taking a write
+  // transaction each time to insert a row that is already there would put them
+  // in each other's way for no reason at all.
+  let row = find()
+
+  if (!row) {
+    // `do nothing` rather than trusting the read above: on first launch the GUI
+    // and an agent's MCP server routinely open the database within milliseconds
+    // of each other, both find nothing, and both insert. The unique index over
+    // (kind, identifier) is the only thing that can arbitrate that correctly.
+    db.insert(principals)
+      .values({ kind: LOCAL_PRINCIPAL_KIND, identifier, displayName: HUMAN_NAME })
+      .onConflictDoNothing()
+      .run()
+    row = find()
+  }
+
+  // The row was either found or just written, so this is only reachable if
+  // something removed it in between. Nothing does, and a database whose
+  // principal vanished mid-open is not something to paper over.
+  if (!row) throw new Error('The local principal could not be created.')
+
+  adoptExistingHumanComments(db, row.id)
+
+  cached = row
+  return row
+}
+
+/**
+ * Point every human comment that has no principal at this install's.
+ *
+ * The claim being made is narrow and worth stating: on a machine that has been
+ * running GitWarren, the person who typed those comments is the person who owns
+ * this install, because a comment written from the app has never had any other
+ * possible author. That is what makes the backfill safe rather than a guess.
+ *
+ * Agent rows are deliberately untouched. Their identity is the MCP handshake
+ * they arrived on - a tool and a session, not a person - and inventing a
+ * principal for a process that has long since exited would make the column mean
+ * two different things.
+ */
+function adoptExistingHumanComments(db: AppDatabase, principalId: number): void {
+  // The guard exists so the common case - every open after the first - is a
+  // single indexed read rather than a write transaction over the whole table.
+  const orphan = db
+    .select({ id: comments.id })
+    .from(comments)
+    .where(and(eq(comments.authorKind, 'human'), isNull(comments.authorId)))
+    .limit(1)
+    .get()
+  if (!orphan) return
+
+  db.update(comments)
+    .set({ authorId: principalId })
+    .where(and(eq(comments.authorKind, 'human'), isNull(comments.authorId)))
+    .run()
+}
+
+/**
+ * The principal to stamp on anything the person at this keyboard writes.
+ *
+ * Cheap enough to call per comment: it is a cached row, resolved while the
+ * database was being opened.
+ */
+export function getLocalPrincipal(): PrincipalRow {
+  if (cached) return cached
+  // Unreachable through any normal path: every write goes through a service,
+  // and every service reaches the database through `getDatabase()`, which
+  // resolves this before it hands the connection out. Loud rather than lazily
+  // re-resolving, because a silent second resolution would mean the open did
+  // not happen and something else is wrong.
+  throw new Error('The database has not been opened, so there is no local principal yet.')
+}
+
+/** Called by `closeDatabase`. See the note on `cached`. */
+export function resetLocalPrincipalCache(): void {
+  cached = null
+}

--- a/src/core/db/schema.ts
+++ b/src/core/db/schema.ts
@@ -8,16 +8,77 @@
 import { sql } from 'drizzle-orm'
 import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
+/**
+ * A person, as opposed to a name printed next to a comment.
+ *
+ * GitWarren still has no accounts and no auth, and this table does not add
+ * either. What it adds is a *stable subject* for the one human in the system,
+ * which is the piece that stops working the moment there is more than one
+ * machine: "Human" is a fine label on one laptop and meaningless as soon as a
+ * review can be read from a second one, where the local user of *that* install
+ * is also called "Human".
+ *
+ * So a principal is identified by where the claim comes from rather than by
+ * what it is called. `kind` is the authority and `identifier` is what that
+ * authority says. For `local` the identifier is this install's instance id
+ * (`core/instance.ts`), which makes the local user of each install a distinct,
+ * durable subject. `tailscale` is the second authority, and the reason the
+ * shape is a pair rather than a plain string: Tailscale reports the same login
+ * on every device the user owns, so one principal spans their machines while
+ * the local ones stay per-install.
+ *
+ * `displayName` is still denormalised onto every comment row, exactly as
+ * before. This table is what those rows now *point at*, not a replacement for
+ * what they carry - see the note on `comments` below.
+ */
+export const principals = sqliteTable(
+  'principals',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    /**
+     * Which authority vouches for `identifier`. `local` is the owner of one
+     * install; `tailscale` arrives with the tailnet listener and carries a
+     * login that is the same on all of the user's devices.
+     */
+    kind: text('kind', { enum: ['local', 'tailscale'] }).notNull(),
+    /** Instance id for `local`, the login for `tailscale`. Never displayed. */
+    identifier: text('identifier').notNull(),
+    /** What to call them. "Human" for the local principal, as the UI always has. */
+    displayName: text('display_name').notNull(),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`)
+  },
+  // One row per (authority, subject). This is what makes seeding the local
+  // principal idempotent when the GUI and the MCP server open the database at
+  // the same moment.
+  (table) => [uniqueIndex('principals_identity_idx').on(table.kind, table.identifier)]
+)
+
+export type PrincipalRow = typeof principals.$inferSelect
+export type NewPrincipalRow = typeof principals.$inferInsert
+
 export const repositories = sqliteTable(
   'repositories',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     /**
-     * Canonical absolute path to the repository root. UNIQUE is the backstop
-     * that enforces "one row per repository"; the path is resolved through
-     * `git rev-parse --show-toplevel` + realpath before it ever gets here.
+     * The install that owns this repository, or NULL for this one.
+     *
+     * A host owns its repositories: SQLite, git and the MCP server for a repo
+     * all live on the machine the repo is on, and a row here for a repository
+     * on another host is a *reference* to it, never a copy. NULL rather than
+     * this install's own instance id, so that nothing has to be rewritten when
+     * a data directory is moved or restored onto a machine that mints a new id.
      */
-    path: text('path').notNull().unique(),
+    hostId: text('host_id'),
+    /**
+     * Canonical absolute path to the repository root, on its host. The path is
+     * resolved through `git rev-parse --show-toplevel` + realpath before it
+     * ever gets here; the unique indexes below are the backstop that enforces
+     * "one row per repository per host".
+     */
+    path: text('path').notNull(),
     name: text('name').notNull(),
     /** ISO-8601 UTC strings - readable in a SQLite browser, no timezone traps. */
     createdAt: text('created_at')
@@ -27,7 +88,26 @@ export const repositories = sqliteTable(
       .notNull()
       .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`)
   },
-  (table) => [index('repositories_name_idx').on(table.name)]
+  (table) => [
+    index('repositories_name_idx').on(table.name),
+    /**
+     * One row per path per host.
+     *
+     * This index alone is not enough, and the reason is a SQLite rule worth
+     * stating out loud: NULLs in a unique index are all distinct from one
+     * another, so `(NULL, '/work/app')` twice would satisfy it perfectly. Since
+     * NULL is precisely how a *local* repository is spelled, relying on this
+     * index by itself would quietly retire the duplicate guard that local
+     * repositories have always had.
+     */
+    uniqueIndex('repositories_host_path_idx').on(table.hostId, table.path),
+    /** Which is why local rows get their own index, where there is no NULL to
+     *  make two identical paths look different. Together the two say what
+     *  `UNIQUE(path)` used to say, once per host. */
+    uniqueIndex('repositories_local_path_idx')
+      .on(table.path)
+      .where(sql`${table.hostId} is null`)
+  ]
 )
 
 export type RepositoryRow = typeof repositories.$inferSelect
@@ -169,12 +249,18 @@ export type NewCommentThreadRow = typeof commentThreads.$inferInsert
 /**
  * One message in a thread.
  *
- * Authorship is denormalised onto every row on purpose. There is no users
- * table and there will not be one: GitWarren is a single-person app with no
- * auth, and an "author" here is not an account but a description of where a
- * message came from - the person at the keyboard, or a named agent process that
- * has since exited. Copying the label onto the row keeps that description true
- * forever, which a foreign key to a mutable identity would not.
+ * Authorship is denormalised onto every row on purpose. An "author" here is not
+ * an account but a description of where a message came from - the person at the
+ * keyboard, or a named agent process that has since exited. Copying the label
+ * onto the row keeps that description true forever, which a foreign key to a
+ * mutable identity would not.
+ *
+ * `authorId` does not change that; it adds the other half. The denormalised
+ * columns say what a comment *looked like* when it was written and must never
+ * be recomputed; the principal says *who* wrote it, so two humans' comments can
+ * be told apart once a review is readable from more than one machine. Agent
+ * rows have no principal and are not meant to: an agent session is a process,
+ * not a person, and its identity is the MCP handshake it arrived on.
  */
 export const comments = sqliteTable(
   'comments',
@@ -185,6 +271,21 @@ export const comments = sqliteTable(
       .references(() => commentThreads.id, { onDelete: 'cascade' }),
     /** 'human' for anything typed in the app, 'agent' for anything over MCP. */
     authorKind: text('author_kind', { enum: ['human', 'agent'] }).notNull(),
+    /**
+     * Which person wrote this, when a person did. NULL for every agent comment,
+     * and for a human comment written before principals existed that has not
+     * been backfilled yet (see `db/principals.ts`).
+     *
+     * No delete action, which in SQLite means the delete is *refused*: a
+     * principal who has written comments cannot be removed out from under them.
+     * That is the conservative reading of "a discussion outlives the code it
+     * was about" and, unlike `set null` or `cascade`, it is what SQLite's
+     * `ALTER TABLE ... ADD COLUMN` can actually express - anything else would
+     * mean rebuilding the comments table to add one nullable column, and the
+     * declaration here has to match the SQL that ships or the two quietly
+     * disagree forever.
+     */
+    authorId: integer('author_id').references(() => principals.id),
     /**
      * Display name. Always "Human" from the UI. For an agent this is derived
      * from the MCP `clientInfo` handshake rather than self-reported, so every

--- a/src/core/git-compare.ts
+++ b/src/core/git-compare.ts
@@ -28,8 +28,9 @@
  * while making a small change on top of a long branch.
  */
 import { readFile, stat } from 'node:fs/promises'
-import { join, resolve, sep } from 'node:path'
+import { resolve, sep } from 'node:path'
 import { canonicalise, isDirectory, runGit, runGitBinary, runGitRaw } from './git-exec.js'
+import { isValidRef } from './git-refs.js'
 import { buildUntrackedFileDiff, parseUnifiedDiff } from './diff-parser.js'
 import { AppError } from '../shared/errors.js'
 import { imageMediaType } from '../shared/git.js'
@@ -397,6 +398,20 @@ async function readUpstreamTracking(
 }
 
 async function resolveEndpoint(repositoryPath: string, ref: string): Promise<CompareEndpoint> {
+  // The gate every ref in this module goes through. Both writes and every read
+  // reach git through here, so one check covers a ref typed into the review
+  // form, one an agent passed to `create_review`, and one stored years ago -
+  // see `git-refs.ts` for why the check is a check rather than a `--`.
+  if (!(await isValidRef(ref, repositoryPath))) {
+    return {
+      ref,
+      sha: null,
+      shortSha: null,
+      upstream: null,
+      error: `\`${ref}\` is not a valid ref name.`
+    }
+  }
+
   // `^{commit}` makes an annotated tag resolve to the commit it points at, and
   // rejects refs that name a tree or a blob.
   const [result, upstream] = await Promise.all([
@@ -505,7 +520,12 @@ export async function readReviewCommits(
       `--max-count=${MAX_COMMITS + 1}`,
       '--no-color',
       `--format=${format}`,
-      `${compare.base.sha}..${compare.head.sha}`
+      `${compare.base.sha}..${compare.head.sha}`,
+      // The range is git's own output from `rev-parse`, so this separator is
+      // not protecting against these two shas. It says the argument list is
+      // finished, which stops a repository that happens to contain a file
+      // named like the range from making `log` ambiguous.
+      '--'
     ],
     repositoryPath
   )
@@ -673,14 +693,21 @@ export async function readReviewDiff(
  * `node_modules` stay out of the review the same way they stay out of a commit.
  */
 async function readUntrackedFiles(worktreePath: string): Promise<FileDiff[]> {
-  const listed = await runGitRaw(['ls-files', '--others', '--exclude-standard', '-z'], worktreePath)
+  const listed = await runGitRaw(
+    ['ls-files', '--others', '--exclude-standard', '-z', '--'],
+    worktreePath
+  )
   if (listed.code !== 0) return []
 
   const paths = listed.stdout.split('\0').filter((path) => path.length > 0)
 
   return Promise.all(
     paths.map(async (path) => {
-      const absolute = join(worktreePath, path)
+      const absolute = resolveInsideRoot(worktreePath, path)
+      // git listed it as untracked *in this worktree*, so it is inside it by
+      // construction and this is unreachable. Handled as "listed but not read",
+      // exactly like a file that vanished mid-scan, rather than trusted.
+      if (absolute === null) return buildUntrackedFileDiff(path, '', { isBinary: true })
       try {
         const info = await stat(absolute)
         if (!info.isFile() || info.size > MAX_UNTRACKED_BYTES) {
@@ -729,6 +756,34 @@ export function isSafeRelativePath(path: string): boolean {
 }
 
 /**
+ * Where a repository-relative path lands on disk, or null if it lands outside.
+ *
+ * The second half is the point. `isSafeRelativePath` is a check on the *string*
+ * and it runs first, but a string check is the wrong last line of defence for a
+ * filesystem read: it has to anticipate every way a path can be spelled, and
+ * platforms keep inventing more of them. This asks the path resolver instead,
+ * after normalisation, and takes its answer.
+ *
+ * Every read of a file from a worktree in this module goes through here, so
+ * "GitWarren reads files from inside the checkout it is reviewing" is a
+ * property of one function rather than a habit at four call sites.
+ *
+ * Note that symlinks are deliberately not resolved. A symlink committed to a
+ * repository is a file the repository has, and git shows it; following it to
+ * its target and then refusing to read it would make GitWarren less able to
+ * show a checkout than `cat` is. What is being prevented is a *path* that
+ * addresses its way out, which is the thing a caller can actually construct.
+ */
+function resolveInsideRoot(root: string, relativePath: string): string | null {
+  const base = resolve(root)
+  const absolute = resolve(base, relativePath)
+  // `resolve` collapses `..`, so this catches a traversal however it was
+  // spelled - and the equality case catches a path that names the root itself.
+  if (absolute === base || !absolute.startsWith(base + sep)) return null
+  return absolute
+}
+
+/**
  * The head-side text of one file in a review, whole.
  *
  * Sent in one go rather than a line range per click. A range API would mean a
@@ -757,8 +812,9 @@ export async function readReviewFile(
   const worktree =
     effectiveChanges(options.changes, compare) === 'committed' ? null : compare.headWorktree
 
-  if (worktree) {
-    const absolute = join(worktree.path, filePath)
+  const absolute = worktree === null ? null : resolveInsideRoot(worktree.path, filePath)
+
+  if (absolute !== null) {
     try {
       const info = await stat(absolute)
       if (!info.isFile()) throw new Error('not a file')
@@ -779,7 +835,10 @@ export async function readReviewFile(
 
   if (!compare.head.sha) return emptyContent(filePath, 'The head ref does not resolve to a commit.')
 
-  const result = await runGitRaw(['show', `${compare.head.sha}:${filePath}`], repositoryPath, {
+  // `<sha>:<path>` is one argument naming a blob, not a rev and a pathspec, so
+  // the trailing `--` is what tells `show` there are no pathspecs coming. The
+  // path itself has already been through `isSafeRelativePath` above.
+  const result = await runGitRaw(['show', `${compare.head.sha}:${filePath}`, '--'], repositoryPath, {
     maxBuffer: MAX_FILE_BYTES
   })
   if (result.code !== 0) {
@@ -862,8 +921,9 @@ export async function readReviewImage(
   // next to a diff that says it changed.
   const worktree = side === 'head' && changes !== 'committed' ? compare.headWorktree : null
 
-  if (worktree) {
-    const absolute = join(worktree.path, filePath)
+  const absolute = worktree === null ? null : resolveInsideRoot(worktree.path, filePath)
+
+  if (absolute !== null) {
     try {
       const info = await stat(absolute)
       if (!info.isFile()) throw new Error('not a file')
@@ -933,9 +993,8 @@ export async function resolveReviewFilePath(
   )
 
   for (const root of roots) {
-    const absolute = resolve(root, filePath)
-    // `resolve` collapses any traversal the check above somehow let through.
-    if (!absolute.startsWith(resolve(root) + sep)) continue
+    const absolute = resolveInsideRoot(root, filePath)
+    if (absolute === null) continue
     try {
       if ((await stat(absolute)).isFile()) return absolute
     } catch {

--- a/src/core/git-refs.ts
+++ b/src/core/git-refs.ts
@@ -1,0 +1,139 @@
+/**
+ * Checking that a ref is a ref before handing it to git.
+ *
+ * ## What this is for, and what it is not
+ *
+ * Every caller of this app is its owner, so this is not a security boundary and
+ * pretending otherwise would be dishonest. It is hygiene, and the thing it
+ * closes is argument confusion rather than injection: `execFile` is used
+ * everywhere and there is no shell, but git commands take revisions, options
+ * and pathspecs in the same argv, and a value that is none of the three can
+ * still make a command mean something its caller did not intend.
+ *
+ * The reason it lands now rather than later is that the refs stop being local
+ * in M4. A ref stored on this machine is one the user picked from their own
+ * branches; a ref that arrives over a carrier from another host has been
+ * through a network and a second install first. The rule is much easier to put
+ * in while every caller is still trustworthy than afterwards.
+ *
+ * ## Why not simply put `--` in front of it
+ *
+ * Because for the commands that take a revision, `--` does not mean "stop
+ * reading options". It means "everything after this is a *path*", which for
+ * `git rev-parse -- main` turns the ref into a filename and quietly produces
+ * the wrong answer instead of an error. `--` belongs before pathspecs, and
+ * `git-compare.ts` puts it there. Refs get this instead.
+ *
+ * ## Why `git check-ref-format`
+ *
+ * The rules for a valid ref name are long, exception-ridden and versioned with
+ * git (no `..`, no ASCII control characters, no `~^:?*[`, no component starting
+ * with a dot or ending in `.lock`, no trailing slash, and more). Reimplementing
+ * them here would mean maintaining a second, slightly wrong copy forever. git
+ * ships the check as a command precisely so that programs do not have to.
+ */
+import { runGit } from './git-exec.js'
+
+/**
+ * How long a ref may be. Matches the schema's ceiling; the point is only to
+ * keep something absurd out of an argv, not to enforce a git rule.
+ */
+const MAX_REF_LENGTH = 512
+
+/**
+ * The suffixes that turn a ref name into a revision.
+ *
+ * `HEAD~3`, `main^2`, `v1.0^{commit}`, `main@{yesterday}` are all things a user
+ * may legitimately have typed into a review, and none of them is a ref *name* -
+ * `check-ref-format` rejects every one. So the suffixes are peeled off and the
+ * name underneath is what gets checked. Order matters: the brace forms have to
+ * be tried before the bare `^` that starts them.
+ */
+const REVISION_SUFFIXES = [/\^\{[^{}]*\}$/, /@\{[^{}]*\}$/, /\^\d*$/, /~\d*$/]
+
+/**
+ * Answers cached for the life of the process.
+ *
+ * The check is pure syntax and does not depend on the repository, so one cache
+ * serves all of them. It exists because `resolveCompare` runs on every read of
+ * every review - opening one screen would otherwise pay for two extra `git`
+ * processes it does not need.
+ */
+const answers = new Map<string, boolean>()
+
+/** Bounded so a pathological caller cannot turn the cache into a leak. */
+const MAX_CACHED_ANSWERS = 1_000
+
+function stripRevisionSuffixes(ref: string): string {
+  let name = ref
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const suffix of REVISION_SUFFIXES) {
+      const stripped = name.replace(suffix, '')
+      if (stripped !== name) {
+        name = stripped
+        changed = true
+      }
+    }
+  }
+  return name
+}
+
+/**
+ * The cheap rejections, made without spawning anything.
+ *
+ * A leading `-` is the one that matters: it is the only value in this file that
+ * could be read as an option by a command that has already been given its
+ * arguments. The rest are things `check-ref-format` would reject anyway, caught
+ * here because a control character has no business reaching an argv at all.
+ */
+function isObviouslyNotARef(ref: string): boolean {
+  if (ref.length === 0 || ref.length > MAX_REF_LENGTH) return true
+  if (ref.startsWith('-')) return true
+  // C0 controls, space and DEL. A NUL in particular would truncate the argument
+  // rather than be refused by whatever reads it.
+  // eslint-disable-next-line no-control-regex
+  return /[\u0000-\u0020\u007f]/.test(ref)
+}
+
+/**
+ * Whether git would accept this as a way of naming a commit.
+ *
+ * Deliberately permissive about *revisions* and strict about *names*: the
+ * question being asked is "could a user plausibly have meant this", not "does
+ * it exist". Existence is asked separately, on every read, because branches get
+ * deleted while a review is open.
+ */
+export async function isValidRef(ref: string, cwd: string): Promise<boolean> {
+  const cached = answers.get(ref)
+  if (cached !== undefined) return cached
+
+  const answer = await computeIsValidRef(ref, cwd)
+
+  // Nothing clever about the eviction: the cache is a saved process spawn, and
+  // a rare miss after a flush costs one of them back.
+  if (answers.size >= MAX_CACHED_ANSWERS) answers.clear()
+  answers.set(ref, answer)
+  return answer
+}
+
+async function computeIsValidRef(ref: string, cwd: string): Promise<boolean> {
+  if (isObviouslyNotARef(ref)) return false
+
+  const name = stripRevisionSuffixes(ref)
+  // Everything peeled away: `^`, `~3` and friends name a commit relative to
+  // something, and there is nothing here for them to be relative to.
+  if (name.length === 0) return false
+  if (isObviouslyNotARef(name)) return false
+
+  // `--allow-onelevel` is what permits `main`, `HEAD` and a raw sha, none of
+  // which have a slash in them. Without it only `refs/heads/main` would pass.
+  const result = await runGit(['check-ref-format', '--allow-onelevel', name], cwd)
+  return result.code === 0
+}
+
+/** Drops the cache. For tests; nothing in the app needs to call it. */
+export function resetRefValidationCache(): void {
+  answers.clear()
+}

--- a/src/core/instance.ts
+++ b/src/core/instance.ts
@@ -1,0 +1,93 @@
+/**
+ * The name this install answers to.
+ *
+ * A GitWarren install is about to stop being the only one in the world. Once a
+ * GUI can talk to a daemon on another machine, three questions all need the
+ * same answer: which host does this repository live on, which install does a
+ * link point into, and which principal is "the local user" here. A UUID
+ * generated once into the data directory is that answer.
+ *
+ * Deliberately a file rather than a row in SQLite, and deliberately free of any
+ * `electron` import, for the same reason `paths.ts` is: the GUI, the MCP server
+ * and - from M2 - the daemon are separate processes that must agree, and one of
+ * them may need the id before, or without, opening the database.
+ *
+ * The id names the *install*, not the machine and not the person. Two copies of
+ * GitWarren pointed at two data directories on one laptop are two instances,
+ * which is what the rest of the system wants: a review lives in a database, and
+ * the database is what the id is attached to.
+ */
+import { randomUUID } from 'node:crypto'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { isInstanceId } from '../shared/instance-id.js'
+import { ensureDataDirectory, getInstanceIdPath } from './paths.js'
+
+/**
+ * Cached for the life of the process. The file is written once and never
+ * changes afterwards, so re-reading it per call would buy nothing at all.
+ */
+let cached: string | null = null
+
+function readExisting(): string | null {
+  try {
+    const contents = readFileSync(getInstanceIdPath(), 'utf8').trim()
+    // A value that is not shaped like a UUID came from something other than
+    // this code, and there is nothing in it worth preserving.
+    return isInstanceId(contents) ? contents : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Create the file, or lose the race and read the winner's value.
+ *
+ * `wx` is the load-bearing part. First launch commonly starts the GUI and an
+ * agent's MCP server within the same second, and a plain write would let both
+ * of them mint an id and the second clobber the first - after the first had
+ * already stamped it on a principal. An exclusive create makes exactly one of
+ * them the author and sends the other back to read what was written.
+ */
+function readOrCreate(): string {
+  const existing = readExisting()
+  if (existing) return existing
+
+  ensureDataDirectory()
+  const minted = randomUUID()
+  try {
+    writeFileSync(getInstanceIdPath(), `${minted}\n`, { encoding: 'utf8', flag: 'wx' })
+    return minted
+  } catch {
+    // Either someone else got there first, in which case their value is the
+    // right one, or the file is unwritable. A second read tells them apart.
+    const other = readExisting()
+    if (other) return other
+  }
+
+  // The file exists and holds something this code did not write. There is no id
+  // in it to preserve, so it is replaced - a plain write this time, since
+  // `wx` is what just refused and no other process is racing for a name that
+  // was never valid.
+  try {
+    writeFileSync(getInstanceIdPath(), `${minted}\n`, 'utf8')
+    return minted
+  } catch {
+    // Nothing writable at all. Carry on with an id that lives only as long as
+    // this process: an install that cannot write its own data directory has
+    // larger problems, and refusing to start over a name would be the wrong
+    // trade. Links minted now simply stop resolving when the process ends.
+    console.error('[instance] could not persist the instance id; using a temporary one')
+    return minted
+  }
+}
+
+/** This install's id. Generated on first call, then stable forever. */
+export function getInstanceId(): string {
+  if (cached === null) cached = readOrCreate()
+  return cached
+}
+
+/** Drops the cached value. For tests that switch data directories mid-run. */
+export function resetInstanceIdCache(): void {
+  cached = null
+}

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -15,6 +15,8 @@ import { mkdirSync } from 'node:fs'
 
 export const APP_DIR_NAME = 'GitWarren'
 export const DATABASE_FILE_NAME = 'gitwarren.db'
+/** Holds this install's instance id. See `core/instance.ts`. */
+export const INSTANCE_FILE_NAME = 'instance-id'
 
 /** Set to point the whole app at a throwaway directory. Used by the tests. */
 export const DATA_DIR_ENV_VAR = 'GITWARREN_DATA_DIR'
@@ -35,6 +37,15 @@ export function getDataDirectory(): string {
 
 export function getDatabasePath(): string {
   return join(getDataDirectory(), DATABASE_FILE_NAME)
+}
+
+/**
+ * Where this install's instance id is kept. Next to the database rather than
+ * inside it: the id names the install, and it has to be readable by a process
+ * that has not opened - or cannot open - SQLite.
+ */
+export function getInstanceIdPath(): string {
+  return join(getDataDirectory(), INSTANCE_FILE_NAME)
 }
 
 export function ensureDataDirectory(): string {

--- a/src/core/services/comments.ts
+++ b/src/core/services/comments.ts
@@ -14,6 +14,7 @@
  */
 import { asc, eq, inArray } from 'drizzle-orm'
 import { getDatabase } from '../db/client.js'
+import { getLocalPrincipal } from '../db/principals.js'
 import {
   commentThreads,
   comments,
@@ -75,6 +76,22 @@ export interface AnchoredCommentThread extends CommentThread {
 
 function nowIso(): string {
   return new Date().toISOString()
+}
+
+/**
+ * Which principal a write belongs to.
+ *
+ * Resolved here rather than carried on the `CommentAuthor`, and the reason is
+ * the same one that keeps the author out of the payload: the caller must not be
+ * able to choose it. A human comment reaching this service arrived by someone
+ * typing into this install, so the principal is this install's, and it is not
+ * something the IPC layer should have to remember to attach - `HUMAN_AUTHOR` is
+ * a constant and could not carry a row id anyway.
+ *
+ * Agents get no principal. See the note on the column in `db/schema.ts`.
+ */
+function principalIdFor(actor: CommentAuthor): number | null {
+  return actor.kind === 'human' ? getLocalPrincipal().id : null
 }
 
 /**
@@ -453,6 +470,7 @@ export const commentsService = {
           authorName: actor.name,
           authorLabel: actor.label,
           authorSession: actor.session,
+          authorId: principalIdFor(actor),
           body,
           createdAt: timestamp,
           updatedAt: timestamp
@@ -489,6 +507,7 @@ export const commentsService = {
           authorName: actor.name,
           authorLabel: actor.label,
           authorSession: actor.session,
+          authorId: principalIdFor(actor),
           body,
           createdAt: timestamp,
           updatedAt: timestamp

--- a/src/core/services/repositories.ts
+++ b/src/core/services/repositories.ts
@@ -8,7 +8,7 @@
  * bad write through that the other would have rejected. That is the whole
  * reason the module exists.
  */
-import { asc, eq } from 'drizzle-orm'
+import { and, asc, eq, isNull } from 'drizzle-orm'
 import { getDatabase } from '../db/client.js'
 import { repositories, type RepositoryRow } from '../db/schema.js'
 import { defaultNameForPath, readGitState, resolveRepositoryRoot } from '../git.js'
@@ -42,6 +42,24 @@ async function withGitState(row: RepositoryRow): Promise<RepositoryWithGitState>
 
 function nowIso(): string {
   return new Date().toISOString()
+}
+
+/**
+ * A repository already tracked at this path *on this host*.
+ *
+ * The host scope is the point of the predicate rather than a detail of it. A
+ * path is only unique within the machine it is on - `/home/xfor/app` on a
+ * laptop and the same string inside a WSL distro are two different repositories
+ * - so a bare path match would start refusing perfectly good additions the
+ * moment there is a second host to add one from. `host_id IS NULL` is how a
+ * local row is spelled; see the schema.
+ */
+function localRepositoryAt(path: string): RepositoryRow | undefined {
+  return getDatabase()
+    .select()
+    .from(repositories)
+    .where(and(isNull(repositories.hostId), eq(repositories.path, path)))
+    .get()
 }
 
 function requireRow(id: number): RepositoryRow {
@@ -98,7 +116,7 @@ export const repositoriesService = {
     const { path, name } = parse(addRepositoryInputSchema, input)
     const root = await resolveRepositoryRoot(path)
 
-    const existing = getDatabase().select().from(repositories).where(eq(repositories.path, root)).get()
+    const existing = localRepositoryAt(root)
     if (existing) {
       throw new AppError(
         'DUPLICATE_REPOSITORY',
@@ -137,7 +155,7 @@ export const repositoriesService = {
       // A new path goes through exactly the same validation as `add`.
       const root = await resolveRepositoryRoot(path)
       if (root !== current.path) {
-        const clash = getDatabase().select().from(repositories).where(eq(repositories.path, root)).get()
+        const clash = localRepositoryAt(root)
         if (clash && clash.id !== id) {
           throw new AppError(
             'DUPLICATE_REPOSITORY',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -14,6 +14,7 @@ import { repositoriesService } from '../core/services/repositories.js'
 import { reviewedFilesService } from '../core/services/reviewed-files.js'
 import { reviewsService } from '../core/services/reviews.js'
 import { getDataDirectory, getDatabasePath } from '../core/paths.js'
+import { getInstanceId } from '../core/instance.js'
 import { HUMAN_AUTHOR } from '../shared/actors.js'
 import { AppError } from '../shared/errors.js'
 import { parseWithSchema as parse } from '../shared/validation.js'
@@ -166,6 +167,7 @@ export function registerIpcHandlers(): void {
 
   handle(IPC_CHANNELS.systemAppInfo, (): AppInfo => ({
     version: app.getVersion(),
+    instanceId: getInstanceId(),
     platform: process.platform,
     packaged: app.isPackaged,
     dataDirectory: getDataDirectory(),

--- a/src/shared/__tests__/routes.test.ts
+++ b/src/shared/__tests__/routes.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Coverage for the route grammar, and for the host segment M0 adds to it.
+ *
+ * The claim being tested is not that the new segment works - it is that adding
+ * it changed nothing. Every link this app has ever written is a hash without a
+ * host in it, they are stored in nothing and can arrive from anywhere, and a
+ * grammar change that quietly reinterpreted one of them would be the worst
+ * possible outcome of a milestone whose whole promise is "no visible change".
+ * So the local cases come first and are pinned to exact strings.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { HOME, hrefFor, parseRoute, type Route } from '../routes.js'
+
+const HOST = 'a1b2c3d4-0000-4000-8000-00000000beef'
+
+// ---------------------------------------------------------------------------
+// Local routes, exactly as they were before the host segment existed
+// ---------------------------------------------------------------------------
+
+test('local hrefs are the same strings they always were', () => {
+  assert.equal(hrefFor({ name: 'repositories' }), '#/')
+  assert.equal(hrefFor({ name: 'repository', repositoryId: 3 }), '#/repositories/3')
+  assert.equal(hrefFor({ name: 'review', reviewId: 4, tab: 'files' }), '#/reviews/4/files')
+  assert.equal(
+    hrefFor({
+      name: 'review',
+      reviewId: 4,
+      tab: 'files',
+      focus: { filePath: 'src/main/index.ts', side: 'head', line: 94 }
+    }),
+    '#/reviews/4/files/src%2Fmain%2Findex.ts/head/94'
+  )
+})
+
+test('a local route carries no host key at all', () => {
+  // Not `host: undefined`: routes are compared for equality in the router and
+  // in tests, and a key that is present but empty is not the same object.
+  assert.deepEqual(parseRoute('#/reviews/4/files'), { name: 'review', reviewId: 4, tab: 'files' })
+  assert.deepEqual(parseRoute('#/'), HOME)
+  assert.deepEqual(parseRoute('#/repositories/3'), { name: 'repository', repositoryId: 3 })
+})
+
+test('the pre-M0 fallbacks still fall back', () => {
+  assert.deepEqual(parseRoute(''), HOME)
+  assert.deepEqual(parseRoute('#/nonsense'), HOME)
+  assert.deepEqual(parseRoute('#/repositories/0'), HOME)
+  assert.deepEqual(parseRoute('#/reviews/-2'), HOME)
+  assert.deepEqual(parseRoute('#/reviews/4/nonsense'), {
+    name: 'review',
+    reviewId: 4,
+    tab: 'conversation'
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The host segment
+// ---------------------------------------------------------------------------
+
+test('a host is written as one segment in front of the rest', () => {
+  assert.equal(hrefFor({ name: 'repositories', host: HOST }), `#/h/${HOST}/`)
+  assert.equal(
+    hrefFor({ name: 'repository', repositoryId: 3, host: HOST }),
+    `#/h/${HOST}/repositories/3`
+  )
+  assert.equal(
+    hrefFor({ name: 'review', reviewId: 4, tab: 'commits', host: HOST }),
+    `#/h/${HOST}/reviews/4/commits`
+  )
+})
+
+test('every route round-trips with and without a host', () => {
+  const routes: Route[] = [
+    { name: 'repositories' },
+    { name: 'repositories', host: HOST },
+    { name: 'repository', repositoryId: 12 },
+    { name: 'repository', repositoryId: 12, host: HOST },
+    { name: 'review', reviewId: 7, tab: 'conversation' },
+    { name: 'review', reviewId: 7, tab: 'files', host: HOST },
+    {
+      name: 'review',
+      reviewId: 7,
+      tab: 'files',
+      focus: { filePath: 'docs/Release Notes #2.md', side: 'base', line: 1 },
+      host: HOST
+    }
+  ]
+
+  for (const route of routes) {
+    assert.deepEqual(parseRoute(hrefFor(route)), route, hrefFor(route))
+  }
+})
+
+test('a file path with slashes survives the host segment', () => {
+  const route: Route = {
+    name: 'review',
+    reviewId: 7,
+    tab: 'files',
+    focus: { filePath: 'src/main/index.ts', side: 'head', line: 94 },
+    host: HOST
+  }
+
+  assert.equal(hrefFor(route), `#/h/${HOST}/reviews/7/files/src%2Fmain%2Findex.ts/head/94`)
+  assert.deepEqual(parseRoute(hrefFor(route)), route)
+})
+
+test('a host with nothing after it is that host, at home', () => {
+  assert.deepEqual(parseRoute(`#/h/${HOST}`), { name: 'repositories', host: HOST })
+  assert.deepEqual(parseRoute(`#/h/${HOST}/`), { name: 'repositories', host: HOST })
+})
+
+test('a known host with an unreadable location still lands on that host', () => {
+  // Losing the host here would silently send the user to the wrong machine.
+  assert.deepEqual(parseRoute(`#/h/${HOST}/nonsense`), { name: 'repositories', host: HOST })
+  assert.deepEqual(parseRoute(`#/h/${HOST}/reviews/0`), { name: 'repositories', host: HOST })
+})
+
+test('anything that is not an instance id is not a host', () => {
+  for (const candidate of [
+    'h/not-a-uuid/reviews/4',
+    'h//reviews/4',
+    'h/../reviews/4',
+    'h/A1B2C3D4-0000-4000-8000-00000000BEEF/reviews/4', // uppercase; ids are lowercase
+    `h/${HOST}x/reviews/4`
+  ]) {
+    assert.deepEqual(parseRoute(`#/${candidate}`), HOME, candidate)
+  }
+})
+
+test('a repository id that is really a host segment is not confused for one', () => {
+  // `repositories/h` was always nonsense and still is.
+  assert.deepEqual(parseRoute('#/repositories/h'), HOME)
+  // And a review on the local install whose *file* is called `h` is untouched.
+  assert.deepEqual(parseRoute('#/reviews/4/files/h/head/2'), {
+    name: 'review',
+    reviewId: 4,
+    tab: 'files',
+    focus: { filePath: 'h', side: 'head', line: 2 }
+  })
+})

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -111,6 +111,12 @@ export interface AttachmentIngestInput {
 
 export interface AppInfo {
   version: string
+  /**
+   * This install's id - see `core/instance.ts`. Stable for the life of the data
+   * directory, and how a host, a link or a principal names this GitWarren once
+   * there is more than one of them to tell apart.
+   */
+  instanceId: string
   /** `process.platform`: 'darwin' | 'win32' | 'linux' in practice. Typed as a
    *  plain string because this module is also compiled for the renderer, which
    *  has no Node type definitions. */

--- a/src/shared/instance-id.ts
+++ b/src/shared/instance-id.ts
@@ -1,0 +1,26 @@
+/**
+ * What an instance id looks like, on its own.
+ *
+ * Split from `core/instance.ts`, which mints and stores one, because two places
+ * that cannot import it need to recognise one: the route grammar in
+ * `shared/routes.ts`, which is compiled for the renderer, and anything else
+ * validating a host segment that arrived from outside.
+ *
+ * Nothing here touches a global or a node module, for the same reason
+ * `routes.ts` does not.
+ */
+
+/**
+ * A lowercase hex UUID, which is what `core/instance.ts` writes.
+ *
+ * Kept narrow on purpose. A host segment in a link is a string someone else
+ * chose - an agent's comment body, a URL in a chat window - and the parser that
+ * reads it should accept the one shape this app produces rather than any
+ * plausible-looking identifier.
+ */
+export const INSTANCE_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+export function isInstanceId(value: string): boolean {
+  return INSTANCE_ID_PATTERN.test(value)
+}

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -10,6 +10,7 @@
  * Nothing here touches a global. It is compiled for the renderer *and* for the
  * node-side processes, so it may use only what both of them have.
  */
+import { isInstanceId } from './instance-id.js'
 
 export const REVIEW_TABS = ['conversation', 'commits', 'files'] as const
 export type ReviewTab = (typeof REVIEW_TABS)[number]
@@ -29,24 +30,62 @@ export interface DiffFocus {
   line: number
 }
 
+/**
+ * Which install a location is on.
+ *
+ * Every route may name a host, and every route omits it when the location is on
+ * the GitWarren doing the reading. That asymmetry is deliberate and is what
+ * keeps this change invisible: a link written before hosts existed, or written
+ * today for a local review, is byte-for-byte the link it always was.
+ *
+ * The value is an instance id (`core/instance.ts`), not a hostname. Machines
+ * are renamed, move between networks and are reached over four different
+ * carriers; the id is the one name that survives all of it, and it is what the
+ * `hosts` table will resolve to a way of connecting.
+ *
+ * Ids stay per-host autoincrement integers rather than becoming globally unique
+ * - a review is "4 on host X" everywhere, in routes, links and cache keys - so
+ * a review id without a host is meaningless anywhere but locally. That is
+ * precisely why the segment goes in now, before any link that needs it exists.
+ */
+export interface HostScoped {
+  /** Instance id of the install this location is on. Absent means the local one. */
+  host?: string
+}
+
 export type Route =
-  | { name: 'repositories' }
-  | { name: 'repository'; repositoryId: number }
-  | { name: 'review'; reviewId: number; tab: ReviewTab; focus?: DiffFocus }
+  | ({ name: 'repositories' } & HostScoped)
+  | ({ name: 'repository'; repositoryId: number } & HostScoped)
+  | ({ name: 'review'; reviewId: number; tab: ReviewTab; focus?: DiffFocus } & HostScoped)
 
 /** The review screen - the only route anything links *into* from outside. */
 export type ReviewRoute = Extract<Route, { name: 'review' }>
 
 export const HOME: Route = { name: 'repositories' }
 
+/** The segment that introduces a host. Short because it prefixes every link. */
+const HOST_SEGMENT = 'h'
+
+/**
+ * `#/h/<instance>`, or nothing at all for a local route.
+ *
+ * The empty string in the local case is what makes the grammar backwards
+ * compatible: `hrefFor` builds the same strings it always did unless someone
+ * has explicitly asked for a location on another install.
+ */
+function hostPrefix(route: HostScoped): string {
+  return route.host === undefined ? '' : `${HOST_SEGMENT}/${route.host}/`
+}
+
 export function hrefFor(route: Route): string {
+  const prefix = hostPrefix(route)
   switch (route.name) {
     case 'repositories':
-      return '#/'
+      return `#/${prefix}`
     case 'repository':
-      return `#/repositories/${route.repositoryId}`
+      return `#/${prefix}repositories/${route.repositoryId}`
     case 'review': {
-      const base = `#/reviews/${route.reviewId}/${route.tab}`
+      const base = `#/${prefix}reviews/${route.reviewId}/${route.tab}`
       if (!route.focus) return base
       // The path is encoded whole, slashes included, so it stays one segment.
       const { filePath, side, line } = route.focus
@@ -76,14 +115,40 @@ function parseFocus(segments: string[]): DiffFocus | undefined {
   }
 }
 
+/**
+ * Take a leading `h/<instance>` off the front, if there is one.
+ *
+ * A host segment that is not an instance id is not a host segment. Rejecting it
+ * rather than passing the string through is the same rule the rest of this
+ * parser follows: a hash is hostile input - it can arrive from a deep link an
+ * agent wrote into a comment - and nothing here may produce a location the app
+ * cannot already express. An unrecognised prefix simply is not stripped, and
+ * the route falls through to the home screen below.
+ */
+function takeHost(segments: string[]): { host?: string; rest: string[] } {
+  if (segments[0] !== HOST_SEGMENT) return { rest: segments }
+  const candidate = segments[1]
+  if (candidate === undefined || !isInstanceId(candidate)) return { rest: segments }
+  return { host: candidate, rest: segments.slice(2) }
+}
+
 export function parseRoute(hash: string): Route {
-  const segments = hash.replace(/^#\/?/, '').split('/').filter(Boolean)
-  if (segments.length === 0) return HOME
+  const all = hash.replace(/^#\/?/, '').split('/').filter(Boolean)
+  const { host, rest: segments } = takeHost(all)
+
+  // Spread rather than assign, so a local route has no `host` key at all rather
+  // than one set to undefined. The difference is invisible to a reader and very
+  // visible to anything comparing two routes for equality.
+  const scope = host === undefined ? {} : { host }
+
+  // A host with nothing after it is that host's repository list, which is a
+  // real location and the right place for a truncated link to land.
+  if (segments.length === 0) return host === undefined ? HOME : { name: 'repositories', host }
 
   if (segments[0] === 'repositories' && segments[1]) {
     const repositoryId = Number(segments[1])
     if (Number.isInteger(repositoryId) && repositoryId > 0)
-      return { name: 'repository', repositoryId }
+      return { name: 'repository', repositoryId, ...scope }
   }
 
   if (segments[0] === 'reviews' && segments[1]) {
@@ -93,9 +158,13 @@ export function parseRoute(hash: string): Route {
       // still perfectly viewable without one.
       const tab = isReviewTab(segments[2]) ? segments[2] : 'conversation'
       const focus = parseFocus(segments.slice(3))
-      return focus ? { name: 'review', reviewId, tab, focus } : { name: 'review', reviewId, tab }
+      return focus
+        ? { name: 'review', reviewId, tab, focus, ...scope }
+        : { name: 'review', reviewId, tab, ...scope }
     }
   }
 
-  return HOME
+  // Unrecognised, but the host - if there was a valid one - is still known, and
+  // dropping it would send the user to the wrong machine's home screen.
+  return host === undefined ? HOME : { name: 'repositories', host }
 }


### PR DESCRIPTION
Milestone M0 from `docs/across-hosts.md`. One PR, no visible change, in the order the plan sets out.

## Instance id

A UUID written once into the data directory and read by the GUI (through `AppInfo`), the MCP server (through the principal) and, from M2, the daemon. Created with an exclusive-create write: first launch routinely starts the GUI and an agent's MCP server within the same second, and a plain write would let both mint an id and the second clobber the first, after the first had already stamped it on a principal.

## Principals

A person, as opposed to a name printed next to a comment. Identified by a pair rather than a string: `local` with this install's instance id today, `tailscale` with a login at M6. That shape is what lets one principal span a user's devices while the local ones stay per-install.

`comments.author_id` points at it for human comments. Agent rows keep the MCP handshake as their identity and get no principal, because a session is a process and not a person.

Existing `"Human"` rows are adopted on first open after the upgrade. That is a runtime step rather than SQL, since drizzle writes its migrations at build time and cannot know what the instance id will be. It is guarded by a read, so every open after the first does no write.

## Repository identity

`repositories.host_id`, null meaning this install, and `UNIQUE(host_id, path)` in place of `UNIQUE(path)`.

That index alone would have quietly retired the local duplicate guard. SQLite treats NULLs in a unique index as distinct from one another, and NULL is exactly how a local row is spelled, so `(NULL, '/work/app')` twice would have satisfied it. A partial `UNIQUE(path) WHERE host_id IS NULL` sits alongside it; the two together say what `UNIQUE(path)` used to say, once per host. Noted in the plan doc.

The service's duplicate check is scoped to local rows for the same reason: a path is only unique within the machine it is on.

## Routes

An optional `h/<instance>` segment in front of any location, omitted for local. Every link the app has ever written parses and serialises byte-identically, which the new tests pin to exact strings. A host segment that is not an instance id is not treated as one; a valid host with an unreadable location lands on that host's home screen rather than the local one.

## Git hygiene

The `--` goes the other way round from how the plan's shorthand reads, and the doc now says so. For a command that takes a revision, `--` means "everything after this is a path", so `git rev-parse -- main` reads the ref as a filename and answers the wrong question instead of failing. So `--` goes before pathspecs only, and refs are validated instead.

Validation is `git check-ref-format --allow-onelevel`, memoised per process, with revision suffixes peeled off first so `HEAD~3`, `main^2` and `v1.0^{commit}` keep working. It hooks into endpoint resolution, which every read and both writes already pass through, so one check covers a ref typed into the form, one an agent passed to `create_review`, and one stored years ago.

Worktree file reads are confined to the worktree root by one function rather than by a habit at four call sites. Symlinks are deliberately not resolved: a symlink committed to a repository is a file the repository has.

## Verification

`npm run lint`, `npm run typecheck` and `npm test` all pass. 277 tests, up from 240.

The acceptance test from the plan is `src/core/__tests__/pre-m0-database.test.ts`. It builds a pre-M0 database by running the migrations as they stood at 0006, seeds a repository, a review and a discussion with raw SQL against that old schema, then opens it through the app and checks that the reviews and comments are unchanged, that the old human comment is adopted while the agent's is not, that a comment written afterwards carries the local principal, and that reopening mints no second principal. It is built from the real schema history rather than a committed `.db` file, so nobody has to review a binary in a diff and it cannot rot silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fr5S9ChVbxYgNyH2wkcDo
