### PR TITLE
Read a Windows drive letter as a path, not a URL scheme

### DIFF
--- a/src/core/attachment-ingest.ts
+++ b/src/core/attachment-ingest.ts
@@ -85,7 +85,20 @@ export function localPathFor(url: string): string | null {
 
   // Any other scheme is remote, or at least not ours: http(s), data, and the
   // gitwarren tokens produced by an earlier pass through this function.
-  if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return null
+  //
+  // Except a Windows drive letter, which parses as a scheme and is not one:
+  // `C:\Users\me\shot.png` matches any scheme pattern that can be written,
+  // which meant every absolute path on Windows was read as remote and left in
+  // the body as dead text - the whole screenshot feature, silently doing
+  // nothing on one platform. A drive letter is one character and is always
+  // followed by a separator, and single-letter schemes are not used in
+  // practice, so that pair tells them apart.
+  //
+  // Deliberately not conditional on `process.platform`: the check below is
+  // `isAbsolute`, which already answers per platform, so a POSIX host reading a
+  // body written on Windows still declines the path - it just declines it for
+  // the true reason rather than by mistaking it for a URL.
+  if (!/^[a-z]:[\\/]/i.test(url) && /^[a-z][a-z0-9+.-]*:/i.test(url)) return null
 
   const decoded = safeDecode(url)
   return isAbsolute(decoded) ? decoded : null


### PR DESCRIPTION
Found while setting up a Windows development machine, once #38 made the test suite runnable there.

## The bug

`localPathFor` in `src/core/attachment-ingest.ts` rejects anything matching a URI scheme, which is how it skips `http(s):`, `data:` and the `gitwarren://` tokens an earlier pass produces:

```js
if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return null
```

A Windows absolute path matches that pattern. `C:\Users\me\shot.png` parses as scheme `c`. So **every local image path on Windows was classified as remote** and left in the comment body as dead text.

That is the whole screenshot feature doing nothing on one platform. The tool descriptions for `add_review_comment` and `reply_to_review_comment` instruct agents to write a file to disk and reference it as ordinary markdown. On Windows the reference was never rewritten, no attachment was stored, and **the call still succeeded** — so the failure was silent at both ends. The agent believes it attached a screenshot; the person opens the review and finds a path where a picture should be.

## The fix

A drive letter is one character followed by a separator, and single-letter URI schemes are not used in practice, so that pair is enough to tell them apart.

The exception is deliberately **not** conditional on `process.platform`. The next check is `isAbsolute`, which already answers per platform — so a POSIX host reading a body written on Windows still declines the path, it just declines it for the true reason rather than by mistaking it for a URL. One code path, and the platform question is asked in the one place that already knew how to answer it.

## Verification

The nine tests that cover this were **already written and already correct**. They had simply never run on Windows, because the runner could not start there. That is the more interesting half of this: the coverage existed, the bug was in shipped code, and the gap was that one platform never executed the suite.

- `attachment-ingest.test.ts`: **19/19** on Windows 11, run directly with `tsx` since this branch alone still has the broken runner.
- Whole suite with #38 also applied: **322/322**, exit 0.
- Typecheck and lint pass.

Best merged alongside #38 — either order works, but Windows CI would need both before it could be trusted to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnwziXQv4zzYR2BhdotzWN
