### PR TITLE
M1 - One protocol

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -243,7 +243,7 @@ Record the outcome under each one.
   | → commits tab | 0 | — | already fetched |
   | → files tab | 3 | 1 | `reviewedFiles`, `system:editors`, `comments:list`; the diff is reused |
   | Back to home | 2 | 1 | `repositories:list` again, as designed (nothing is cached) |
-  | Review files tab, cold load | 11 | 2 | `reviews:get`, `comments:list`, `system:editors` and `reviewedFiles` each fetched **twice** - a second wave 45 ms after the first, on the same keys |
+  | Review files tab, cold load | 11 | 2 | `reviews:get`, `comments:list`, `system:editors` and `reviewedFiles` each fetched **twice** - a second wave 45 ms after the first, on the same keys. *The doubling was the spike script; see the amendment below.* |
 
   The renderer is already coarse: the heavy calls are `commits` and `diff` at
   ~100 ms each locally, and everything else is under 5 ms. A network carrier
@@ -263,6 +263,19 @@ Record the outcome under each one.
   Not measured here: the 15-second comment poll, which over a network becomes
   one request per open review per host every 15 s until M6 replaces it with
   events.
+
+  **Amended during M1.** The first of those three findings was not the app. The
+  spike script set the location hash and *then* reloaded, so the screen mounted
+  twice - once on the hashchange, once on the new document - and every key was
+  fetched twice about 40 ms apart. That is the "duplicated wave", and it is a
+  measurement of the navigation helper. Re-measured against the pre-M1 build
+  with the helper fixed (it now navigates for real, so a cold load is one
+  document and one mount), the cold review load is seven calls with nothing
+  duplicated. The other two findings were real and are confirmed in the M1
+  numbers below: `system:appInfo` was re-read on every return to the home
+  screen, `system:editors` on every visit to the files tab, and the review open
+  was two deep. Worth keeping in mind for the spikes still to come: a number
+  produced by driving the app is a number about the driver too.
 
 ### S6 — The fixed loopback port
 
@@ -366,6 +379,60 @@ process. This is the load-bearing refactor; every carrier after it is small.
 
 **Verify:** S5's counts re-measured; a review opens in at most three sequential
 round trips. UI checked over CDP with a scratch data dir.
+
+- **Outcome.** *Done, 10 September 2026, macOS, the same seeded demo database
+  S5 used (3 repositories, review 1 with 5 threads), both sides built with
+  `npm run build` and driven over CDP by
+  `scripts/spikes/s5-ipc-per-screen.mjs`.* Before is the merge of M0; after is
+  this milestone. Calls include the Electron-only ones -
+  `system`, `updates` - because the renderer pays a round trip for those too,
+  and a count that left them out would flatter itself.
+
+  | Screen | Calls before | Calls after | Depth before | Depth after |
+  | --- | --- | --- | --- | --- |
+  | Home, cold load | 3 | 3 | 1 | 1 |
+  | Review → conversation tab | 4 | **3** | **2** | **1** |
+  | → commits tab | 0 | 0 | — | — |
+  | → files tab | 3 | 2 | 1 | 1 |
+  | Back to home | 2 | **1** | 1 | 1 |
+  | Review files tab, cold load | 7 | **5** | **2** | **1** |
+
+  Opening a review is now three calls that start together - `reviews.open`,
+  `reviews.commits`, `reviews.diff`, all within 6 ms of each other - so it is
+  one round trip, not the three the target allowed. Two changes got it there.
+  `reviews.open` folds `reviews:get`, `comments:list` and `reviewedFiles` into
+  one answer, and the three hooks that used to hold three cache keys now share
+  the one it lands under, so however many of them mount at once, SWR issues a
+  single request. And the diff is asked for by the review screen at mount
+  rather than by whichever tab is showing: it used to wait for the review to
+  come back before the tab existed to ask for it, which is exactly the wait a
+  network multiplies.
+
+  The static reads, measured on their own by walking home → files → home →
+  files → home inside one document, after the first paint:
+
+  | | Before | After |
+  | --- | --- | --- |
+  | Calls over four navigations | 14 | 7 |
+  | of which `system:appInfo` | 2 | 0 |
+  | of which `system:editors` | 2 | 1 |
+
+  Both are memoised in `renderer/src/lib/api.ts` for the life of the window -
+  the promise, not the value, so two callers racing on the first render still
+  share one call. Once per document is the floor; a reload is a new process and
+  asks again, which is correct.
+
+  What did not need fixing: the duplicated wave, which was the spike script -
+  see the amendment under S5. The carrier coalesces identical reads that are in
+  flight at the same moment anyway, because SWR's deduplication is a property of
+  one renderer and M3's and M4's carriers will have callers that are not SWR.
+  Writes are never coalesced; the list of methods that may be is in
+  `shared/rpc.ts` and a test asserts no write is on it.
+
+  Checked over CDP against a scratch data directory: all three tabs render, a
+  reviewed tick survives leaving the review and coming back - a real read of the
+  composite endpoint, so the optimistic patch matched what was written - and a
+  comment typed into the app is stored as the person's, not an agent's.
 
 ### M2 — Always on, locally
 

--- a/scripts/spikes/s5-ipc-per-screen.mjs
+++ b/scripts/spikes/s5-ipc-per-screen.mjs
@@ -16,8 +16,7 @@
  *     ./node_modules/.bin/electron . --remote-debugging-port=9222 2>/tmp/gw-ipc.log
  *   node scripts/spikes/s5-ipc-per-screen.mjs /tmp/gw-ipc.log 1
  *
- * The second argument is the review to open. Re-run after M1 to confirm the
- * duplicated cold-load wave is gone and the review opens at depth 1.
+ * The second argument is the review to open.
  */
 import { readFileSync } from 'node:fs'
 import { Cdp, settle, wait } from '../cdp.mjs'
@@ -48,9 +47,26 @@ async function screen(name, action) {
 }
 
 const go = (hash) => () => cdp.evaluate(`location.hash = ${JSON.stringify(hash)}`)
+
+/**
+ * Land on a screen with nothing cached, in exactly one mount.
+ *
+ * Setting the hash and then reloading looks equivalent and is not. The
+ * hashchange lands first, React renders the screen, every read fires - and only
+ * then does the reload tear the document down and do it all again. The log then
+ * shows each key fetched twice, some 40 ms apart, which is a measurement of the
+ * navigation helper rather than of the app. That artefact is what S5 recorded
+ * as a "duplicated wave"; see the M1 note in docs/across-hosts.md.
+ *
+ * So the fragment travels with a real navigation: away to a blank document,
+ * which throws the renderer's caches out, then straight to the target URL with
+ * its hash already on it. One document, one mount, one wave.
+ */
 const reload = (hash) => async () => {
-  await go(hash)()
-  await cdp.evaluate('location.reload()')
+  const base = await cdp.evaluate("location.href.split('#')[0]")
+  await cdp.send('Page.navigate', { url: 'about:blank' })
+  await wait(250)
+  await cdp.send('Page.navigate', { url: base + hash })
   await wait(1500)
 }
 

--- a/src/core/rpc/__tests__/dispatcher.test.ts
+++ b/src/core/rpc/__tests__/dispatcher.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Contract coverage for the message protocol.
+ *
+ * These tests drive `dispatch` and `handleRequest` directly against a real
+ * repository in a temporary directory - no Electron, no window, no carrier.
+ * That is the point of them: M2, M3, M4 and M5 each add a way of getting a
+ * request to this dispatcher, and every one of those carriers has to produce
+ * exactly the behaviour asserted here. When one of them lands, it should be
+ * pointed at this file rather than given tests of its own.
+ *
+ * The service-level behaviour is covered next door in `core/__tests__`; what is
+ * tested here is the contract on top of it - which methods exist, what an error
+ * looks like once it has been through a response, that the coarse endpoint
+ * agrees with the fine ones it replaces, and that a comment arriving this way
+ * is attributed to the person at the keyboard.
+ */
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, beforeEach, test } from 'node:test'
+
+import type { AppError as AppErrorInstance } from '../../../shared/errors.js'
+import type { RpcMethod } from '../../../shared/rpc.js'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-rpc-data-'))
+// Realpathed because a repository is stored under its resolved root, and on
+// macOS the temporary directory is reached through a symlink.
+const workDir = realpathSync(mkdtempSync(join(tmpdir(), 'gitwarren-rpc-work-')))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+const { dispatch, handleRequest, isRpcMethod, rpcMethodNames } = await import('../dispatcher.js')
+const { READ_METHODS } = await import('../../../shared/rpc.js')
+const { getDatabase, closeDatabase } = await import('../../db/client.js')
+const { comments, commentThreads, repositories, reviewedFiles, reviews } = await import(
+  '../../db/schema.js'
+)
+const { AppError } = await import('../../../shared/errors.js')
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}
+
+async function expectError(code: string, fn: () => Promise<unknown>): Promise<AppErrorInstance> {
+  try {
+    await fn()
+  } catch (error) {
+    assert.ok(error instanceof AppError, `expected AppError, got ${String(error)}`)
+    assert.equal(error.code, code)
+    return error
+  }
+  throw new Error(`expected the call to reject with ${code}`)
+}
+
+let checkout: string
+let repositoryId: number
+let reviewId: number
+
+before(() => {
+  checkout = join(workDir, 'project')
+  mkdirSync(checkout, { recursive: true })
+  git(checkout, 'init', '-b', 'main')
+  git(checkout, 'config', 'user.email', 'test@example.com')
+  git(checkout, 'config', 'user.name', 'Test')
+
+  writeFileSync(join(checkout, 'a.txt'), 'one\ntwo\nthree\n')
+  git(checkout, 'add', '.')
+  git(checkout, 'commit', '-m', 'initial')
+
+  git(checkout, 'checkout', '-b', 'feature')
+  writeFileSync(join(checkout, 'a.txt'), 'one\nTWO\nthree\n')
+  writeFileSync(join(checkout, 'b.txt'), 'added on the branch\n')
+  git(checkout, 'add', '.')
+  git(checkout, 'commit', '-m', 'feature work')
+})
+
+beforeEach(async () => {
+  const database = getDatabase()
+  database.delete(comments).run()
+  database.delete(commentThreads).run()
+  database.delete(reviewedFiles).run()
+  database.delete(reviews).run()
+  database.delete(repositories).run()
+
+  repositoryId = (await dispatch('repositories.add', { path: checkout })).id
+  reviewId = (
+    await dispatch('reviews.create', { repositoryId, baseRef: 'main', headRef: 'feature' })
+  ).id
+})
+
+after(() => {
+  closeDatabase()
+  rmSync(dataDir, { recursive: true, force: true })
+  rmSync(workDir, { recursive: true, force: true })
+})
+
+test('a method that is not in the map is refused by name', async () => {
+  assert.equal(isRpcMethod('reviews.open'), true)
+  assert.equal(isRpcMethod('reviews.summon'), false)
+
+  const error = await expectError('INVALID_INPUT', () =>
+    dispatch('reviews.summon' as RpcMethod, undefined)
+  )
+  // The message names the method, because in M4 this is how a host older than
+  // the GUI talking to it reports the mismatch, and a log has to be enough.
+  assert.match(error.message, /reviews\.summon/)
+})
+
+test('every read method is a method', () => {
+  // A typo in READ_METHODS is otherwise silent: the entry would simply never
+  // match, and request coalescing would quietly stop applying to that method.
+  for (const method of READ_METHODS) {
+    assert.ok(rpcMethodNames.includes(method), `${method} is in READ_METHODS but not in the map`)
+  }
+})
+
+test('no write method claims to be a read', () => {
+  // The dangerous direction. A write listed as a read would let a carrier fold
+  // two of them into one, and one of the two comments would never be written.
+  for (const method of ['comments.createThread', 'comments.reply', 'reviews.create'] as const) {
+    assert.equal(READ_METHODS.has(method), false)
+  }
+})
+
+test('reviews.open answers with the review, its threads and its marks', async () => {
+  await dispatch('comments.createThread', { reviewId, body: 'A review-level remark.' })
+  await dispatch('reviews.setFileReviewed', {
+    reviewId,
+    filePath: 'b.txt',
+    contentDigest: 'abc123'
+  })
+
+  const opened = await dispatch('reviews.open', { id: reviewId })
+
+  assert.equal(opened.review.id, reviewId)
+  assert.equal(opened.review.repository.path, checkout)
+  assert.equal(opened.threads.length, 1)
+  assert.equal(opened.reviewedFiles.length, 1)
+  assert.equal(opened.reviewedFiles[0]?.filePath, 'b.txt')
+})
+
+test('reviews.open agrees with the three calls it replaces', async () => {
+  await dispatch('comments.createThread', { reviewId, body: 'Something worth saying.' })
+  await dispatch('reviews.setFileReviewed', { reviewId, filePath: 'a.txt', contentDigest: 'd' })
+
+  const opened = await dispatch('reviews.open', { id: reviewId })
+  const [review, threads, marks] = await Promise.all([
+    dispatch('reviews.get', { id: reviewId }),
+    dispatch('comments.list', { reviewId }),
+    dispatch('reviews.reviewedFiles', { reviewId })
+  ])
+
+  // The whole justification for the coarse endpoint is that it is the same
+  // answer in one round trip instead of three. If that ever stops being true,
+  // the renderer is showing something the fine methods would not have shown.
+  assert.deepEqual(opened.review, review)
+  assert.deepEqual(opened.threads, threads)
+  assert.deepEqual(opened.reviewedFiles, marks)
+})
+
+test('reviews.open on a review that is not there is NOT_FOUND, not an empty review', async () => {
+  await expectError('NOT_FOUND', () => dispatch('reviews.open', { id: reviewId + 999 }))
+})
+
+test('a comment written through the dispatcher belongs to the person at the keyboard', async () => {
+  // The one thing this boundary is responsible for. Agents never come through
+  // here - the MCP server calls the service directly with its own author - so
+  // anything arriving this way is someone typing into a GitWarren window.
+  const thread = await dispatch('comments.createThread', { reviewId, body: 'Mine.' })
+
+  assert.equal(thread.comments[0]?.author.kind, 'human')
+  assert.equal(thread.comments[0]?.author.name, 'Human')
+})
+
+test('handleRequest returns the answer under the id it was asked with', async () => {
+  const response = await handleRequest({ id: 7, method: 'reviews.get', params: { id: reviewId } })
+
+  assert.equal(response.id, 7)
+  assert.ok('result' in response)
+  assert.equal((response.result as { id: number }).id, reviewId)
+})
+
+test('handleRequest turns a failure into a message rather than a throw', async () => {
+  // A carrier holding a byte stream has nowhere to put an exception, so this
+  // has to come back as a response no matter what went wrong.
+  const response = await handleRequest({ id: 8, method: 'reviews.get', params: { id: 999_999 } })
+
+  assert.equal(response.id, 8)
+  assert.ok('error' in response)
+  assert.equal(response.error.code, 'NOT_FOUND')
+})
+
+test('field errors survive the trip, so a form can still put them under an input', async () => {
+  const response = await handleRequest({
+    id: 9,
+    method: 'reviews.create',
+    params: { repositoryId, baseRef: 'main', headRef: 'no-such-branch' }
+  })
+
+  assert.ok('error' in response)
+  assert.equal(response.error.code, 'INVALID_INPUT')
+  assert.deepEqual(response.error.fieldErrors?.headRef, [
+    'No such branch, tag or commit: no-such-branch'
+  ])
+})
+
+test('an unknown method comes back as a response too', async () => {
+  const response = await handleRequest({ id: 10, method: 'nope.nope' as RpcMethod })
+
+  assert.ok('error' in response)
+  assert.equal(response.error.code, 'INVALID_INPUT')
+})
+
+test('the git-backed reads answer for a review, named by id and nothing else', async () => {
+  const commits = await dispatch('reviews.commits', { id: reviewId })
+  assert.equal(commits.commits.length, 1)
+  assert.equal(commits.commits[0]?.subject, 'feature work')
+
+  const diff = await dispatch('reviews.diff', { id: reviewId, changes: 'committed' })
+  assert.deepEqual(
+    diff.files.map((file) => file.path),
+    ['a.txt', 'b.txt']
+  )
+
+  const content = await dispatch('reviews.file', {
+    id: reviewId,
+    path: 'a.txt',
+    changes: 'committed'
+  })
+  assert.deepEqual(content.lines, ['one', 'TWO', 'three'])
+
+  // A path is only ever "a file of this review", and the answer is where that
+  // file actually is - which is not always under the repository path once the
+  // head branch lives in a linked worktree.
+  const absolute = await dispatch('reviews.filePath', { id: reviewId, path: 'a.txt' })
+  assert.equal(absolute, join(checkout, 'a.txt'))
+})
+
+test('repositories answer through the dispatcher as they do through a service', async () => {
+  const list = await dispatch('repositories.list', undefined)
+  assert.equal(list.length, 1)
+  assert.equal(list[0]?.id, repositoryId)
+
+  const one = await dispatch('repositories.get', { id: repositoryId })
+  assert.equal(one.path, checkout)
+
+  const refs = await dispatch('repositories.refs', { id: repositoryId })
+  assert.ok(refs.refs.some((ref) => ref.name === 'feature'))
+
+  await expectError('DUPLICATE_REPOSITORY', () => dispatch('repositories.add', { path: checkout }))
+})
+
+test('a mark set through the dispatcher is a mark reviews.open reports', async () => {
+  await dispatch('reviews.setFileReviewed', { reviewId, filePath: 'a.txt', contentDigest: 'v1' })
+  assert.equal((await dispatch('reviews.open', { id: reviewId })).reviewedFiles.length, 1)
+
+  await dispatch('reviews.setFileReviewed', { reviewId, filePath: 'a.txt', contentDigest: null })
+  assert.deepEqual((await dispatch('reviews.open', { id: reviewId })).reviewedFiles, [])
+})
+
+test('an image arrives as bytes and comes back as an attachment', async () => {
+  // A 1x1 PNG. The point is the transport: the renderer has no filesystem, so
+  // the bytes travel and are turned back into a Buffer at this boundary.
+  const png = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    'base64'
+  )
+
+  const attachment = await dispatch('attachments.ingest', {
+    bytes: [...png],
+    originalName: 'dot.png'
+  })
+
+  assert.equal(attachment.mimeType, 'image/png')
+  assert.equal(attachment.width, 1)
+  assert.equal(attachment.height, 1)
+})
+
+test('ingesting nothing is refused before a service is troubled with it', async () => {
+  await expectError('INVALID_INPUT', () =>
+    dispatch('attachments.ingest', undefined as unknown as { bytes: number[] })
+  )
+})

