### PR TITLE
Make the test suite runnable on Windows

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -7,7 +7,8 @@
  */
 import { spawn } from 'node:child_process'
 import { readdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
 
 function findTests(dir) {
   const found = []
@@ -25,9 +26,31 @@ if (tests.length === 0) {
   process.exit(1)
 }
 
-const child = spawn(
-  process.platform === 'win32' ? 'npx.cmd' : 'npx',
-  ['tsx', '--test', ...tests],
-  { stdio: 'inherit' }
-)
+/**
+ * tsx's CLI, to be run by this same Node rather than reached through `npx`.
+ *
+ * `npx` is a shell script on POSIX and `npx.cmd` on Windows, and since the fix
+ * for CVE-2024-27980 Node refuses to spawn a `.cmd` at all unless `shell` is
+ * set - it throws `EINVAL` before the command runs. So `npm test` had never
+ * worked on Windows: naming `npx.cmd` there looks like the platform was handled
+ * and stops one step short of it. CI only runs ubuntu, which is why nothing
+ * said so.
+ *
+ * Handing the batch file to a shell would fix the spawn and buy a worse
+ * problem, because `shell: true` concatenates rather than escapes: one test
+ * file with a space in its path and the command line means something else.
+ * Resolving the CLI and running it with `process.execPath` avoids the shell
+ * altogether, and is the same code on every platform - which is the point, as
+ * the branch is what went wrong here in the first place.
+ *
+ * Resolved through the package manifest rather than assumed to be at
+ * `node_modules/tsx`, so it survives being hoisted somewhere else.
+ */
+function tsxCli() {
+  const require = createRequire(import.meta.url)
+  const manifest = require.resolve('tsx/package.json')
+  return join(dirname(manifest), require(manifest).bin)
+}
+
+const child = spawn(process.execPath, [tsxCli(), '--test', ...tests], { stdio: 'inherit' })
 child.on('exit', (code) => process.exit(code ?? 1))

--- a/src/core/__tests__/pre-m0-database.test.ts
+++ b/src/core/__tests__/pre-m0-database.test.ts
@@ -39,8 +39,18 @@ const { HUMAN_NAME, HUMAN_AUTHOR } = await import('../../shared/actors.js')
  */
 let raw: Database.Database
 
-after(() => {
+after(async () => {
   raw?.close()
+
+  // The app's own connection is a module-level singleton, and the last test in
+  // this file reopens it deliberately, so it is still holding the database file
+  // when this runs. POSIX is happy to unlink a file someone has open and
+  // Windows is not: `rmSync` fails there with EPERM and takes every test in the
+  // file down with it. Closed rather than left to the process exiting, because
+  // the directory has to be gone before that.
+  const { closeDatabase } = await import('../db/client.js')
+  closeDatabase()
+
   rmSync(dataDir, { recursive: true, force: true })
   rmSync(migrationsDir, { recursive: true, force: true })
 })


### PR DESCRIPTION
Found while setting up a Windows development machine, after the M2 verification (#35).

`npm test` had never worked on Windows, in two independent ways. CI runs `ubuntu-latest` only, so nothing said so.

## The runner could not start

`scripts/run-tests.mjs` spawned `npx.cmd` without `shell`, and since the fix for CVE-2024-27980 Node refuses to spawn a `.cmd` that way — it throws `EINVAL` before the command runs:

```
Error: spawn EINVAL
    at file:///C:/Users/.../scripts/run-tests.mjs:28:15
```

Naming `npx.cmd` on win32 is the part worth noting: it *looks* like the platform was handled, and stops one step short of it.

The obvious repair is `shell: true`, and it is the wrong one — `shell: true` concatenates arguments rather than escaping them, so the first test file with a space in its path would change what the command means. Instead the runner resolves tsx's CLI through its package manifest and runs it with `process.execPath`. No shell, no `.cmd`, and one code path on every platform — the branch being what went wrong here in the first place. Resolved via the manifest rather than assumed at `node_modules/tsx` so it survives hoisting.

## Then ten tests failed on cleanup

`pre-m0-database.test.ts` removes its temp directory in `after`. The app's database connection is a module-level singleton, and the last test in the file reopens it deliberately, so it was still holding the file. POSIX will unlink a file someone has open; Windows will not:

```
Error: EPERM, Permission denied: ...\gitwarren-pre-m0-data-Ix0EoV
```

The hook now closes it before removing the directory.

## Result

**322 tests, 322 passing, exit 0** on Windows 11 with Node 24.20.0 — with #39 also applied. Without #39 the suite runs but nine attachment tests fail, and they fail for a real reason: they were the first thing to notice that Windows paths never worked. This PR is what made that visible.

Typecheck and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnwziXQv4zzYR2BhdotzWN
