### PR TITLE
Daemon tarballs as release assets, and 0.1.7-beta.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,3 +248,61 @@ jobs:
             release/*/*.blockmap
           if-no-files-found: ignore
           retention-days: 14
+
+  # The self-contained daemon, for hosts that have no GitWarren and no Node —
+  # a VPS, a WSL distro, someone else's Linux box. Proved in spike S3; see
+  # scripts/build-daemon-tarball.mjs for what goes in one.
+  #
+  # A job of its own rather than a fourth entry in the matrix above, because it
+  # shares almost nothing with the platform builds: no electron-builder, no
+  # code signing, no update manifest, and one runner produces *both*
+  # architectures — better-sqlite3 ships prebuilds for each, so nothing is
+  # compiled and nothing needs a matching host. Putting it in the matrix would
+  # mean an `if:` on every signing step.
+  daemon:
+    name: Daemon tarballs (linux x64 + arm64)
+    needs: draft
+    runs-on: ubuntu-latest
+    # Same reasoning as the matrix: a failure here should not throw away
+    # installers that already uploaded to the draft.
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      # Both bundles, and only the bundles — the renderer and the Electron main
+      # process have no business in a tarball for a machine with no screen.
+      - run: npm run build:mcp
+      - run: npm run build:daemon
+
+      - name: Build the tarballs
+        run: |
+          node scripts/build-daemon-tarball.mjs linux-x64
+          node scripts/build-daemon-tarball.mjs linux-arm64
+
+      # Into the same draft the platform jobs upload into. `--clobber` so that
+      # re-running against an existing tag replaces the assets rather than
+      # failing on a name that is already taken.
+      - name: Upload into the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: gh release upload "$TAG" out/daemon-tarball/*.tar.gz --clobber
+
+      - name: Upload as a workflow artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daemon-tarballs
+          path: out/daemon-tarball/*.tar.gz
+          if-no-files-found: ignore
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -980,8 +980,7 @@ From a source checkout, `npm run mcp:dev` runs the same server against your dev
 database.
 
 The app does not need to be running for the MCP server to work — both open the
-same database independently, and since 0.1.7 an agent gets a working `guiUrl`
-either way.
+same database independently, and an agent gets a working `guiUrl` either way.
 
 ---
 
@@ -1033,6 +1032,7 @@ npm run package:dir    # unpacked app only, much faster
 | Windows | `GitWarren-<v>-x64.exe`, `-arm64.exe` (NSIS), `.blockmap` each, `latest.yml` |
 | macOS | `-arm64.dmg`, `-x64.dmg`, `-arm64.zip`, `-x64.zip`, `.blockmap` each, `latest-mac.yml` |
 | Linux | `-x64.AppImage`, `-arm64.AppImage`, `latest-linux.yml` |
+| Any host | `gitwarren-daemon-<v>-linux-x64.tar.gz`, `-linux-arm64.tar.gz` |
 
 The `.blockmap` files are what make updates differential: electron-updater
 compares block hashes with the installed version and downloads only the changed
@@ -1041,6 +1041,19 @@ ranges.
 The macOS **zip is required** — electron-updater reads the zip, not the dmg.
 Dropping that target still produces a working installer but silently breaks
 auto-update.
+
+The **daemon tarballs** are not installers and electron-updater ignores them.
+Each carries a Node binary, the daemon and MCP bundles, the one matching
+`better_sqlite3.node` and the migrations — about 44 MB, and enough to run
+GitWarren's core on a Linux box with nothing installed on it. They are built by
+the `daemon` job in `release.yml` from `scripts/build-daemon-tarball.mjs`, on
+one runner for both architectures, and nothing in them is compiled.
+
+Their **file names are a contract**. A GitWarren installing a daemon on a
+remote host runs `uname -sm` there, maps the answer to `linux-x64` or
+`linux-arm64`, and fetches `gitwarren-daemon-<version>-<target>.tar.gz` from
+the release by URL — one request, no listing and no search. Renaming them
+breaks that.
 
 Cross-building for every platform from one machine is not reliable (Windows
 code signing and macOS notarization both need their own host). Run the release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitwarren",
-  "version": "0.1.6",
+  "version": "0.1.7-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitwarren",
-      "version": "0.1.6",
+      "version": "0.1.7-beta.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitwarren",
   "productName": "GitWarren",
-  "version": "0.1.6",
+  "version": "0.1.7-beta.1",
   "description": "Desktop app for doing local-only code reviews",
   "author": {
     "name": "Klarluft B.V.",

--- a/scripts/build-daemon-tarball.mjs
+++ b/scripts/build-daemon-tarball.mjs
@@ -1,0 +1,175 @@
+/**
+ * The self-contained daemon tarball, as a release asset.
+ *
+ * Promoted from `scripts/spikes/s3-daemon-tarball.mjs`, which proved the idea
+ * on 10 September 2026: a Node binary, the bundles, the one matching
+ * `better_sqlite3.node` and the migrations, in a tarball that runs on a Linux
+ * box with nothing installed. See spike S3 in docs/across-hosts.md.
+ *
+ * The spike predated the daemon and carried only the MCP server. This carries
+ * both, because the two things a remote host has to be able to do are answer a
+ * GitWarren on another machine (`serve.cjs`, over a pipe) and be reached by the
+ * agent working next to the code (`server.cjs`, over stdio) - and rule 6 says
+ * those are different processes with different callers.
+ *
+ * Nothing is compiled. better-sqlite3 ships prebuilds for both Linux
+ * architectures, so a tarball for either can be built from any machine that can
+ * run `npm ci` - which is what lets one ubuntu runner produce both.
+ *
+ *   npm run build:mcp && npm run build:daemon
+ *   node scripts/build-daemon-tarball.mjs linux-x64
+ *   node scripts/build-daemon-tarball.mjs linux-arm64
+ *
+ * Prove one in a container with no Node (Docker calls x64 "amd64"):
+ *
+ *   printf '{"id":1,"method":"repositories.list"}\n' | docker run --rm -i \
+ *     --platform linux/arm64 -v "$PWD/out/daemon-tarball:/t:ro" ubuntu:24.04 \
+ *     sh -c 'tar xzf /t/gitwarren-daemon-*-linux-arm64.tar.gz -C /opt &&
+ *            HOME=/root /opt/gitwarren-daemon/bin/gitwarren serve --stdio'
+ */
+import {
+  chmodSync,
+  cpSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { pipeline } from 'node:stream/promises'
+import { execFileSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { dirname, join, resolve } from 'node:path'
+
+const target = process.argv[2]
+if (!/^linux-(x64|arm64)$/.test(target ?? '')) {
+  console.error('usage: node scripts/build-daemon-tarball.mjs linux-x64|linux-arm64')
+  process.exit(2)
+}
+
+const root = resolve(import.meta.dirname, '..')
+const version = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version
+
+/**
+ * The Node version to embed.
+ *
+ * Read from `.nvmrc` so the tarball and CI cannot drift apart: a daemon built
+ * against a different Node major from the one the bundles were built for is
+ * exactly the kind of mismatch that shows up as a native-addon error on
+ * somebody else's machine and nowhere else.
+ */
+const nodeVersion = `v${readFileSync(join(root, '.nvmrc'), 'utf8').trim()}`
+
+const bundles = [
+  { from: join(root, 'out', 'daemon', 'serve.cjs'), to: 'serve.cjs', script: 'build:daemon' },
+  { from: join(root, 'out', 'mcp', 'server.cjs'), to: 'server.cjs', script: 'build:mcp' }
+]
+
+for (const bundle of bundles) {
+  if (!existsSync(bundle.from)) {
+    console.error(`${bundle.from} is missing - run \`npm run ${bundle.script}\` first`)
+    process.exit(2)
+  }
+}
+
+const work = join(root, 'out', 'daemon-tarball', 'work', target)
+const stage = join(work, 'gitwarren-daemon')
+rmSync(work, { recursive: true, force: true })
+mkdirSync(join(stage, 'bin'), { recursive: true })
+mkdirSync(join(stage, 'lib'), { recursive: true })
+
+// 1. Node itself, from the official distribution. Cached across runs.
+const nodeArchive = join(root, 'out', 'daemon-tarball', `node-${nodeVersion}-${target}.tar.xz`)
+if (!existsSync(nodeArchive)) {
+  mkdirSync(join(root, 'out', 'daemon-tarball'), { recursive: true })
+  const url = `https://nodejs.org/dist/${nodeVersion}/node-${nodeVersion}-${target}.tar.xz`
+  console.log(`downloading ${url}`)
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`${url}: ${response.status}`)
+  await pipeline(response.body, createWriteStream(nodeArchive))
+}
+execFileSync('tar', [
+  'xJf',
+  nodeArchive,
+  '-C',
+  work,
+  '--strip-components=2',
+  `node-${nodeVersion}-${target}/bin/node`
+])
+cpSync(join(work, 'node'), join(stage, 'bin', 'node'))
+chmodSync(join(stage, 'bin', 'node'), 0o755)
+
+// 2. The bundles, the addon and the migrations.
+for (const bundle of bundles) cpSync(bundle.from, join(stage, 'lib', bundle.to))
+
+// Resolved rather than assumed to be at `<root>/node_modules`. npm hoists, a
+// git worktree has no `node_modules` of its own and reaches the checkout's, and
+// both of those are ordinary ways to run this script - so ask Node where the
+// package is instead of guessing, and fail with the resolver's own message when
+// it is genuinely absent.
+const sqliteRoot = dirname(createRequire(import.meta.url).resolve('better-sqlite3/package.json'))
+
+const prebuild = join(sqliteRoot, 'prebuilds', `${target}.node`)
+if (!existsSync(prebuild)) throw new Error(`no better-sqlite3 prebuild for ${target} at ${prebuild}`)
+// Both bundles do `require('better-sqlite3')`, whose lib/binding.js looks for a
+// prebuild at prebuilds/<platform>-<arch>.node relative to the package, which
+// is exactly how it ships in node_modules - so the package is reproduced with
+// only the one prebuild that matters.
+const pkg = join(stage, 'lib', 'node_modules', 'better-sqlite3')
+mkdirSync(join(pkg, 'prebuilds'), { recursive: true })
+cpSync(prebuild, join(pkg, 'prebuilds', `${target}.node`))
+cpSync(join(sqliteRoot, 'lib'), join(pkg, 'lib'), { recursive: true })
+cpSync(join(sqliteRoot, 'package.json'), join(pkg, 'package.json'))
+cpSync(join(root, 'drizzle'), join(stage, 'drizzle'), { recursive: true })
+
+/**
+ * Outside Electron there is no `resourcesPath` and no project root to walk up
+ * to, so the migrations folder has to be named explicitly. Both launchers do
+ * it the same way, from their own location, so the directory can be unpacked
+ * anywhere.
+ */
+const preamble =
+  '#!/bin/sh\n' +
+  'here="$(cd "$(dirname "$0")/.." && pwd)"\n' +
+  'export GITWARREN_MIGRATIONS_DIR="$here/drizzle"\n'
+
+// 3. The launcher an agent config points at. The same name the tray app
+//    maintains at ~/.gitwarren/bin/gitwarren-mcp, so the one-sentence agent
+//    prompt reads identically on a laptop and on a VPS.
+writeFileSync(
+  join(stage, 'bin', 'gitwarren-mcp'),
+  preamble + 'exec "$here/bin/node" "$here/lib/server.cjs" "$@"\n'
+)
+chmodSync(join(stage, 'bin', 'gitwarren-mcp'), 0o755)
+
+// 4. The launcher a GitWarren on another machine spawns.
+//
+//    One subcommand, because one is all there is: M4 spawns
+//    `~/.gitwarren/bin/gitwarren serve --stdio` over ssh, and that line should
+//    work against this tarball rather than against a name invented later. The
+//    rest of the CLI - `open`, `service install` - is M3's to design, and this
+//    says so rather than guessing at it.
+writeFileSync(
+  join(stage, 'bin', 'gitwarren'),
+  preamble +
+    'if [ "$1" != "serve" ]; then\n' +
+    '  echo "usage: gitwarren serve --stdio" >&2\n' +
+    '  exit 2\n' +
+    'fi\n' +
+    'shift\n' +
+    'exec "$here/bin/node" "$here/lib/serve.cjs" "$@"\n'
+)
+chmodSync(join(stage, 'bin', 'gitwarren'), 0o755)
+
+// 5. Pack.
+//
+//    The name is the contract. M4's installer runs `uname -sm` on a host,
+//    maps it to one of these two targets, and fetches
+//    `gitwarren-daemon-<version>-<target>.tar.gz` from the release by URL -
+//    one request, no listing and no search - so this string is not free to
+//    change without changing that.
+const out = join(root, 'out', 'daemon-tarball', `gitwarren-daemon-${version}-${target}.tar.gz`)
+execFileSync('tar', ['czf', out, '-C', work, 'gitwarren-daemon'])
+const size = execFileSync('du', ['-h', out], { encoding: 'utf8' }).split('\t')[0]
+console.log(`${out} (${size})`)


### PR DESCRIPTION
M0, M1 and M2 are all merged and unreleased — `v0.1.6` is from 8 September. This adds the daemon tarball to the release pipeline and bumps to `0.1.7-beta.1` so there are real artifacts to verify M2 against.

**Nothing gets published.** The tag builds the usual draft; `release.yml` has never auto-published, and `updater.ts` sets no channel so electron-updater's `allowPrerelease` defaults to false — no existing install can see a beta even if the draft were published by accident.

## Why a beta now

Three of M2's code paths have never run on the platform they target, and two of them cannot be tested without a packaged build:

- the Windows `Run`-registry login item, and `--hidden` in argv
- the Linux `~/.config/autostart/gitwarren.desktop` file
- the AppImage form of `~/.gitwarren/bin/gitwarren-mcp`, which reaches the server through `$APPDIR` — you cannot test that without an AppImage

## The daemon tarball

Promoted from `scripts/spikes/s3-daemon-tarball.mjs` into `scripts/build-daemon-tarball.mjs`, built by a new `daemon` job in `release.yml`.

It carries **both** bundles now, not just the MCP server. A remote host has to answer a GitWarren on another machine over a pipe (`serve.cjs`) *and* be reached by the agent working next to the code (`server.cjs`) — rule 6 makes those different processes with different callers. `bin/gitwarren serve --stdio` is the exact line M4 spawns over ssh, so it works against this tarball rather than against a name invented later; `open` and `service install` are M3's to design and the script says so.

A job of its own rather than a fourth matrix entry: no electron-builder, no code signing, no update manifest, and **one runner produces both architectures** because better-sqlite3 ships prebuilds for each, so nothing is compiled and nothing needs a matching host. In the matrix it would have needed an `if:` on every signing step.

Verified in a bare `ubuntu:24.04` arm64 container with no Node installed:

```
$ printf '{"id":1,"method":"repositories.list"}\n' | … bin/gitwarren serve --stdio
[gitwarren-serve] ready (instance 00bd1971-…, protocol v1, database: /root/.config/GitWarren/gitwarren.db)
{"id":1,"result":[]}
exit=0

$ printf '…initialize…' | … bin/gitwarren-mcp
[gitwarren-mcp] ready (database: /root/.config/GitWarren/gitwarren.db)
{"result":{…,"serverInfo":{"name":"gitwarren","version":"0.1.0"}},"jsonrpc":"2.0","id":1}
exit=0
```

So Node ran, the addon loaded, the database was created and migrated, and both protocols answered. 44 MB each.

**The asset names are a contract.** M4's installer runs `uname -sm` on a host, maps it to `linux-x64` or `linux-arm64`, and fetches `gitwarren-daemon-<version>-<target>.tar.gz` by URL — one request, no listing. The README now says so.

## Also

`README.md` had a forward reference to 0.1.7, written before there was one. Removed rather than left to come true.

`npm run lint`, `npm run typecheck` and `npm test` (322 passing) all green.

## What happens next

Merge this, and I'll tag `v0.1.7-beta.1` and report the draft's asset list. The draft stays a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrDyYFs5aqfAPaRzmEjUvB