--- a/src/core/rpc/dispatcher.ts
+++ b/src/core/rpc/dispatcher.ts
@@ -1,0 +1,183 @@
+/**
+ * Method name to service call, and nothing else.
+ *
+ * This is the one place that decides what "everything the core can do" means.
+ * Every carrier - Electron IPC today, a stdio pipe in M2, a WebSocket in M3,
+ * `ssh` in M4 - is a way of getting a `RpcRequest` to `handleRequest` and an
+ * `RpcResponse` back. None of them may add a method, skip validation, or decide
+ * who a comment belongs to. If a carrier grows logic, it is in the wrong file.
+ *
+ * Two properties are load-bearing and worth stating plainly.
+ *
+ * **The dispatcher is the human surface.** Every comment write here passes
+ * `HUMAN_AUTHOR`, because the only way to reach a dispatcher is for someone to
+ * be driving a GitWarren window. Agents do not come through here at all: the
+ * MCP server imports `core/services` directly and passes an author derived from
+ * its handshake (`mcp/identity.ts`). That is the whole enforcement mechanism
+ * for "comments from the UI are the person's, comments over MCP are the
+ * agent's", and it works because the actor is a property of the boundary rather
+ * than a field a caller could set. Moving it here from `main/ipc.ts` changed
+ * where the boundary is drawn, not what it guarantees.
+ *
+ * **The dispatcher has no capabilities.** It reads git and SQLite and that is
+ * all. It cannot open a dialog, reveal a path, or start a process, because in
+ * M4 the thing on the other end of a carrier is a daemon on someone else's
+ * machine, and a request that could launch a process there would be a very
+ * different piece of software. Shell capabilities live in `main/ipc.ts` and
+ * never enter this map.
+ */
+import { attachmentsService } from '../services/attachments.js'
+import { commentsService } from '../services/comments.js'
+import { repositoriesService } from '../services/repositories.js'
+import { reviewedFilesService } from '../services/reviewed-files.js'
+import { reviewsService } from '../services/reviews.js'
+import { traced } from '../trace.js'
+import { HUMAN_AUTHOR } from '../../shared/actors.js'
+import { AppError } from '../../shared/errors.js'
+import type {
+  AttachmentIngestParams,
+  ReviewOpen,
+  RpcMethod,
+  RpcParams,
+  RpcRequest,
+  RpcResponse,
+  RpcResult
+} from '../../shared/rpc.js'
+
+/**
+ * Everything needed to render a review, in one call.
+ *
+ * Three indexed reads that were three round trips. `reviews.get` runs first
+ * because it is the one that decides whether the review exists at all: a
+ * missing review should answer `NOT_FOUND` rather than an empty discussion.
+ * After that the two lists are independent, so they cost the slowest rather
+ * than the sum.
+ */
+async function openReview(params: unknown): Promise<ReviewOpen> {
+  const review = await reviewsService.get(params)
+  const [threads, reviewedFiles] = await Promise.all([
+    commentsService.list({ reviewId: review.id }),
+    reviewedFilesService.list({ reviewId: review.id })
+  ])
+  return { review, threads, reviewedFiles }
+}
+
+/**
+ * Bytes on the way in.
+ *
+ * The only method whose params need touching before a service sees them, and
+ * the reason is transport: `Buffer` is not something a renderer or a JSON
+ * carrier can send, so an image arrives as an `ArrayBuffer` or a plain array
+ * and is turned back into bytes here, at the edge, once.
+ */
+function toIngestSource(params: unknown): { bytes: Buffer; originalName?: string } {
+  if (typeof params !== 'object' || params === null || !('bytes' in params)) {
+    throw new AppError('INVALID_INPUT', 'An image is required.')
+  }
+  const { bytes, originalName } = params as AttachmentIngestParams
+  return {
+    bytes: Buffer.from(bytes as ArrayBuffer),
+    ...(typeof originalName === 'string' ? { originalName } : {})
+  }
+}
+
+/**
+ * The map. Every entry is a one-line delegation, and that thinness is the
+ * point: validation, path resolution and error semantics live in the service,
+ * so the GUI, the daemon and the MCP server cannot disagree about what a valid
+ * review is. Each service re-parses its own input, so `params` is deliberately
+ * `unknown` all the way down to it.
+ */
+const handlers: { [M in RpcMethod]: (params: unknown) => Promise<RpcResult<M>> } = {
+  'repositories.list': () => repositoriesService.list(),
+  'repositories.get': (params) => repositoriesService.get(params),
+  'repositories.add': (params) => repositoriesService.add(params),
+  'repositories.update': (params) => repositoriesService.update(params),
+  'repositories.remove': (params) => repositoriesService.remove(params),
+  'repositories.refs': (params) => repositoriesService.refs(params),
+
+  'reviews.list': (params) => reviewsService.list(params),
+  'reviews.open': (params) => openReview(params),
+  'reviews.get': (params) => reviewsService.get(params),
+  'reviews.create': (params) => reviewsService.create(params),
+  'reviews.update': (params) => reviewsService.update(params),
+  'reviews.remove': (params) => reviewsService.remove(params),
+  'reviews.commits': (params) => reviewsService.commits(params),
+  'reviews.diff': (params) => reviewsService.diff(params),
+  'reviews.file': (params) => reviewsService.file(params),
+  'reviews.image': (params) => reviewsService.image(params),
+  'reviews.filePath': (params) => reviewsService.absolutePath(params),
+
+  // Reviewed marks are a record of what the person at the keyboard has read, so
+  // they are reachable from a GitWarren window and from nowhere else. There is
+  // deliberately no MCP tool for them: an agent claiming a human has reviewed a
+  // file would make the one honest signal on the screen worthless.
+  'reviews.reviewedFiles': (params) => reviewedFilesService.list(params),
+  'reviews.setFileReviewed': (params) => reviewedFilesService.setReviewed(params),
+
+  // `HUMAN_AUTHOR` on every write. See the note at the top of the file.
+  'comments.list': (params) => commentsService.list(params),
+  'comments.createThread': (params) => commentsService.createThread(params, HUMAN_AUTHOR),
+  'comments.reply': (params) => commentsService.reply(params, HUMAN_AUTHOR),
+  'comments.update': (params) => commentsService.update(params, HUMAN_AUTHOR),
+  'comments.remove': (params) => commentsService.remove(params, HUMAN_AUTHOR),
+  'comments.setResolved': (params) => commentsService.setResolved(params, HUMAN_AUTHOR),
+
+  'attachments.ingest': (params) => attachmentsService.ingest(toIngestSource(params))
+}
+
+/** Derived from the map above rather than written out again next to it. */
+export const rpcMethodNames = Object.keys(handlers) as RpcMethod[]
+
+export function isRpcMethod(method: string): method is RpcMethod {
+  return Object.hasOwn(handlers, method)
+}
+
+/**
+ * Answer one method, or throw an `AppError`.
+ *
+ * Typed for the callers that know which method they are asking for - the
+ * renderer through its carrier, and the tests. `handleRequest` below is the
+ * untyped door for a carrier holding a message off a wire.
+ */
+export async function dispatch<M extends RpcMethod>(
+  method: M,
+  params?: RpcParams<M>
+): Promise<RpcResult<M>> {
+  if (!isRpcMethod(method)) {
+    // A caller bug locally; in M4, a host older than the GUI talking to it. The
+    // message names the method so the second case is diagnosable from a log.
+    throw new AppError('INVALID_INPUT', `Unknown method "${String(method)}".`)
+  }
+
+  try {
+    // Traced here rather than in a carrier, so that counting round trips per
+    // screen works the same however the request arrived - the measurement M1
+    // exists to improve, and the one M4 will want again over a real network.
+    return await traced(method, () => handlers[method](params))
+  } catch (error) {
+    const appError = AppError.from(error)
+    if (appError.code === 'INTERNAL') {
+      // Unexpected failures are worth seeing in the terminal; every other code
+      // is an ordinary user-facing outcome that the screen will render.
+      console.error(`[ipc] ${method} failed`, error)
+    }
+    throw appError
+  }
+}
+
+/**
+ * The carrier's entry point: a request in, a response out, never a throw.
+ *
+ * A carrier holding a byte stream has no way to report an exception - there is
+ * only the wire - so every failure has to come back as a message. Errors keep
+ * their `AppError` code and their field errors, which is what lets a form on
+ * the other side of an `ssh` pipe still put a message under the right input.
+ */
+export async function handleRequest(request: RpcRequest): Promise<RpcResponse> {
+  try {
+    return { id: request.id, result: await dispatch(request.method, request.params) }
+  } catch (error) {
+    return { id: request.id, error: AppError.from(error).toSerialized() }
+  }
+}

