### PR TITLE
Comment the Windows launcher the way cmd reads comments

### DIFF
--- a/src/main/mcp-launch.ts
+++ b/src/main/mcp-launch.ts
@@ -87,12 +87,39 @@ function shellQuote(value: string): string {
  *
  * This is what retires the "extract the AppImage first" caveat.
  */
-function launcherScript(): string {
-  const banner =
-    '# GitWarren MCP server. Rewritten by GitWarren whenever the install moves,\n' +
-    '# so an agent config that names this path keeps working across updates.\n' +
-    '# Generated file - edit GitWarren, not this.\n'
+const BANNER_LINES = [
+  'GitWarren MCP server. Rewritten by GitWarren whenever the install moves,',
+  'so an agent config that names this path keeps working across updates.',
+  'Generated file - edit GitWarren, not this.'
+]
 
+/**
+ * The banner, commented for whichever interpreter is going to read it.
+ *
+ * Commented *per branch* rather than once, because the comment character is not
+ * the same in both. `#` is a comment to `/bin/sh` and is not one to `cmd`,
+ * which tries to run it and writes
+ *
+ *     '#' is not recognized as an internal or external command,
+ *     operable program or batch file.
+ *
+ * to stderr - once per banner line, on every single MCP server start. It cost
+ * nothing at the protocol level, which is on stdout, but it landed in the log
+ * of every Windows harness forever, and a harness strict enough to read output
+ * on stderr during startup as a failed spawn would have rejected the server
+ * outright.
+ *
+ * Worth knowing how it survived review: there was one banner string shared by
+ * all three branches, correct in the two that are shell scripts, and the
+ * Windows branch translated its line endings without touching its comments.
+ * Nothing about reading that string suggests a platform question, and no test
+ * on macOS or Linux can reach it. It was found by running the thing on Windows.
+ */
+function bannerFor(comment: string, eol: string): string {
+  return BANNER_LINES.map((line) => `${comment} ${line}${eol}`).join('')
+}
+
+function launcherScript(): string {
   const appImage = process.env.APPIMAGE
   if (appImage) {
     // `-e` rather than a script argument: the argument would have to be an
@@ -101,7 +128,7 @@ function launcherScript(): string {
     const inside = relative(process.env.APPDIR ?? '/', scriptPath())
     return (
       '#!/bin/sh\n' +
-      banner +
+      bannerFor('#', '\n') +
       `ELECTRON_RUN_AS_NODE=1 exec ${shellQuote(appImage)} \\\n` +
       `  -e 'require(process.env.APPDIR + "/${inside}")' "$@"\n`
     )
@@ -110,7 +137,7 @@ function launcherScript(): string {
   if (process.platform === 'win32') {
     return (
       '@echo off\r\n' +
-      banner.replace(/\n/g, '\r\n') +
+      bannerFor('REM', '\r\n') +
       'setlocal\r\n' +
       'set "ELECTRON_RUN_AS_NODE=1"\r\n' +
       `"${process.execPath}" "${scriptPath()}" %*\r\n`
@@ -119,7 +146,7 @@ function launcherScript(): string {
 
   return (
     '#!/bin/sh\n' +
-    banner +
+    bannerFor('#', '\n') +
     `ELECTRON_RUN_AS_NODE=1 exec ${shellQuote(process.execPath)} ${shellQuote(scriptPath())} "$@"\n`
   )
 }


### PR DESCRIPTION
Found while verifying M2 on Windows (#35).

The generated `gitwarren-mcp.cmd` carried the shared banner verbatim, and `#` is not a comment character in a batch file. `cmd` tried to run each of the three lines:

```
'#' is not recognized as an internal or external command,
operable program or batch file.
```

on stderr, on **every MCP server start**. The protocol is on stdout so nothing actually broke — but it landed in the log of every Windows harness on every start, and a harness strict enough to treat output on stderr during startup as a failed spawn would have rejected the server outright.

## The change

`launcherScript()` built one `banner` string with `#` prefixes and shared it across all three branches; the win32 branch translated its line endings to CRLF and left the comment character alone. The banner is now commented per branch — `#` for the two shell scripts, `REM` for the batch file.

Worth recording how it survived review, since the comment in the code now says so: nothing about reading that shared string suggests a platform question, it is correct in the two branches that are shell scripts, and no test on macOS or Linux can reach the third. It was found by running the thing on Windows.

## Verification

Typecheck and lint pass. Beyond that, the generated file was run against the packaged `0.1.7-beta.1` install on Windows 11:

- **Before:** three `is not recognized` lines on stderr, then `[gitwarren-mcp] ready`.
- **After:** zero. stderr carries only the two informational lines the server writes itself, and `agent_identity` still answers over the pipe.

Note the fix was verified by generating the file the new branch produces and running it, not by rebuilding the app — `better-sqlite3` needs MSVC build tools this machine does not have, so a packaged rebuild was out of reach. The generated bytes are what the change controls, and those are what was tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnwziXQv4zzYR2BhdotzWN