--- a/src/core/trace.ts
+++ b/src/core/trace.ts
@@ -1,0 +1,29 @@
+/**
+ * Counting round trips.
+ *
+ * `GITWARREN_TRACE_IPC=1` logs every call a shell makes into the app, with when
+ * it started and how long it took. The offsets are the useful part: calls that
+ * start together are one round trip over a network, and a call that starts
+ * after another finished is a second one. That number per screen is what spike
+ * S5 measured and what M1 set out to reduce - see docs/across-hosts.md.
+ *
+ * Two callers, deliberately. The dispatcher traces every method, so every
+ * carrier is measurable the moment it exists. `main/ipc.ts` traces the handful
+ * of shell channels that are not methods, because they cost the renderer a
+ * round trip too, and a count that quietly left them out would flatter itself.
+ *
+ * The `[ipc]` prefix is what `scripts/spikes/s5-ipc-per-screen.mjs` greps for.
+ */
+export const TRACE_CALLS = process.env.GITWARREN_TRACE_IPC === '1'
+
+export async function traced<T>(label: string, call: () => Promise<T> | T): Promise<T> {
+  if (!TRACE_CALLS) return call()
+
+  const startedAt = performance.now()
+  try {
+    return await call()
+  } finally {
+    const duration = performance.now() - startedAt
+    console.error(`[ipc] ${label} at ${startedAt.toFixed(0)}ms took ${duration.toFixed(1)}ms`)
+  }
+}

--- a/src/main/__tests__/ipc-channels.test.ts
+++ b/src/main/__tests__/ipc-channels.test.ts
@@ -1,0 +1,77 @@
+/**
+ * That the Electron carrier still answers everything it used to.
+ *
+ * M1 replaced twenty-odd hand-written IPC handlers with one carrier channel and
+ * a table. The risk in a change shaped like that is not that something breaks
+ * loudly; it is that a channel quietly stops being registered and nobody finds
+ * out, because the renderer no longer calls it. So the channels are accounted
+ * for here: every name in `IPC_CHANNELS` has to be either a method, something
+ * the shell answers itself, or a push - and never two of those at once.
+ *
+ * `main/ipc.ts` registers from the same table this reads, so a channel added
+ * without a home fails here rather than at runtime.
+ */
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, test } from 'node:test'
+
+// Set before the dispatcher is imported: nothing here opens the database, but a
+// test must not be one edit away from writing to the real data directory.
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-channels-'))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+import { CHANNEL_METHODS, IPC_CHANNELS, PUSH_CHANNELS, SHELL_CHANNELS } from '../../shared/api.js'
+import { rpcMethodNames } from '../../core/rpc/dispatcher.js'
+
+after(() => rmSync(dataDir, { recursive: true, force: true }))
+
+const methodChannels = Object.keys(CHANNEL_METHODS)
+
+test('every channel has exactly one home', () => {
+  for (const channel of Object.values(IPC_CHANNELS)) {
+    // The carrier itself is the one channel that is none of the three.
+    if (channel === IPC_CHANNELS.rpcRequest) continue
+
+    const homes = [
+      methodChannels.includes(channel),
+      (SHELL_CHANNELS as readonly string[]).includes(channel),
+      (PUSH_CHANNELS as readonly string[]).includes(channel)
+    ].filter(Boolean).length
+
+    assert.equal(homes, 1, `${channel} should be a method, a shell channel or a push - not ${homes}`)
+  }
+})
+
+test('every channel that names a method names one that exists', () => {
+  for (const [channel, method] of Object.entries(CHANNEL_METHODS)) {
+    assert.ok(rpcMethodNames.includes(method), `${channel} points at a method that is gone: ${method}`)
+  }
+})
+
+test('no two channels answer with the same method', () => {
+  // Not fatal, but it would mean a channel was pointed at the wrong method
+  // during a rename - and both would keep answering, one of them wrongly.
+  const methods = Object.values(CHANNEL_METHODS)
+  assert.equal(new Set(methods).size, methods.length)
+})
+
+test('the channels the shell keeps are the ones that touch this machine', () => {
+  // Written out rather than derived, because the value of the list is that
+  // adding to it is a decision someone has to make on purpose. A method that
+  // could open a window or launch a program on a host across a network would
+  // make GitWarren a very different piece of software - see the note at the top
+  // of `core/rpc/dispatcher.ts`.
+  assert.deepEqual([...SHELL_CHANNELS].sort(), [
+    'attachments:pick',
+    'reviews:openInEditor',
+    'system:appInfo',
+    'system:editors',
+    'system:pickDirectory',
+    'system:revealPath',
+    'updates:check',
+    'updates:getStatus',
+    'updates:installNow'
+  ])
+})

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,135 +1,109 @@
 /**
- * IPC handlers.
+ * The Electron carrier.
  *
- * Every repository handler is a one-line delegation to `repositoriesService`.
- * That thinness is the point: validation, path resolution and error semantics
- * all live in the service, so the UI and the MCP server cannot disagree about
- * what a valid repository is. If you find yourself adding logic here, it almost
- * certainly belongs in the service instead.
+ * Two kinds of channel are registered here, and the difference between them is
+ * the whole shape of M1.
+ *
+ * **The carrier.** `rpc:request` takes a `{method, params}` and hands it to the
+ * dispatcher. That is the entire implementation. Everything that used to be a
+ * handler in this file - what a valid review is, who a comment belongs to, how
+ * an error is coded - now lives in `core/rpc/dispatcher.ts`, where the daemon
+ * and every carrier after it will read it from too. The per-object channels
+ * below are kept and still answer, each a one-line delegation to the same
+ * dispatcher, so nothing that spoke to this app before M1 stopped being spoken
+ * to; the renderer no longer uses them.
+ *
+ * **The shell.** Folder pickers, revealing a path, launching an editor, the
+ * updater. These do things to the machine the person is sitting at, they stay
+ * here, and they must never become methods - in M4 the far end of a carrier is
+ * a daemon on another machine, and a request that could open a window or start
+ * a process there would be a very different piece of software.
+ *
+ * If you find yourself adding logic to either kind, it almost certainly belongs
+ * in a service instead.
  */
 import { BrowserWindow, dialog, ipcMain, shell, app } from 'electron'
+import { dispatch } from '../core/rpc/dispatcher.js'
+import { traced } from '../core/trace.js'
 import { attachmentsService } from '../core/services/attachments.js'
-import { commentsService } from '../core/services/comments.js'
-import { repositoriesService } from '../core/services/repositories.js'
-import { reviewedFilesService } from '../core/services/reviewed-files.js'
-import { reviewsService } from '../core/services/reviews.js'
 import { getDataDirectory, getDatabasePath } from '../core/paths.js'
 import { getInstanceId } from '../core/instance.js'
-import { HUMAN_AUTHOR } from '../shared/actors.js'
 import { AppError } from '../shared/errors.js'
 import { parseWithSchema as parse } from '../shared/validation.js'
 import { openReviewFileInputSchema } from '../shared/schemas.js'
-import {
-  IPC_CHANNELS,
-  type AppInfo,
-  type AttachmentIngestInput,
-  type IpcResult
-} from '../shared/api.js'
+import { CHANNEL_METHODS, IPC_CHANNELS, type AppInfo } from '../shared/api.js'
+import type { RpcMethod, RpcOutcome, RpcParams } from '../shared/rpc.js'
 import { listEditors, openInEditor } from './editors.js'
 import { getMcpLaunchInfo } from './mcp-launch.js'
 import { checkForUpdates, getUpdateStatus, quitAndInstall } from './updater.js'
 
-const TRACE_IPC = process.env.GITWARREN_TRACE_IPC === '1'
-
 /**
- * Wraps a handler so thrown errors arrive in the renderer as structured data
+ * Wraps a handler so a failure arrives in the renderer as structured data
  * rather than as Electron's flattened "Error invoking remote method" string.
+ *
+ * The envelope is the protocol's own `RpcOutcome`, not an Electron-shaped one:
+ * the same `{result} | {error}` a stdio pipe or a WebSocket will carry, so the
+ * preload's unwrapping is the unwrapping every carrier does.
  */
 function handle<T>(channel: string, handler: (payload: unknown) => Promise<T> | T): void {
-  ipcMain.handle(channel, async (_event, payload: unknown): Promise<IpcResult<T>> => {
-    // Set GITWARREN_TRACE_IPC=1 to see every call with when it started and how
-    // long it took. The point is to count round trips per screen, and how many
-    // of them wait on each other, before the core moves behind a network
-    // carrier - see docs/across-hosts.md, spike S5 - where each one stops
-    // being free.
-    const startedAt = TRACE_IPC ? performance.now() : 0
+  ipcMain.handle(channel, async (_event, payload: unknown): Promise<RpcOutcome<T>> => {
     try {
-      const data = await handler(payload)
-      if (TRACE_IPC) {
-        const duration = performance.now() - startedAt
-        console.error(`[ipc] ${channel} at ${startedAt.toFixed(0)}ms took ${duration.toFixed(1)}ms`)
-      }
-      return { ok: true, data }
+      return { result: await handler(payload) }
     } catch (error) {
-      const appError = AppError.from(error)
-      if (appError.code === 'INTERNAL') {
-        // Unexpected failures are worth seeing in the terminal; the domain
-        // errors below are ordinary user-facing outcomes.
-        console.error(`[ipc] ${channel} failed`, error)
-      }
-      return { ok: false, error: appError.toSerialized() }
+      // Codes, messages and field errors are preserved on the way through; the
+      // dispatcher logs the unexpected ones, so that it happens the same way
+      // for every carrier.
+      return { error: AppError.from(error).toSerialized() }
     }
   })
 }
 
+/**
+ * A shell channel, traced.
+ *
+ * The dispatcher traces every method it answers, so the carrier channels above
+ * need nothing. These do: they are not methods, but they are still a round trip
+ * the renderer paid for, and a count that left them out would be measuring the
+ * wrong thing. See `core/trace.ts`.
+ */
+function handleShell<T>(channel: string, handler: (payload: unknown) => Promise<T> | T): void {
+  handle(channel, (payload) => traced(channel, () => handler(payload)))
+}
+
 export function registerIpcHandlers(): void {
-  handle(IPC_CHANNELS.repositoriesList, () => repositoriesService.list())
-  handle(IPC_CHANNELS.repositoriesGet, (input) => repositoriesService.get(input))
-  handle(IPC_CHANNELS.repositoriesAdd, (input) => repositoriesService.add(input))
-  handle(IPC_CHANNELS.repositoriesUpdate, (input) => repositoriesService.update(input))
-  handle(IPC_CHANNELS.repositoriesRemove, (input) => repositoriesService.remove(input))
-  handle(IPC_CHANNELS.repositoriesRefs, (input) => repositoriesService.refs(input))
+  // The carrier. Everything the renderer does arrives here.
+  handle(IPC_CHANNELS.rpcRequest, (payload) => {
+    if (typeof payload !== 'object' || payload === null || !('method' in payload)) {
+      throw new AppError('INVALID_INPUT', 'A request needs a method.')
+    }
+    const { method, params } = payload as { method: RpcMethod; params?: unknown }
+    return dispatch(method, params as RpcParams<RpcMethod>)
+  })
 
-  handle(IPC_CHANNELS.reviewsList, (input) => reviewsService.list(input))
-  handle(IPC_CHANNELS.reviewsGet, (input) => reviewsService.get(input))
-  handle(IPC_CHANNELS.reviewsCreate, (input) => reviewsService.create(input))
-  handle(IPC_CHANNELS.reviewsUpdate, (input) => reviewsService.update(input))
-  handle(IPC_CHANNELS.reviewsRemove, (input) => reviewsService.remove(input))
-  handle(IPC_CHANNELS.reviewsCommits, (input) => reviewsService.commits(input))
-  handle(IPC_CHANNELS.reviewsDiff, (input) => reviewsService.diff(input))
-  handle(IPC_CHANNELS.reviewsFile, (input) => reviewsService.file(input))
-  handle(IPC_CHANNELS.reviewsImage, (input) => reviewsService.image(input))
+  // Every channel that existed before M1, still answering, now through the
+  // dispatcher. The table lives in `shared/api.ts` next to the channel names.
+  for (const [channel, method] of Object.entries(CHANNEL_METHODS)) {
+    handle(channel, (payload) => dispatch(method, payload as RpcParams<RpcMethod>))
+  }
 
-  // Two steps rather than one service call: *which* file on disk is review
-  // knowledge and belongs in the service, while launching an application is a
-  // main-process capability the service must not have - the MCP server imports
-  // that same service, and an agent must not be able to start processes here.
-  handle(IPC_CHANNELS.reviewsOpenInEditor, async (input) => {
-    const { line, editorId } = parse(openReviewFileInputSchema, input)
-    const absolute = await reviewsService.absolutePath(input)
+  // ---------------------------------------------------------------------------
+  // The shell. Everything below this line does something to this machine.
+  // ---------------------------------------------------------------------------
+
+  // Two steps rather than one: *which* file on disk is review knowledge and
+  // belongs to whoever owns the review - a method, so that in M4 it can be a
+  // host across the network - while launching an application is a capability
+  // only the machine with the screen on it has.
+  handleShell(IPC_CHANNELS.reviewsOpenInEditor, async (input) => {
+    const { id, path, changes, line, editorId } = parse(openReviewFileInputSchema, input)
+    const absolute = await dispatch('reviews.filePath', { id, path, changes })
     await openInEditor(absolute, line, editorId)
   })
 
-  // Reviewed marks are a record of what the person at the keyboard has read,
-  // so they are reachable from the UI and from nowhere else. There is
-  // deliberately no MCP tool for them: an agent claiming a human has reviewed
-  // a file would make the one honest signal on the screen worthless.
-  handle(IPC_CHANNELS.reviewsReviewedFiles, (input) => reviewedFilesService.list(input))
-  handle(IPC_CHANNELS.reviewsSetFileReviewed, (input) => reviewedFilesService.setReviewed(input))
-
-  // Every comment write passes HUMAN_AUTHOR, and there is no way to reach these
-  // channels except by typing into the app - the renderer has no other route to
-  // the main process. That is the whole enforcement mechanism for "comments
-  // from the UI are the person's, comments over MCP are the agent's", and it
-  // works because the actor is a property of the channel rather than a field
-  // any caller could set.
-  handle(IPC_CHANNELS.commentsList, (input) => commentsService.list(input))
-  handle(IPC_CHANNELS.commentsCreateThread, (input) =>
-    commentsService.createThread(input, HUMAN_AUTHOR)
-  )
-  handle(IPC_CHANNELS.commentsReply, (input) => commentsService.reply(input, HUMAN_AUTHOR))
-  handle(IPC_CHANNELS.commentsUpdate, (input) => commentsService.update(input, HUMAN_AUTHOR))
-  handle(IPC_CHANNELS.commentsRemove, (input) => commentsService.remove(input, HUMAN_AUTHOR))
-  handle(IPC_CHANNELS.commentsSetResolved, (input) =>
-    commentsService.setResolved(input, HUMAN_AUTHOR)
-  )
-
-  // The renderer cannot touch the filesystem, so a pasted or dropped image
-  // arrives as bytes and is handed straight to the service - the same service
-  // an agent's file path goes through, so both surfaces produce the same row
-  // and the same token.
-  handle(IPC_CHANNELS.attachmentsIngest, (input) => {
-    if (typeof input !== 'object' || input === null || !('bytes' in input)) {
-      throw new AppError('INVALID_INPUT', 'An image is required.')
-    }
-    const { bytes, originalName } = input as AttachmentIngestInput
-    return attachmentsService.ingest({
-      bytes: Buffer.from(bytes),
-      originalName: typeof originalName === 'string' ? originalName : undefined
-    })
-  })
-
-  handle(IPC_CHANNELS.attachmentsPick, async () => {
+  // The native picker is the shell's; what it picks goes through the same
+  // service an agent's file path goes through, so both produce the same row and
+  // the same token. Not a dispatcher method, because it opens a window.
+  handleShell(IPC_CHANNELS.attachmentsPick, async () => {
     const window = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
     const options: Electron.OpenDialogOptions = {
       title: 'Attach an image',
@@ -146,7 +120,7 @@ export function registerIpcHandlers(): void {
     return path === null ? null : await attachmentsService.ingest({ path })
   })
 
-  handle(IPC_CHANNELS.systemPickDirectory, async () => {
+  handleShell(IPC_CHANNELS.systemPickDirectory, async () => {
     const window = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
     const options: Electron.OpenDialogOptions = {
       title: 'Choose a git repository',
@@ -159,7 +133,7 @@ export function registerIpcHandlers(): void {
     return result.canceled ? null : (result.filePaths[0] ?? null)
   })
 
-  handle(IPC_CHANNELS.systemRevealPath, async (input) => {
+  handleShell(IPC_CHANNELS.systemRevealPath, async (input) => {
     if (typeof input !== 'string' || !input) {
       throw new AppError('INVALID_INPUT', 'A path is required.')
     }
@@ -167,9 +141,9 @@ export function registerIpcHandlers(): void {
     if (failure) throw new AppError('PATH_NOT_FOUND', failure)
   })
 
-  handle(IPC_CHANNELS.systemEditors, () => listEditors())
+  handleShell(IPC_CHANNELS.systemEditors, () => listEditors())
 
-  handle(IPC_CHANNELS.systemAppInfo, (): AppInfo => ({
+  handleShell(IPC_CHANNELS.systemAppInfo, (): AppInfo => ({
     version: app.getVersion(),
     instanceId: getInstanceId(),
     platform: process.platform,
@@ -179,7 +153,7 @@ export function registerIpcHandlers(): void {
     mcp: getMcpLaunchInfo()
   }))
 
-  handle(IPC_CHANNELS.updatesGetStatus, () => getUpdateStatus())
-  handle(IPC_CHANNELS.updatesCheck, () => checkForUpdates({ userInitiated: true }))
-  handle(IPC_CHANNELS.updatesInstallNow, () => quitAndInstall())
+  handleShell(IPC_CHANNELS.updatesGetStatus, () => getUpdateStatus())
+  handleShell(IPC_CHANNELS.updatesCheck, () => checkForUpdates({ userInitiated: true }))
+  handleShell(IPC_CHANNELS.updatesInstallNow, () => quitAndInstall())
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,142 +1,102 @@
 /**
  * The only bridge between the renderer and the main process.
  *
- * The renderer has no Node access; it gets exactly the functions listed here
- * and nothing else. Each one unwraps the `IpcResult` envelope so that a failure
- * in the main process surfaces in React as a thrown `AppError` with its code
- * intact, which is what lets the forms show field-level messages.
+ * The renderer has no Node access; it gets exactly what is exposed here and
+ * nothing else. Since M1 that is two things: a carrier, and the handful of
+ * capabilities only this shell has.
+ *
+ * The carrier is one function over one channel. It is deliberately not a method
+ * per object any more - the list of methods lives in `shared/rpc.ts`, and a
+ * preload that had to be edited every time one was added would be a third place
+ * to keep the same list. What this file still does is unwrap the outcome, so a
+ * failure in the main process surfaces in React as a thrown `AppError` with its
+ * code intact, which is what lets the forms show field-level messages.
+ *
+ * It also coalesces reads. Two identical reads in flight at the same moment are
+ * the same read, and answering both from one round trip is free here and worth
+ * a great deal once a carrier is an `ssh` pipe. Writes are never coalesced -
+ * see `READ_METHODS`.
  */
 import { contextBridge, ipcRenderer } from 'electron'
-import { deserializeAppError } from '../shared/errors.js'
 import {
   IPC_CHANNELS,
   type AppInfo,
-  type AttachmentIngestInput,
   type EditorList,
-  type GitWarrenApi,
-  type IpcResult,
+  type GitWarrenBridge,
   type UpdateStatus
 } from '../shared/api.js'
-import type {
-  FileContent,
-  FileImage,
-  RepositoryRefs,
-  ReviewCommits,
-  ReviewDiff
-} from '../shared/git.js'
-import type {
-  AddRepositoryInput,
-  Attachment,
-  Comment,
-  CommentThread,
-  CreateReviewInput,
-  CreateThreadInput,
-  GetRepositoryInput,
-  GetReviewInput,
-  ListCommentsInput,
-  ListReviewsInput,
-  OpenReviewFileInput,
-  RemoveCommentInput,
-  RemoveRepositoryInput,
-  RemoveReviewInput,
-  ReplyToThreadInput,
-  Repository,
-  RepositoryRefsInput,
-  RepositoryWithGitState,
-  Review,
-  ReviewCommitsInput,
-  ReviewDiffInput,
-  ReviewedFile,
-  ReviewFileInput,
-  ReviewImageInput,
-  ReviewWithRepository,
-  ListReviewedFilesInput,
-  SetFileReviewedInput,
-  SetThreadResolvedInput,
-  UpdateCommentInput,
-  UpdateRepositoryInput,
-  UpdateReviewInput
-} from '../shared/schemas.js'
+import {
+  isReadMethod,
+  resultOf,
+  type Carrier,
+  type RpcMethod,
+  type RpcOutcome,
+  type RpcParams,
+  type RpcResult
+} from '../shared/rpc.js'
+import type { Attachment, OpenReviewFileInput } from '../shared/schemas.js'
 
 async function invoke<T>(channel: string, payload?: unknown): Promise<T> {
   // `invoke` is typed as `any`; the envelope shape is guaranteed by `handle()`
   // in the main process, which is the only thing that answers these channels.
-  const result = (await ipcRenderer.invoke(channel, payload)) as IpcResult<T>
-  if (result.ok) return result.data
-  throw deserializeAppError(result.error)
+  return resultOf((await ipcRenderer.invoke(channel, payload)) as RpcOutcome<T>)
 }
 
-const api: GitWarrenApi = {
-  repositories: {
-    list: () => invoke<RepositoryWithGitState[]>(IPC_CHANNELS.repositoriesList),
-    get: (input: GetRepositoryInput) =>
-      invoke<RepositoryWithGitState>(IPC_CHANNELS.repositoriesGet, input),
-    add: (input: AddRepositoryInput) => invoke<Repository>(IPC_CHANNELS.repositoriesAdd, input),
-    update: (input: UpdateRepositoryInput) =>
-      invoke<Repository>(IPC_CHANNELS.repositoriesUpdate, input),
-    remove: (input: RemoveRepositoryInput) =>
-      invoke<{ id: number }>(IPC_CHANNELS.repositoriesRemove, input),
-    refs: (input: RepositoryRefsInput) =>
-      invoke<RepositoryRefs>(IPC_CHANNELS.repositoriesRefs, input)
-  },
-  reviews: {
-    list: (input: ListReviewsInput) => invoke<Review[]>(IPC_CHANNELS.reviewsList, input),
-    get: (input: GetReviewInput) => invoke<ReviewWithRepository>(IPC_CHANNELS.reviewsGet, input),
-    create: (input: CreateReviewInput) => invoke<Review>(IPC_CHANNELS.reviewsCreate, input),
-    update: (input: UpdateReviewInput) => invoke<Review>(IPC_CHANNELS.reviewsUpdate, input),
-    remove: (input: RemoveReviewInput) => invoke<{ id: number }>(IPC_CHANNELS.reviewsRemove, input),
-    commits: (input: ReviewCommitsInput) =>
-      invoke<ReviewCommits>(IPC_CHANNELS.reviewsCommits, input),
-    diff: (input: ReviewDiffInput) => invoke<ReviewDiff>(IPC_CHANNELS.reviewsDiff, input),
-    file: (input: ReviewFileInput) => invoke<FileContent>(IPC_CHANNELS.reviewsFile, input),
-    image: (input: ReviewImageInput) => invoke<FileImage>(IPC_CHANNELS.reviewsImage, input),
-    openInEditor: (input: OpenReviewFileInput) =>
-      invoke<void>(IPC_CHANNELS.reviewsOpenInEditor, input),
-    reviewedFiles: (input: ListReviewedFilesInput) =>
-      invoke<ReviewedFile[]>(IPC_CHANNELS.reviewsReviewedFiles, input),
-    setFileReviewed: (input: SetFileReviewedInput) =>
-      invoke<ReviewedFile | null>(IPC_CHANNELS.reviewsSetFileReviewed, input)
-  },
-  comments: {
-    list: (input: ListCommentsInput) => invoke<CommentThread[]>(IPC_CHANNELS.commentsList, input),
-    createThread: (input: CreateThreadInput) =>
-      invoke<CommentThread>(IPC_CHANNELS.commentsCreateThread, input),
-    reply: (input: ReplyToThreadInput) => invoke<Comment>(IPC_CHANNELS.commentsReply, input),
-    update: (input: UpdateCommentInput) => invoke<Comment>(IPC_CHANNELS.commentsUpdate, input),
-    remove: (input: RemoveCommentInput) =>
-      invoke<{ id: number; threadRemoved: boolean }>(IPC_CHANNELS.commentsRemove, input),
-    setResolved: (input: SetThreadResolvedInput) =>
-      invoke<CommentThread>(IPC_CHANNELS.commentsSetResolved, input)
-  },
-  attachments: {
-    ingest: (input: AttachmentIngestInput) =>
-      invoke<Attachment>(IPC_CHANNELS.attachmentsIngest, input),
-    pick: () => invoke<Attachment | null>(IPC_CHANNELS.attachmentsPick)
-  },
-  system: {
-    pickDirectory: () => invoke<string | null>(IPC_CHANNELS.systemPickDirectory),
-    revealPath: (path: string) => invoke<void>(IPC_CHANNELS.systemRevealPath, path),
-    appInfo: () => invoke<AppInfo>(IPC_CHANNELS.systemAppInfo),
-    editors: () => invoke<EditorList>(IPC_CHANNELS.systemEditors)
-  },
-  navigation: {
-    onDeepLink: (listener: (hash: string) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, hash: string): void => listener(hash)
-      ipcRenderer.on(IPC_CHANNELS.navigationDeepLink, handler)
-      return () => ipcRenderer.off(IPC_CHANNELS.navigationDeepLink, handler)
-    }
-  },
-  updates: {
-    getStatus: () => invoke<UpdateStatus>(IPC_CHANNELS.updatesGetStatus),
-    check: () => invoke<UpdateStatus>(IPC_CHANNELS.updatesCheck),
-    installNow: () => invoke<void>(IPC_CHANNELS.updatesInstallNow),
-    subscribe: (listener: (status: UpdateStatus) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, status: UpdateStatus): void =>
-        listener(status)
-      ipcRenderer.on(IPC_CHANNELS.updatesChanged, handler)
-      return () => ipcRenderer.off(IPC_CHANNELS.updatesChanged, handler)
-    }
+/**
+ * Reads in flight, by method and params. An entry lives exactly as long as the
+ * request it stands for - long enough to be joined, never long enough to be a
+ * cache. A caller that wants a cache has SWR.
+ */
+const inFlight = new Map<string, Promise<unknown>>()
+
+const carrier: Carrier = {
+  request<M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> {
+    const send = (): Promise<RpcResult<M>> =>
+      invoke<RpcResult<M>>(IPC_CHANNELS.rpcRequest, { method, params })
+
+    if (!isReadMethod(method)) return send()
+
+    const key = `${method}:${JSON.stringify(params ?? null)}`
+    const existing = inFlight.get(key) as Promise<RpcResult<M>> | undefined
+    if (existing) return existing
+
+    const pending = send().finally(() => inFlight.delete(key))
+    inFlight.set(key, pending)
+    return pending
   }
 }
 
-contextBridge.exposeInMainWorld('gitwarren', api)
+const bridge: GitWarrenBridge = {
+  carrier,
+  shell: {
+    system: {
+      pickDirectory: () => invoke<string | null>(IPC_CHANNELS.systemPickDirectory),
+      revealPath: (path: string) => invoke<void>(IPC_CHANNELS.systemRevealPath, path),
+      appInfo: () => invoke<AppInfo>(IPC_CHANNELS.systemAppInfo),
+      editors: () => invoke<EditorList>(IPC_CHANNELS.systemEditors)
+    },
+    updates: {
+      getStatus: () => invoke<UpdateStatus>(IPC_CHANNELS.updatesGetStatus),
+      check: () => invoke<UpdateStatus>(IPC_CHANNELS.updatesCheck),
+      installNow: () => invoke<void>(IPC_CHANNELS.updatesInstallNow),
+      subscribe: (listener: (status: UpdateStatus) => void) => {
+        const handler = (_event: Electron.IpcRendererEvent, status: UpdateStatus): void =>
+          listener(status)
+        ipcRenderer.on(IPC_CHANNELS.updatesChanged, handler)
+        return () => ipcRenderer.off(IPC_CHANNELS.updatesChanged, handler)
+      }
+    },
+    navigation: {
+      onDeepLink: (listener: (hash: string) => void) => {
+        const handler = (_event: Electron.IpcRendererEvent, hash: string): void => listener(hash)
+        ipcRenderer.on(IPC_CHANNELS.navigationDeepLink, handler)
+        return () => ipcRenderer.off(IPC_CHANNELS.navigationDeepLink, handler)
+      }
+    },
+    pickAttachment: () => invoke<Attachment | null>(IPC_CHANNELS.attachmentsPick),
+    openInEditor: (input: OpenReviewFileInput) =>
+      invoke<void>(IPC_CHANNELS.reviewsOpenInEditor, input)
+  }
+}
+
+contextBridge.exposeInMainWorld('gitwarren', bridge)

--- a/src/renderer/src/features/comments/comment-composer.tsx
+++ b/src/renderer/src/features/comments/comment-composer.tsx
@@ -49,6 +49,7 @@ import { Markdown } from '@/components/markdown'
 import { Tabs, TabsList, TabsPanel, TabsTab } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import { Tooltip } from '@/components/ui/tooltip'
+import { api } from '@/lib/api'
 import { errorMessage } from '@/lib/errors'
 import { cn } from '@/lib/utils'
 import {
@@ -240,7 +241,7 @@ export function CommentComposer({
       try {
         const markdown: string[] = []
         for (const [index, file] of images.entries()) {
-          const attachment = await window.gitwarren.attachments.ingest({
+          const attachment = await api.attachments.ingest({
             bytes: await file.arrayBuffer(),
             originalName: file.name
           })
@@ -299,7 +300,7 @@ export function CommentComposer({
     setBusy(true)
     setError(null)
     try {
-      const attachment = await window.gitwarren.attachments.pick()
+      const attachment = await api.attachments.pick()
       if (attachment === null) return
       const selected = state.value.slice(state.selectionStart, state.selectionEnd).trim()
       const alt = selected.length > 0 ? selected : (attachment.originalName ?? 'image')

--- a/src/renderer/src/features/comments/use-comments.ts
+++ b/src/renderer/src/features/comments/use-comments.ts
@@ -1,17 +1,23 @@
 /**
  * Data access for review comments.
  *
- * Unlike the commit and diff reads next door, this one *is* revalidated on
- * focus, and that difference is deliberate. The git reads are expensive and
- * spawn processes, so the app waits to be asked. Comments are a single indexed
- * SQLite query against a database another process is actively writing to -
- * every agent working the review writes through the MCP server - so the cost of
- * checking is nil and the cost of not checking is reading a discussion that
- * moved on while the window was in the background.
+ * The read itself lives next door, in `useReviewThreads`: since M1 the
+ * discussion arrives as part of `reviews.open`, together with the review and
+ * its reviewed marks, so opening a review is one round trip rather than three.
+ * What is left here is the writing half.
+ *
+ * Unlike the commit and diff reads, the discussion *is* revalidated on focus
+ * and on an interval, and that difference is deliberate. The git reads are
+ * expensive and spawn processes, so the app waits to be asked. This one is an
+ * indexed SQLite query against a database another process is actively writing
+ * to - every agent working the review writes through the MCP server - so the
+ * cost of checking is nil and the cost of not checking is reading a discussion
+ * that moved on while the window was in the background.
  */
-import useSWR, { useSWRConfig } from 'swr'
+import { useSWRConfig } from 'swr'
 import { useCallback } from 'react'
-import { api, CACHE_KEYS, CACHE_PREFIXES } from '@/lib/api'
+import { api, CACHE_PREFIXES } from '@/lib/api'
+import { useReviewThreads } from '@/features/reviews/use-reviews'
 import type {
   Comment,
   CommentThread,
@@ -29,18 +35,8 @@ export interface CommentsState {
 const EMPTY: CommentThread[] = []
 
 export function useReviewComments(reviewId: number): CommentsState {
-  const { data, error, isLoading, mutate } = useSWR<CommentThread[], unknown>(
-    CACHE_KEYS.reviewComments(reviewId),
-    () => api.comments.list({ reviewId }),
-    {
-      // Agents write to the same database from their own processes; a stale
-      // thread list is the one thing this screen must not show.
-      revalidateOnFocus: true,
-      refreshInterval: 15_000
-    }
-  )
-
-  return { threads: data ?? EMPTY, error, isLoading, refresh: mutate }
+  const { data, error, isLoading, refresh } = useReviewThreads(reviewId)
+  return { threads: data ?? EMPTY, error, isLoading, refresh }
 }
 
 export interface CommentMutations {
@@ -51,21 +47,20 @@ export interface CommentMutations {
   setResolved: (threadId: number, resolved: boolean) => Promise<void>
 }
 
-export function useCommentMutations(reviewId: number): CommentMutations {
+export function useCommentMutations(): CommentMutations {
   const { mutate } = useSWRConfig()
 
   // A comment also bumps its review's `updatedAt`, which reorders every review
-  // list, so the whole family is revalidated rather than just this thread list.
+  // list, so the whole family is revalidated rather than just this review. The
+  // `review:` prefix now covers the thread list, which lives under that key.
   const revalidate = useCallback(
     () =>
       mutate(
         (key) =>
           typeof key === 'string' &&
-          (key === CACHE_KEYS.reviewComments(reviewId) ||
-            key.startsWith(CACHE_PREFIXES.reviews) ||
-            key.startsWith(CACHE_PREFIXES.review))
+          (key.startsWith(CACHE_PREFIXES.reviews) || key.startsWith(CACHE_PREFIXES.review))
       ),
-    [mutate, reviewId]
+    [mutate]
   )
 
   return {

--- a/src/renderer/src/features/reviews/review-conversation-tab.tsx
+++ b/src/renderer/src/features/reviews/review-conversation-tab.tsx
@@ -29,7 +29,7 @@ import { CommentComposer } from '../comments/comment-composer'
 import { CommentThreadCard } from '../comments/comment-thread-card'
 import { useCommentMutations, useReviewComments } from '../comments/use-comments'
 import { DiffSnippet } from './diff-snippet'
-import { useReviewDiff } from './use-reviews'
+import { DEFAULT_DIFF_CHANGES, useReviewDiff } from './use-reviews'
 import { findAnchorFile, isInlineAnchor, resolveAnchor } from '@shared/comment-anchors'
 import { threadSnippet, type ThreadSnippet } from '@shared/comment-snippets'
 import type { FileDiff } from '@shared/git'
@@ -78,10 +78,10 @@ function buildTimeline(threads: CommentThread[], files: FileDiff[] | undefined):
 
 export function ReviewConversationTab({ review, onEdit }: ReviewConversationTabProps) {
   const { threads, error, isLoading } = useReviewComments(review.id)
-  const mutations = useCommentMutations(review.id)
+  const mutations = useCommentMutations()
 
   // Matches the Files changed tab's default, so the two share one cached diff.
-  const { data: diff, isLoading: diffLoading } = useReviewDiff(review.id, 'all')
+  const { data: diff, isLoading: diffLoading } = useReviewDiff(review.id, DEFAULT_DIFF_CHANGES)
 
   const timeline = useMemo(() => buildTimeline(threads, diff?.files), [threads, diff?.files])
 

--- a/src/renderer/src/features/reviews/review-detail.tsx
+++ b/src/renderer/src/features/reviews/review-detail.tsx
@@ -1,12 +1,19 @@
 /**
  * The review screen: a header describing the comparison, and the three tabs.
  *
- * The commit read is issued here rather than only inside the commits tab. It is
- * cheap (`git log` plus a `git status` in the head worktree), it is shared with
- * the tab through SWR's cache under the same key, and it is what lets the
- * header say "this branch has uncommitted work" no matter which tab you land
- * on - which is the single most useful thing this app can tell you on arrival.
- * The diff stays lazy, because that one is not cheap.
+ * All three reads a review needs are issued here, side by side, and that is the
+ * whole reason opening a review costs one round trip rather than two. The
+ * commit read is cheap and is what lets the header say "this branch has
+ * uncommitted work" no matter which tab you land on. The diff is not cheap -
+ * but it used to be started by whichever tab was showing, which meant it could
+ * not begin until the review itself had come back and the tab had mounted. Over
+ * a network that wait is a whole round trip spent doing nothing, so the diff is
+ * asked for here, at mount, keyed on the review id alone.
+ *
+ * Both tabs open on the complete diff, so this is the same read they would have
+ * made; SWR hands it to them from the cache under the same key. Turning the
+ * files tab's "include uncommitted" switch asks for a second one, exactly as
+ * before.
  */
 import { useCallback, useMemo, useState } from 'react'
 import {
@@ -39,7 +46,13 @@ import { ReviewConversationTab } from './review-conversation-tab'
 import { ReviewFilesTab } from './review-files-tab'
 import { ReviewFormDialog } from './review-form-dialog'
 import { RemoveReviewDialog } from './remove-review-dialog'
-import { useReview, useReviewCommits, useReviewMutations } from './use-reviews'
+import {
+  DEFAULT_DIFF_CHANGES,
+  useReview,
+  useReviewCommits,
+  useReviewDiff,
+  useReviewMutations
+} from './use-reviews'
 import { isSelfReview } from '@shared/schemas'
 import type { CompareEndpoint } from '@shared/git'
 import type { Review } from '@shared/schemas'
@@ -68,9 +81,11 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
   const { data: review, error, isLoading } = useReview(reviewId)
   const { updateReview } = useReviewMutations()
   const commits = useReviewCommits(reviewId)
-  // Read here rather than inside the tab so the count is on the tab itself.
-  // It is one indexed query and it is polled, which matters because agents
-  // write into this review from their own processes while it is open.
+  // Started here so it does not wait for the review. Nothing on this screen
+  // reads the result - the tabs do, from the cache.
+  useReviewDiff(reviewId, DEFAULT_DIFF_CHANGES)
+  // Free: the discussion arrived with the review above, under the same key. It
+  // is read here so the unresolved count can sit on the tab itself.
   const { threads } = useReviewComments(reviewId)
 
   const [editing, setEditing] = useState(false)

--- a/src/renderer/src/features/reviews/review-files-tab.tsx
+++ b/src/renderer/src/features/reviews/review-files-tab.tsx
@@ -52,7 +52,12 @@ import { CompareErrorCard, NoWorktreeNotice, WorkingTreeBanner } from './compare
 import { fileDomId, lineDomId } from './dom-ids'
 import { DiffSnippet } from './diff-snippet'
 import { DiffStat, FileDiffCard, type AnchoredThread } from './diff-view'
-import { useEditors, useReviewDiff, useReviewedFiles } from './use-reviews'
+import {
+  DEFAULT_DIFF_CHANGES,
+  useEditors,
+  useReviewDiff,
+  useReviewedFiles
+} from './use-reviews'
 import { fileDiffDigest } from '@shared/diff-digest'
 import { findAnchorFile, isInlineAnchor, resolveAnchor } from '@shared/comment-anchors'
 import { threadSnippet } from '@shared/comment-snippets'
@@ -266,13 +271,13 @@ function useFocusScroll(focus: DiffFocus | undefined, ready: boolean): DiffFocus
 }
 
 export function ReviewFilesTab({ review, focus }: { review: Review; focus?: DiffFocus }) {
-  const [changes, setChanges] = useState<DiffChanges>('all')
+  const [changes, setChanges] = useState<DiffChanges>(DEFAULT_DIFF_CHANGES)
   const [treeOpen, setTreeOpen] = useStoredFlag('files-tree', true)
   const [editorId, setEditorId] = useStoredPreference('editor', null)
   const [openError, setOpenError] = useState<unknown>(null)
   const { data, error, isLoading, isRefreshing, refresh } = useReviewDiff(review.id, changes)
   const { threads } = useReviewComments(review.id)
-  const mutations = useCommentMutations(review.id)
+  const mutations = useCommentMutations()
   const editors = useEditors()
 
   const threadsByFile = useMemo(

--- a/src/renderer/src/features/reviews/use-reviews.ts
+++ b/src/renderer/src/features/reviews/use-reviews.ts
@@ -12,10 +12,11 @@
  * behind the user's back; the screens carry an explicit refresh button instead,
  * which is honest about when the app looks at the disk.
  */
-import useSWR, { useSWRConfig } from 'swr'
+import useSWR, { useSWRConfig, type SWRResponse } from 'swr'
 import { useCallback, useMemo, useState } from 'react'
 import { api, CACHE_KEYS, CACHE_PREFIXES } from '@/lib/api'
 import type { EditorList } from '@shared/api'
+import type { ReviewOpen } from '@shared/rpc'
 import type {
   DiffChanges,
   DiffFileSide,
@@ -26,6 +27,7 @@ import type {
   ReviewDiff
 } from '@shared/git'
 import type {
+  CommentThread,
   CreateReviewInput,
   Review,
   ReviewedFile,
@@ -80,12 +82,39 @@ export function useReviews(
   )
 }
 
-export function useReview(reviewId: number): ListState<ReviewWithRepository> {
-  return toState(
-    useSWR<ReviewWithRepository, unknown>(CACHE_KEYS.review(reviewId), () =>
-      api.reviews.get({ id: reviewId })
-    )
+/**
+ * A whole review in one read: the review itself, its discussion, and which of
+ * its files have been ticked off.
+ *
+ * One hook and one cache key behind all three, which is what makes opening a
+ * review a single round trip. Every consumer - the header, the conversation
+ * tab, the files tab - subscribes to the same key, so however many of them
+ * mount at once, SWR issues one request. Before M1 these were three keys and
+ * three calls, and the second and third were pure overhead over a network.
+ *
+ * Revalidated on focus and every fifteen seconds, because the discussion is in
+ * it: agents write to the same database from their own processes, and a stale
+ * thread list is the one thing this screen must not show. The review row and
+ * the marks come along for free - all three are indexed queries, and asking for
+ * them separately would cost a round trip each.
+ */
+function useReviewOpen(reviewId: number): SWRResponse<ReviewOpen, unknown> {
+  return useSWR<ReviewOpen, unknown>(
+    CACHE_KEYS.review(reviewId),
+    () => api.reviews.open({ id: reviewId }),
+    { revalidateOnFocus: true, refreshInterval: 15_000 }
   )
+}
+
+export function useReview(reviewId: number): ListState<ReviewWithRepository> {
+  const result = useReviewOpen(reviewId)
+  return toState({ ...result, data: result.data?.review })
+}
+
+/** The discussion. See `useReviewOpen` for why this is not a read of its own. */
+export function useReviewThreads(reviewId: number): ListState<CommentThread[]> {
+  const result = useReviewOpen(reviewId)
+  return toState({ ...result, data: result.data?.threads })
 }
 
 export function useReviewCommits(reviewId: number): ListState<ReviewCommits> {
@@ -97,6 +126,16 @@ export function useReviewCommits(reviewId: number): ListState<ReviewCommits> {
     )
   )
 }
+
+/**
+ * The diff a review opens on, and the one both tabs ask for first.
+ *
+ * Shared rather than written out three times, because the review screen starts
+ * this read before either tab exists (see `review-detail.tsx`). A tab that
+ * defaulted to a different setting would silently make that head start useless
+ * and cost the extra round trip it was there to save.
+ */
+export const DEFAULT_DIFF_CHANGES: DiffChanges = 'all'
 
 export function useReviewDiff(reviewId: number, changes: DiffChanges): ListState<ReviewDiff> {
   return toState(
@@ -220,12 +259,9 @@ export interface ReviewedFilesState {
  * and revalidates, which is the same read the screen already trusts.
  */
 export function useReviewedFiles(reviewId: number): ReviewedFilesState {
-  const { data, isLoading, mutate } = useSWR<ReviewedFile[], unknown>(
-    CACHE_KEYS.reviewedFiles(reviewId),
-    () => api.reviews.reviewedFiles({ reviewId })
-  )
+  const { data, isLoading, mutate } = useReviewOpen(reviewId)
 
-  const files = data ?? NO_REVIEWED_FILES
+  const files = data?.reviewedFiles ?? NO_REVIEWED_FILES
 
   const digests = useMemo(
     () => new Map(files.map((file) => [file.filePath, file.contentDigest])),
@@ -234,17 +270,29 @@ export function useReviewedFiles(reviewId: number): ReviewedFilesState {
 
   const setReviewed = useCallback(
     async (filePath: string, contentDigest: string | null) => {
-      const next = (current: ReviewedFile[] = NO_REVIEWED_FILES): ReviewedFile[] => {
-        const others = current.filter((file) => file.filePath !== filePath)
-        return contentDigest === null
-          ? others
-          : [...others, { reviewId, filePath, contentDigest, reviewedAt: new Date().toISOString() }]
+      // Nothing on screen to patch - the review has not arrived yet. Write, then
+      // let the ordinary read bring the mark back with everything else.
+      if (!data) {
+        await api.reviews.setFileReviewed({ reviewId, filePath, contentDigest })
+        await mutate()
+        return
+      }
+
+      // The marks live inside the opened review now, so the optimistic update
+      // replaces that one field and leaves the review and its threads alone.
+      const others = data.reviewedFiles.filter((file) => file.filePath !== filePath)
+      const next: ReviewOpen = {
+        ...data,
+        reviewedFiles:
+          contentDigest === null
+            ? others
+            : [...others, { reviewId, filePath, contentDigest, reviewedAt: new Date().toISOString() }]
       }
 
       await mutate(
         async () => {
           await api.reviews.setFileReviewed({ reviewId, filePath, contentDigest })
-          return next(data)
+          return next
         },
         { optimisticData: next, revalidate: false, rollbackOnError: true }
       )

--- a/src/renderer/src/global.d.ts
+++ b/src/renderer/src/global.d.ts
@@ -1,9 +1,13 @@
-import type { GitWarrenApi } from '@shared/api'
+import type { GitWarrenBridge } from '@shared/api'
 
 declare global {
   interface Window {
-    /** Exposed by the preload script. The renderer's only way out. */
-    gitwarren: GitWarrenApi
+    /**
+     * Exposed by the preload script. The renderer's only way out: a carrier
+     * and the Electron shell. The API the screens use is built on top of it in
+     * `lib/api.ts`.
+     */
+    gitwarren: GitWarrenBridge
   }
 }
 

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -1,11 +1,14 @@
 /**
- * The renderer's view of the bridge, plus the SWR cache keys.
+ * The renderer's view of the app, and the SWR cache keys.
  *
- * Everything the UI can do goes through `window.gitwarren`, which the preload
- * script installed. There is no fetch client and no API base URL - see the
- * README on why this app talks over IPC rather than a local HTTP server.
+ * `window.gitwarren` is no longer the API - it is a carrier plus the Electron
+ * shell (see `shared/api.ts`). The API is assembled here, on top of it, and
+ * that indirection is the whole of M1 as far as a screen is concerned: every
+ * object method below is one `carrier.request`, so the day a browser tab
+ * supplies a WebSocket carrier instead of the IPC one, nothing above this file
+ * changes. There is still no fetch client and no API base URL.
  */
-import type { GitWarrenApi } from '@shared/api'
+import type { GitWarrenApi, GitWarrenBridge } from '@shared/api'
 import type { DiffChanges } from '@shared/git'
 
 if (typeof window.gitwarren === 'undefined') {
@@ -14,7 +17,71 @@ if (typeof window.gitwarren === 'undefined') {
   )
 }
 
-export const api: GitWarrenApi = window.gitwarren
+const bridge: GitWarrenBridge = window.gitwarren
+const { carrier, shell } = bridge
+
+/**
+ * Ask once, for the life of the window.
+ *
+ * The app's version, where its database is, and which editors are installed do
+ * not change while it is running - the editor list is already probed once and
+ * cached in the main process. They were nonetheless being re-read on every
+ * navigation, because a component that unmounts and comes back asks again.
+ * Holding the promise rather than the value means even two callers racing on
+ * the first render share one call. See spike S5 in docs/across-hosts.md.
+ */
+function once<T>(read: () => Promise<T>): () => Promise<T> {
+  let pending: Promise<T> | undefined
+  return () => (pending ??= read())
+}
+
+export const api: GitWarrenApi = {
+  repositories: {
+    list: () => carrier.request('repositories.list', undefined),
+    get: (input) => carrier.request('repositories.get', input),
+    add: (input) => carrier.request('repositories.add', input),
+    update: (input) => carrier.request('repositories.update', input),
+    remove: (input) => carrier.request('repositories.remove', input),
+    refs: (input) => carrier.request('repositories.refs', input)
+  },
+  reviews: {
+    list: (input) => carrier.request('reviews.list', input),
+    open: (input) => carrier.request('reviews.open', input),
+    get: (input) => carrier.request('reviews.get', input),
+    create: (input) => carrier.request('reviews.create', input),
+    update: (input) => carrier.request('reviews.update', input),
+    remove: (input) => carrier.request('reviews.remove', input),
+    commits: (input) => carrier.request('reviews.commits', input),
+    diff: (input) => carrier.request('reviews.diff', input),
+    file: (input) => carrier.request('reviews.file', input),
+    image: (input) => carrier.request('reviews.image', input),
+    reviewedFiles: (input) => carrier.request('reviews.reviewedFiles', input),
+    setFileReviewed: (input) => carrier.request('reviews.setFileReviewed', input),
+    // Where the file is comes from whoever owns the review; opening it is the
+    // shell's job. The two halves are joined in the main process.
+    openInEditor: (input) => shell.openInEditor(input)
+  },
+  comments: {
+    list: (input) => carrier.request('comments.list', input),
+    createThread: (input) => carrier.request('comments.createThread', input),
+    reply: (input) => carrier.request('comments.reply', input),
+    update: (input) => carrier.request('comments.update', input),
+    remove: (input) => carrier.request('comments.remove', input),
+    setResolved: (input) => carrier.request('comments.setResolved', input)
+  },
+  attachments: {
+    ingest: (input) => carrier.request('attachments.ingest', input),
+    pick: () => shell.pickAttachment()
+  },
+  system: {
+    pickDirectory: () => shell.system.pickDirectory(),
+    revealPath: (path) => shell.system.revealPath(path),
+    appInfo: once(() => shell.system.appInfo()),
+    editors: once(() => shell.system.editors())
+  },
+  navigation: shell.navigation,
+  updates: shell.updates
+}
 
 /**
  * SWR cache keys.
@@ -26,10 +93,24 @@ export const api: GitWarrenApi = window.gitwarren
  */
 export const CACHE_KEYS = {
   repositories: 'repositories',
-  appInfo: 'app-info',
   repositoryRefs: (repositoryId: number) => `repository-refs:${repositoryId}`,
   reviews: (repositoryId?: number, status?: string) =>
     `reviews:${repositoryId ?? 'all'}:${status ?? 'any'}`,
+  /**
+   * A whole review, as `reviews.open` answers it: the review itself, its
+   * threads and its reviewed marks.
+   *
+   * One key for all three, and that is the point rather than a convenience. The
+   * three used to be three keys, which meant three fetches whenever a review
+   * was opened, three chances for one of them to be revalidated on its own, and
+   * three round trips once a carrier is a network. Now the review screen, the
+   * conversation tab and the files tab all subscribe to this one key, and SWR
+   * turns that into a single request no matter how many of them mount at once.
+   *
+   * The 15-second poll and the focus revalidation run against it too, so a
+   * refresh brings back the discussion, the marks and any change to the review
+   * itself together - one request where there used to be two.
+   */
   review: (reviewId: number) => `review:${reviewId}`,
   reviewCommits: (reviewId: number) => `review-commits:${reviewId}`,
   reviewDiff: (reviewId: number, changes: DiffChanges) => `review-diff:${reviewId}:${changes}`,
@@ -46,32 +127,22 @@ export const CACHE_KEYS = {
    */
   reviewImage: (reviewId: number, path: string, side: string, changes: DiffChanges) =>
     `review-image:${reviewId}:${changes}:${side}:${path}`,
-  /** Installed code editors. Probed once per run; see `main/editors.ts`. */
-  editors: 'editors',
   /**
-   * Comments are keyed per review and *not* per diff view. They are a plain
-   * database read, so the same list serves the conversation tab and both
-   * settings of the files tab's "include uncommitted" switch; only the anchor
-   * resolution differs between them, and that is computed in the component
-   * from whichever diff it is showing.
+   * The two reads that never change while the app runs. They keep keys so the
+   * components that show them keep a loading state, but the reads underneath
+   * are memoised in `api` above and happen at most once per window.
    */
-  reviewComments: (reviewId: number) => `review-comments:${reviewId}`,
-  /**
-   * Reviewed marks, keyed per review for the same reason as comments: they are
-   * a plain database read, and which of them still count is worked out in the
-   * component from whichever diff it is showing.
-   */
-  reviewedFiles: (reviewId: number) => `review-reviewed:${reviewId}`
+  appInfo: 'app-info',
+  editors: 'editors'
 } as const
 
 /** Prefixes used by the family-wide invalidation above. */
 export const CACHE_PREFIXES = {
   reviews: 'reviews:',
+  /** Covers the threads and the reviewed marks too - they live under this key. */
   review: 'review:',
   reviewCommits: 'review-commits:',
   reviewDiff: 'review-diff:',
   reviewFile: 'review-file:',
-  reviewImage: 'review-image:',
-  reviewComments: 'review-comments:',
-  reviewedFiles: 'review-reviewed:'
+  reviewImage: 'review-image:'
 } as const

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { SWRConfig } from 'swr'
 import { App } from './App'
+import { api } from './lib/api'
 import './index.css'
 
 /** Follow the OS appearance, and keep following it if the user switches. */
@@ -25,7 +26,7 @@ applyColourScheme()
  * the main process from a parsed route, so setting it here is not trusting the
  * link - see `main/deep-link.ts`.
  */
-window.gitwarren.navigation.onDeepLink((hash) => {
+api.navigation.onDeepLink((hash) => {
   window.location.hash = hash
 })
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,13 +1,24 @@
 /**
- * The contract between the main process and the renderer.
+ * The contract between the Electron shell and the renderer.
  *
- * Channel names and the shape of the bridge live here so the preload script and
- * the React code are typed from one declaration. The MCP server does not use
- * any of this - it talks to `core/services` directly - which is deliberate:
- * this file is transport, not behaviour.
+ * Two things live here, and the line between them is the one M1 drew.
+ *
+ * `GitWarrenApi` is what a screen sees: the whole app, grouped by object. Most
+ * of it is now one carrier call each (`shared/rpc.ts`), and `lib/api.ts` builds
+ * it. What is left in this file that is *not* a carrier call is the Electron
+ * shell - folder pickers, revealing a path, launching an editor, the updater,
+ * deep links. Those are capabilities of the machine the person is sitting at.
+ * They are not methods, they never travel to another host, and a browser tab in
+ * M3 will simply not have some of them.
+ *
+ * `GitWarrenBridge` is what the preload actually exposes: the carrier plus that
+ * shell surface, and nothing else.
+ *
+ * The MCP server uses none of this - it talks to `core/services` directly - and
+ * that is deliberate: this file is transport, not behaviour.
  */
-import type { SerializedAppError } from './errors.js'
 import type { FileContent, FileImage, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
+import type { AttachmentIngestParams, Carrier, ReviewOpen, RpcMethod } from './rpc.js'
 import type {
   AddRepositoryInput,
   Attachment,
@@ -43,6 +54,15 @@ import type {
 } from './schemas.js'
 
 export const IPC_CHANNELS = {
+  /**
+   * The carrier. One channel, every core method, `{method, params}` in and an
+   * `RpcOutcome` out - see `shared/rpc.ts`.
+   *
+   * The per-object channels below still answer, each a one-line delegation to
+   * the same dispatcher, so nothing that spoke to this app before M1 has
+   * stopped being spoken to. The renderer no longer uses them.
+   */
+  rpcRequest: 'rpc:request',
   repositoriesList: 'repositories:list',
   repositoriesGet: 'repositories:get',
   repositoriesAdd: 'repositories:add',
@@ -86,28 +106,66 @@ export const IPC_CHANNELS = {
 } as const
 
 /**
- * Errors cannot cross `ipcRenderer.invoke` intact - Electron stringifies them
- * and the code would be lost. Every handler returns this envelope instead, and
- * the preload script turns a failure back into a real `AppError` before the
- * renderer ever sees it.
+ * The channels that are one method by another name.
+ *
+ * Every one of these existed before M1 and still answers; each is now a
+ * one-line delegation to the dispatcher. They are a table rather than a list of
+ * registration calls so that `main/ipc.ts` and the test that checks none of
+ * them was dropped read the same thing.
+ *
+ * The renderer does not use them - it goes through `rpcRequest` - but a channel
+ * is a published surface, and removing one would be a change with no way to
+ * find out who noticed.
  */
-export type IpcResult<T> =
-  | { ok: true; data: T }
-  | { ok: false; error: SerializedAppError }
+export const CHANNEL_METHODS = {
+  [IPC_CHANNELS.repositoriesList]: 'repositories.list',
+  [IPC_CHANNELS.repositoriesGet]: 'repositories.get',
+  [IPC_CHANNELS.repositoriesAdd]: 'repositories.add',
+  [IPC_CHANNELS.repositoriesUpdate]: 'repositories.update',
+  [IPC_CHANNELS.repositoriesRemove]: 'repositories.remove',
+  [IPC_CHANNELS.repositoriesRefs]: 'repositories.refs',
+  [IPC_CHANNELS.reviewsList]: 'reviews.list',
+  [IPC_CHANNELS.reviewsGet]: 'reviews.get',
+  [IPC_CHANNELS.reviewsCreate]: 'reviews.create',
+  [IPC_CHANNELS.reviewsUpdate]: 'reviews.update',
+  [IPC_CHANNELS.reviewsRemove]: 'reviews.remove',
+  [IPC_CHANNELS.reviewsCommits]: 'reviews.commits',
+  [IPC_CHANNELS.reviewsDiff]: 'reviews.diff',
+  [IPC_CHANNELS.reviewsFile]: 'reviews.file',
+  [IPC_CHANNELS.reviewsImage]: 'reviews.image',
+  [IPC_CHANNELS.reviewsReviewedFiles]: 'reviews.reviewedFiles',
+  [IPC_CHANNELS.reviewsSetFileReviewed]: 'reviews.setFileReviewed',
+  [IPC_CHANNELS.commentsList]: 'comments.list',
+  [IPC_CHANNELS.commentsCreateThread]: 'comments.createThread',
+  [IPC_CHANNELS.commentsReply]: 'comments.reply',
+  [IPC_CHANNELS.commentsUpdate]: 'comments.update',
+  [IPC_CHANNELS.commentsRemove]: 'comments.remove',
+  [IPC_CHANNELS.commentsSetResolved]: 'comments.setResolved',
+  [IPC_CHANNELS.attachmentsIngest]: 'attachments.ingest'
+} as const satisfies Record<string, RpcMethod>
 
 /**
- * An image on its way into the store.
- *
- * A plain array of bytes rather than a Buffer or a Blob: the structured clone
- * used by `ipcRenderer.invoke` carries `number[]` and `ArrayBuffer` faithfully,
- * while Node's Buffer is not a thing the renderer has. The main process turns
- * it back into bytes on arrival.
+ * The channels the shell answers itself, because each one does something to
+ * this machine: puts a window in front of the person, launches a program, quits
+ * and reinstalls the app. None of them is a method, and none may become one.
  */
-export interface AttachmentIngestInput {
-  bytes: ArrayBuffer
-  /** Only ever used for display and default alt text; the format is sniffed. */
-  originalName?: string
-}
+export const SHELL_CHANNELS = [
+  IPC_CHANNELS.reviewsOpenInEditor,
+  IPC_CHANNELS.attachmentsPick,
+  IPC_CHANNELS.systemPickDirectory,
+  IPC_CHANNELS.systemRevealPath,
+  IPC_CHANNELS.systemEditors,
+  IPC_CHANNELS.systemAppInfo,
+  IPC_CHANNELS.updatesGetStatus,
+  IPC_CHANNELS.updatesCheck,
+  IPC_CHANNELS.updatesInstallNow
+] as const
+
+/** Main -> renderer pushes. Nothing handles these; they are sent. */
+export const PUSH_CHANNELS = [
+  IPC_CHANNELS.updatesChanged,
+  IPC_CHANNELS.navigationDeepLink
+] as const
 
 export interface AppInfo {
   version: string
@@ -178,6 +236,12 @@ export interface GitWarrenApi {
   }
   reviews: {
     list(input: ListReviewsInput): Promise<Review[]>
+    /**
+     * Everything the review screen needs, in one call: the review, its threads
+     * and its reviewed marks. What the screens actually use - `get`, `list` and
+     * `reviewedFiles` remain for callers that want one of the three on its own.
+     */
+    open(input: GetReviewInput): Promise<ReviewOpen>
     get(input: GetReviewInput): Promise<ReviewWithRepository>
     create(input: CreateReviewInput): Promise<Review>
     update(input: UpdateReviewInput): Promise<Review>
@@ -236,7 +300,7 @@ export interface GitWarrenApi {
    * draws the real image before the comment has been submitted.
    */
   attachments: {
-    ingest(input: AttachmentIngestInput): Promise<Attachment>
+    ingest(input: AttachmentIngestParams): Promise<Attachment>
     /** Opens the native image picker and ingests the choice. Null if cancelled. */
     pick(): Promise<Attachment | null>
   }
@@ -271,4 +335,43 @@ export interface GitWarrenApi {
     /** Returns an unsubscribe function. */
     subscribe(listener: (status: UpdateStatus) => void): () => void
   }
+}
+
+/**
+ * What the preload script exposes on `window`.
+ *
+ * The carrier, and the handful of things only this shell can do. Deliberately
+ * not `GitWarrenApi`: that one is assembled in the renderer, on top of this, so
+ * that the day a browser tab supplies a WebSocket carrier instead, the screens
+ * above it do not change at all.
+ */
+export interface GitWarrenBridge {
+  /** Every core method, in one function. See `shared/rpc.ts`. */
+  carrier: Carrier
+  shell: ShellApi
+}
+
+/**
+ * The Electron-only surface.
+ *
+ * Each of these does something to *this* machine: puts a window in front of the
+ * user, launches a program, quits and reinstalls the app. None of them is a
+ * method on the dispatcher, and none of them may become one - a request that
+ * could start a process on a host across the network would make this a very
+ * different piece of software. See the note in `core/rpc/dispatcher.ts`.
+ */
+export interface ShellApi {
+  system: GitWarrenApi['system']
+  updates: GitWarrenApi['updates']
+  navigation: GitWarrenApi['navigation']
+  /** Native picker, then straight into `attachments.ingest`. */
+  pickAttachment(): Promise<Attachment | null>
+  /**
+   * Ask the owning host where the file is, then open it here.
+   *
+   * Two halves that must not be merged: *which* file on disk is review
+   * knowledge and belongs to whoever owns the review, while launching an
+   * application is a capability of the machine the person is sitting at.
+   */
+  openInEditor(input: OpenReviewFileInput): Promise<void>
 }

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -1,0 +1,260 @@
+/**
+ * The message protocol: requests, responses and events.
+ *
+ * One protocol, several carriers. Today the only carrier is Electron IPC and
+ * everything runs in one process, so this file can look like ceremony around a
+ * function call. It is not: the same three message shapes have to survive a
+ * child-process pipe, `wsl.exe`, `ssh` and a WebSocket without changing, and
+ * the way to make sure of that is to write them down once, here, where the
+ * renderer, the main process, the daemon and the tests all read them from. See
+ * docs/across-hosts.md.
+ *
+ * Plain types and two small functions - no Node, no Electron, no zod. The
+ * renderer imports this module too, and a carrier is allowed to be nothing more
+ * than "put this object in, get that object out".
+ *
+ * Validation is deliberately absent. Every method's params are re-parsed by the
+ * service that answers it, with the zod schema in `schemas.ts`, which is the
+ * check that matters; a second one here would be a second place to keep in step
+ * and a second opinion about what a valid review is.
+ */
+import { deserializeAppError, type SerializedAppError } from './errors.js'
+import type { FileContent, FileImage, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
+import type {
+  AddRepositoryInput,
+  Attachment,
+  Comment,
+  CommentThread,
+  CreateReviewInput,
+  CreateThreadInput,
+  GetRepositoryInput,
+  GetReviewInput,
+  ListCommentsInput,
+  ListReviewedFilesInput,
+  ListReviewsInput,
+  RemoveCommentInput,
+  RemoveRepositoryInput,
+  RemoveReviewInput,
+  ReplyToThreadInput,
+  Repository,
+  RepositoryRefsInput,
+  RepositoryWithGitState,
+  Review,
+  ReviewCommitsInput,
+  ReviewDiffInput,
+  ReviewedFile,
+  ReviewFileInput,
+  ReviewImageInput,
+  ReviewWithRepository,
+  SetFileReviewedInput,
+  SetThreadResolvedInput,
+  UpdateCommentInput,
+  UpdateRepositoryInput,
+  UpdateReviewInput
+} from './schemas.js'
+
+/**
+ * Bumped when a change would make an older peer misread a message.
+ *
+ * Adding a method or a field is not such a change: an unknown method comes back
+ * as an error the caller can read, and unknown fields are ignored. The constant
+ * is here now so that M4's handshake has something to exchange, rather than
+ * having to invent one under time pressure.
+ */
+export const RPC_PROTOCOL_VERSION = 1
+
+export interface RpcRequest<M extends RpcMethod = RpcMethod> {
+  /** Unique per connection. Answers may come back in any order. */
+  id: number
+  method: M
+  params?: RpcParams<M>
+}
+
+/**
+ * How a call turned out: exactly one of `result` and `error`.
+ *
+ * `SerializedAppError` rather than a protocol error type of its own. The code
+ * vocabulary in `errors.ts` is already what every surface speaks, field errors
+ * included, and a second one here would mean translating between them at every
+ * carrier. A failed request carries exactly what a thrown `AppError` carried
+ * before there was a wire to put it on.
+ *
+ * Separate from `RpcResponse` because not every carrier needs the id. Electron's
+ * `invoke` pairs a call with its answer itself, so the IPC carrier sends an
+ * outcome and nothing else; a byte stream has to say which request it is
+ * answering, and adds one.
+ */
+export type RpcOutcome<T = unknown> = { result: T } | { error: SerializedAppError }
+
+export type RpcResponse<T = unknown> = RpcOutcome<T> & { id: number }
+
+/**
+ * A push from whoever owns the data. Carries no id: nobody asked for it.
+ *
+ * Nothing emits one yet - the renderer polls, and M6 is where events replace
+ * that - but the shape belongs next to the other two, because a carrier reading
+ * a stream has to be able to tell an event from an answer.
+ */
+export interface RpcEvent<T = unknown> {
+  event: string
+  data: T
+}
+
+export type RpcMessage = RpcRequest | RpcResponse | RpcEvent
+
+/** Discriminators, for a carrier reading a stream of mixed messages. */
+export function isRpcEvent(message: RpcMessage): message is RpcEvent {
+  return 'event' in message
+}
+
+export function isRpcResponse(message: RpcMessage): message is RpcResponse {
+  return 'id' in message && !('method' in message)
+}
+
+/**
+ * Everything the core can be asked to do, and nothing else.
+ *
+ * What is *not* here is as deliberate as what is. Opening a folder picker,
+ * revealing a path, launching an editor, checking for an update: those are
+ * things a shell does on the machine the person is sitting at, and none of them
+ * may ever become something a remote host is asked to perform. They stay
+ * outside this map - see `GitWarrenApi` in `api.ts` for where they live.
+ *
+ * Object-centric on purpose. Every method names a review or a repository by id,
+ * never a raw ref, and a path only ever means "a file of this review". Whoever
+ * answers resolves refs itself, so a caller on another machine cannot ask for a
+ * diff between two arbitrary strings.
+ */
+export interface RpcMethods {
+  'repositories.list': { params: void; result: RepositoryWithGitState[] }
+  'repositories.get': { params: GetRepositoryInput; result: RepositoryWithGitState }
+  'repositories.add': { params: AddRepositoryInput; result: Repository }
+  'repositories.update': { params: UpdateRepositoryInput; result: Repository }
+  'repositories.remove': { params: RemoveRepositoryInput; result: { id: number } }
+  'repositories.refs': { params: RepositoryRefsInput; result: RepositoryRefs }
+
+  'reviews.list': { params: ListReviewsInput; result: Review[] }
+  /** The coarse one. See `ReviewOpen`. */
+  'reviews.open': { params: GetReviewInput; result: ReviewOpen }
+  'reviews.get': { params: GetReviewInput; result: ReviewWithRepository }
+  'reviews.create': { params: CreateReviewInput; result: Review }
+  'reviews.update': { params: UpdateReviewInput; result: Review }
+  'reviews.remove': { params: RemoveReviewInput; result: { id: number } }
+  'reviews.commits': { params: ReviewCommitsInput; result: ReviewCommits }
+  'reviews.diff': { params: ReviewDiffInput; result: ReviewDiff }
+  'reviews.file': { params: ReviewFileInput; result: FileContent }
+  'reviews.image': { params: ReviewImageInput; result: FileImage }
+  /**
+   * Where a file of this review is on disk, on the host that owns it.
+   *
+   * A method rather than a main-process detail, because of who will have to
+   * ask. Launching an editor is the shell's job, but only the owning host knows
+   * whether the head branch is checked out somewhere other than the repository
+   * path - so the shell asks, and then launches.
+   */
+  'reviews.filePath': { params: ReviewFileInput; result: string }
+  'reviews.reviewedFiles': { params: ListReviewedFilesInput; result: ReviewedFile[] }
+  'reviews.setFileReviewed': { params: SetFileReviewedInput; result: ReviewedFile | null }
+
+  'comments.list': { params: ListCommentsInput; result: CommentThread[] }
+  'comments.createThread': { params: CreateThreadInput; result: CommentThread }
+  'comments.reply': { params: ReplyToThreadInput; result: Comment }
+  'comments.update': { params: UpdateCommentInput; result: Comment }
+  'comments.remove': { params: RemoveCommentInput; result: { id: number; threadRemoved: boolean } }
+  'comments.setResolved': { params: SetThreadResolvedInput; result: CommentThread }
+
+  'attachments.ingest': { params: AttachmentIngestParams; result: Attachment }
+}
+
+export type RpcMethod = keyof RpcMethods
+export type RpcParams<M extends RpcMethod> = RpcMethods[M]['params']
+export type RpcResult<M extends RpcMethod> = RpcMethods[M]['result']
+
+/**
+ * Everything needed to put a review on screen, in one answer.
+ *
+ * Three reads that used to be three round trips: the review with its
+ * repository, the discussion, and which files have been ticked off. All three
+ * are indexed SQLite queries, all three are wanted the instant a review is
+ * opened, and not one of them is useful without the others - so over a network
+ * they were three waits for no benefit. See spike S5 in docs/across-hosts.md.
+ *
+ * The diff and the commit list stay separate. They are the expensive half, they
+ * are refreshed on their own schedule, and they already run in parallel with
+ * this one.
+ */
+export interface ReviewOpen {
+  review: ReviewWithRepository
+  /** Threads as stored, unanchored - see `comments.list`. */
+  threads: CommentThread[]
+  reviewedFiles: ReviewedFile[]
+}
+
+/**
+ * An image on its way into the store.
+ *
+ * Bytes rather than a path: the renderer has no filesystem, so a pasted or
+ * dropped image has to travel. `ArrayBuffer` survives Electron's structured
+ * clone; `number[]` is what a JSON carrier will turn it into. Whoever answers
+ * accepts either.
+ */
+export interface AttachmentIngestParams {
+  bytes: ArrayBuffer | number[]
+  /** Only ever used for display and default alt text; the format is sniffed. */
+  originalName?: string
+}
+
+/**
+ * The methods that only read.
+ *
+ * Two identical reads in flight at once are the same read, so a carrier may
+ * answer both from one round trip. Two identical writes are two writes and must
+ * never be folded into one - which is why this is a list someone maintains
+ * rather than a guess made from the method name.
+ */
+export const READ_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
+  'repositories.list',
+  'repositories.get',
+  'repositories.refs',
+  'reviews.list',
+  'reviews.open',
+  'reviews.get',
+  'reviews.commits',
+  'reviews.diff',
+  'reviews.file',
+  'reviews.image',
+  'reviews.filePath',
+  'reviews.reviewedFiles',
+  'comments.list'
+])
+
+export function isReadMethod(method: string): boolean {
+  return READ_METHODS.has(method as RpcMethod)
+}
+
+/**
+ * A way to reach whoever answers. The whole point of the exercise.
+ *
+ * One function. Everything M2 through M5 adds - a child-process pipe, a
+ * WebSocket, `wsl.exe`, `ssh` - is another implementation of this interface,
+ * and nothing above it has to know which one it got. A carrier is responsible
+ * for delivery and for turning a returned `error` back into a thrown
+ * `AppError`; it is responsible for nothing else, and in particular it never
+ * inspects `params` or decides what a method means.
+ */
+export interface Carrier {
+  request<M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>>
+}
+
+/**
+ * Unwrap an outcome, or throw the error it carries.
+ *
+ * Shared so that every carrier fails the same way: a `NOT_FOUND` from a daemon
+ * over `ssh` has to reach a React component as the same `AppError` a local call
+ * would have thrown, or the screens would need a second set of error handling
+ * for remote hosts.
+ */
+export function resultOf<T>(outcome: RpcOutcome<T>): T {
+  if ('error' in outcome) throw deserializeAppError(outcome.error)
+  return outcome.result
+}


### PR DESCRIPTION
Milestone M1 from [docs/across-hosts.md](docs/across-hosts.md). No visible
change; opening a review costs one round trip instead of two.

## What moved

**`src/shared/rpc.ts`** — the three message shapes (request, response, event)
and the method list. Object-centric: every method names a review or a
repository by id, never a raw ref, and a path only ever means "a file of this
review". Errors keep travelling as `SerializedAppError`, so codes and field
errors survive a carrier and a form on the far side of an `ssh` pipe can still
put a message under the right input.

**`src/core/rpc/dispatcher.ts`** — the only place that maps a method to a
service. Two properties moved with it, and both are stated at the top of the
file because losing either would be quiet:

- *It is the human surface.* Every comment write passes `HUMAN_AUTHOR`, because
  the only way to reach a dispatcher is for someone to be driving a GitWarren
  window. Agents do not come through it at all — the MCP server still imports
  the services directly with an author derived from its handshake. The actor
  stays a property of the boundary rather than a field a caller can set.
- *It has no capabilities.* It reads git and SQLite. It cannot open a dialog,
  reveal a path or launch a process, because in M4 the far end of a carrier is
  a daemon on another machine.

**`src/main/ipc.ts`** — the carrier, plus the Electron shell that was always
going to stay here (pickers, reveal, editor launch, updater). Every channel
that existed before M1 still answers, each a one-line delegation to the
dispatcher, registered from a table in `shared/api.ts` that a test checks
nothing fell out of.

**The renderer** goes through one `rpc:request` channel. The preload supplies
the `Carrier`; `renderer/src/lib/api.ts` assembles `GitWarrenApi` on top of it,
so the day a browser tab supplies a WebSocket carrier instead, no screen
changes. The preload also coalesces identical *reads* that are in flight at the
same moment — SWR does that for one renderer, and M3's and M4's carriers will
have callers that are not SWR. Writes are never coalesced; the list of methods
that may be is in `shared/rpc.ts`, and a test asserts no write is on it.

## The three things S5 asked for

| | Before | After |
| --- | --- | --- |
| Review → conversation tab | 4 calls, depth 2 | **3 calls, depth 1** |
| Review files tab, cold load | 7 calls, depth 2 | **5 calls, depth 1** |
| Four navigations after first paint | 14 calls | **7 calls** |
| of which `system:appInfo` | 2 | **0** |
| of which `system:editors` | 2 | **1** |

- `reviews.open(id)` folds `reviews:get`, `comments:list` and `reviewedFiles`
  into one answer, and the three hooks that used to hold three cache keys now
  share the one it lands under — so however many of them mount at once, SWR
  issues a single request. `commits` and `diff` stay their own calls.
- The diff is issued by the review screen at mount rather than by whichever tab
  is showing. It used to wait for the review to come back before a tab existed
  to ask for it, which is exactly the wait a network multiplies. `reviews.open`,
  `reviews.commits` and `reviews.diff` now start within 6 ms of each other.
- `system.appInfo` and `system.editors` are memoised for the life of the window
  — the promise, not the value, so two callers racing on the first render share
  one call.

## One correction to S5

S5's "duplicated wave — the same SWR keys fetched twice within 45 ms" was the
spike script, not the app. It set the location hash and *then* reloaded, so the
screen mounted twice, once on the hashchange and once on the new document.
Re-measured against the pre-M1 build with the helper fixed — it now navigates
for real — the cold review load is seven calls with nothing duplicated. The
script is fixed in this PR and the amendment is written under S5 in the doc, so
the next spike does not inherit the same trap. The other two findings were real
and are confirmed by the numbers above.

## Verified

- `npm run lint`, `npm run typecheck`, `npm test` — 297 pass, 20 of them new:
  16 contract tests driving the dispatcher against temp repos (these become the
  tests for every carrier), and 4 accounting for the IPC channels.
- Re-measured with `GITWARREN_TRACE_IPC=1` against the seeded demo database,
  both builds, driven over CDP. Tracing now covers the shell channels too, so
  the count means what it did before.
- UI checked over CDP with a scratch data dir and `--user-data-dir`: all three
  tabs render, a reviewed tick survives leaving the review and coming back — a
  real read of the composite endpoint, so the optimistic patch matched what was
  written — and a comment typed into the app is stored as the person's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7EK3hgix4Yshr7mow3SDp
