### PR TITLE
M3.1 - The web view: one handler, two shells, one token

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -891,6 +891,68 @@ and Codex both reach the MCP server from the pasted prompt; a `guiUrl` from an
 agent opens the review in the browser. A page on another origin cannot reach
 the API.
 
+#### How it is being built, and where it has got to
+
+M3 is the largest milestone in this file, so it is going in as five changes,
+each mergeable on its own:
+
+1. **The carrier, the serving and the token.** *(done — see below.)*
+2. **What the browser shell lacks.** Attachments over HTTP, open-in-editor as a
+   `vscode://` link, and a shell *capability flag* so a screen can hide a
+   control instead of offering one that explains itself when pressed.
+3. **The `gitwarren` CLI and distribution.** `serve`, `open`,
+   `service install`; the S3 tarball, a Homebrew formula, `npx gitwarren`.
+4. **The Agent Access page**, one-sentence prompt leading.
+5. **The responsive pass.**
+
+**M3.1, done on the Mac, 10 September.** One handler (`core/web/handler.ts`)
+mounted by both shells: the app serves it at `/app/` because `/` is the link
+page M2 is verified on, and `gitwarren serve --listen` serves it at `/`, where
+an agent's `guiUrl` opens the review with no "Open in GitWarren" hop — which is
+the thing this milestone exists for. The gate is Host, then Origin, then a
+per-launch token swapped for a `SameSite=Strict` cookie; the token is written
+to `web-token` at mode 0600 rather than into `daemon-runtime.json`, which is a
+published fact and no place for a secret. `--listen` claims the runtime file and
+refuses to start beside a running app, which is the ownership check `daemon.ts`
+said belonged here.
+
+Verified in Chrome against both shells with a scratch data directory: the
+renderer paints, the socket connects, a repository added *in the browser* lands
+in SQLite, `app-info` answers over HTTP, and a refusal a tab must give — reveal
+a folder — arrives as a sentence rather than a silence. No console errors and no
+failed requests in either run. The renderer needed no change at all, which is
+what M1 was for.
+
+Two things bit, and both are worth keeping:
+
+**A doubled `#`.** `hrefFor` already returns a string beginning with `#`, and
+the translated route was being written back as `` `#${hrefFor(route)}` ``. The
+hash became `##/reviews/2/files`, `parseRoute` read a first segment of `#`, and
+every agent link quietly opened the repository list. Nothing threw and nothing
+was logged — the screen it lands on is a completely plausible one. The
+translation now lives in `web/loopback-fragment.ts`, apart from the DOM so it
+can be tested, and the test asserts on `parseRoute(hrefFor(...))` rather than on
+the route alone.
+
+**`ws` and its optional native accelerators.** `bufferutil` and `utf-8-validate`
+are reached for by reassigning `module.exports` at the bottom of two `ws`
+modules. Rollup's *ESM* output turns the module's own later reference into
+`bufferUtil$1.unmask`, which is `undefined`, so the first masked frame — and
+every frame a browser sends is masked — dies inside `Receiver._write` before
+anything of ours runs. The socket connects perfectly, accepts everything and
+answers nothing. It hit the Electron main bundle and not the daemon purely
+because main is built as ESM and `serve.cjs` is CommonJS. Both builds now define
+`WS_NO_BUFFER_UTIL` and `WS_NO_UTF_8_VALIDATE` so the optional block is compiled
+away (`vite.ws-define.ts`). A distinction between two bundlers' output formats
+is not something anyone should have to remember.
+
+**Not done in M3.1, and why.** `GitWarren --serve --listen` from inside the
+packaged app is not a supported combination: `out/web` lives in the asar and
+only `out/daemon` is unpacked, and the app serves the web view itself anyway.
+The browser shell's missing capabilities are honest refusals rather than hidden
+controls until M3.2 gives it the capability flag. Attachments in markdown do not
+render in a tab yet — that is the HTTP blob endpoint, also M3.2.
+
 ### M4 — SSH hosts
 
 *Ships: review the PC's WSL repos from the Mac; any VPS.*

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -2,9 +2,11 @@ import { resolve } from 'node:path'
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { WS_PURE_JS } from './vite.ws-define.js'
 
 export default defineConfig({
   main: {
+    define: WS_PURE_JS,
     plugins: [externalizeDepsPlugin()],
     resolve: {
       alias: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "^26.4.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.5",
+        "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^5.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -47,10 +48,12 @@
         "typescript-eslint": "^8.69.0",
         "unist-util-visit": "^5.1.0",
         "vite": "^7.3.6",
+        "ws": "^8.21.3",
         "zod": "^4.5.4"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24.20.0",
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -84,7 +87,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -723,6 +725,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -744,6 +747,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -2830,7 +2834,6 @@
       "integrity": "sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2959,7 +2962,6 @@
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2990,6 +2992,16 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.69.0",
@@ -3036,7 +3048,6 @@
       "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.69.0",
         "@typescript-eslint/types": "8.69.0",
@@ -3317,7 +3328,6 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3679,7 +3689,6 @@
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^8.0.0"
       },
@@ -3775,7 +3784,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
@@ -4256,7 +4264,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4528,7 +4537,6 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -4891,6 +4899,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -4911,6 +4920,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -4926,6 +4936,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4936,6 +4947,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -5153,7 +5165,6 @@
       "integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -6128,7 +6139,6 @@
       "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8032,6 +8042,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -8474,7 +8485,6 @@
       "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8574,6 +8584,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -8591,6 +8602,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8790,7 +8802,6 @@
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8801,7 +8812,6 @@
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9038,6 +9048,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -9652,6 +9663,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -10392,7 +10404,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10695,7 +10706,6 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -11314,6 +11324,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -11389,7 +11421,6 @@
       "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "dev": "electron-vite dev",
     "start": "electron-vite preview",
-    "build": "npm run typecheck && electron-vite build && npm run build:mcp && npm run build:daemon",
+    "build": "npm run typecheck && electron-vite build && npm run build:mcp && npm run build:daemon && npm run build:web",
     "build:mcp": "vite build --config vite.mcp.config.ts",
     "build:daemon": "vite build --config vite.daemon.config.ts",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
@@ -46,7 +46,9 @@
     "package": "npm run build && electron-builder --publish never",
     "package:dir": "npm run build && electron-builder --dir --publish never",
     "release": "npm run build && electron-builder --publish always",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "build:web": "vite build --config vite.web.config.ts",
+    "listen:dev": "tsx src/daemon/serve.ts --listen"
   },
   "dependencies": {
     "better-sqlite3": "^13.0.3",
@@ -61,6 +63,7 @@
     "@types/node": "^26.4.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
+    "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^5.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -86,6 +89,7 @@
     "typescript-eslint": "^8.69.0",
     "unist-util-visit": "^5.1.0",
     "vite": "^7.3.6",
+    "ws": "^8.21.3",
     "zod": "^4.5.4"
   }
 }

--- a/src/core/mcp-launcher.ts
+++ b/src/core/mcp-launcher.ts
@@ -1,0 +1,25 @@
+/**
+ * Where the stable MCP launcher lives. One path per OS, on every machine.
+ *
+ * Split out of `main/mcp-launch.ts` - which still owns *writing* the file and
+ * everything Electron knows about where this install put its server - because
+ * from M3 the path has a second reader: a `gitwarren serve` with no Electron
+ * anywhere near it has to tell the Agent Access panel the same command the app
+ * would have told it. Two processes computing "one path per OS" separately is
+ * exactly the drift the launcher exists to prevent, so the computation is here,
+ * free of any `electron` import, and both import it.
+ */
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** `~/.gitwarren/bin`. The same on Windows, where `~` is the user profile. */
+export function getLauncherDirectory(): string {
+  return join(homedir(), '.gitwarren', 'bin')
+}
+
+export function getMcpLauncherPath(): string {
+  return join(
+    getLauncherDirectory(),
+    process.platform === 'win32' ? 'gitwarren-mcp.cmd' : 'gitwarren-mcp'
+  )
+}

--- a/src/core/rpc/websocket.ts
+++ b/src/core/rpc/websocket.ts
@@ -1,0 +1,135 @@
+/**
+ * The protocol on a WebSocket. The third carrier, and the first one with a
+ * peer that can vanish without telling anyone.
+ *
+ * Almost everything `stdio.ts` had to invent is already here: a WebSocket
+ * delivers whole messages, so there is no framing to do, no buffer to bound and
+ * no partial line to hold. What is left is what a network adds.
+ *
+ * ## Why there is a heartbeat
+ *
+ * A pipe ends when the process at the other end exits, and the OS says so. A
+ * TCP connection to a laptop that closed its lid ends when nobody is looking,
+ * and both sides sit there believing in a socket that no longer exists - the
+ * classic half-open connection. On loopback that is nearly impossible; over the
+ * tailnet in M6 it is Tuesday. The server pings, and a client that has not
+ * answered by the next tick is terminated rather than closed, because a close
+ * handshake with a peer that is gone is a message into a void.
+ *
+ * The client pings nothing and answers everything: browsers reply to a ping in
+ * the WebSocket implementation itself, below anything JavaScript can see, which
+ * is exactly what makes this a liveness check on the *connection* rather than
+ * on the page's event loop.
+ *
+ * ## What it does not do
+ *
+ * Decide anything. Every request goes through `handleRequest`, the same door
+ * `main/ipc.ts` and `stdio.ts` use, and this file may not add a method, skip
+ * validation or name an author - see the note at the top of `dispatcher.ts`.
+ * Authentication happened before the upgrade was accepted (`web/server.ts`); a
+ * socket that reaches here is one the user's browser was told the secret for,
+ * and this file is not the place to second-guess that.
+ */
+import type { WebSocket } from 'ws'
+import { handleRequest } from './dispatcher.js'
+import { AppError } from '../../shared/errors.js'
+import type { RpcRequest, RpcResponse } from '../../shared/rpc.js'
+
+/**
+ * How long a peer has to answer a ping before it is treated as gone.
+ *
+ * 30 seconds is comfortably longer than the renderer's 15-second poll, so a tab
+ * that is doing its ordinary work never comes close to it, and short enough
+ * that a dead socket does not hold a database handle open for minutes.
+ */
+const HEARTBEAT_MS = 30_000
+
+/** Same as `stdio.ts`: the id used when a frame has no usable one. */
+const NO_ID = 0
+
+function asRequest(value: unknown): RpcRequest | null {
+  if (typeof value !== 'object' || value === null) return null
+  const { id, method } = value as Partial<RpcRequest>
+  if (!Number.isInteger(id) || typeof method !== 'string') return null
+  return value as RpcRequest
+}
+
+/**
+ * Answer requests arriving on one socket.
+ *
+ * Like the stdio carrier, requests are answered concurrently and responses are
+ * written the moment they are ready, so they may arrive in a different order
+ * from the questions. That is what `id` is for.
+ */
+export function serveWebSocket(socket: WebSocket): void {
+  let alive = true
+
+  const write = (message: RpcResponse): void => {
+    // A response for a socket that has closed is not an error worth logging on
+    // every navigation - a tab going away mid-request is ordinary.
+    if (socket.readyState !== socket.OPEN) return
+    socket.send(JSON.stringify(message))
+  }
+
+  const refuse = (id: number, message: string): void => {
+    write({ id, error: new AppError('INVALID_INPUT', message).toSerialized() })
+  }
+
+  socket.on('message', (data: unknown, isBinary: boolean) => {
+    // The protocol is JSON text. A binary frame is not a mangled request, it is
+    // a different protocol, and answering it as though it were ours would be a
+    // guess.
+    if (isBinary) {
+      refuse(NO_ID, 'A message must be JSON text, not a binary frame.')
+      return
+    }
+
+    let decoded: unknown
+    try {
+      decoded = JSON.parse(String(data))
+    } catch {
+      refuse(NO_ID, 'A message must be one JSON object.')
+      return
+    }
+
+    const request = asRequest(decoded)
+    if (!request) {
+      refuse(NO_ID, 'A request needs an integer id and a method.')
+      return
+    }
+
+    // `handleRequest` never throws - that is its contract. The catch is for the
+    // write, which can fail on a socket that closed between the two.
+    void handleRequest(request)
+      .then(write)
+      .catch((error: unknown) => {
+        console.error('[web] could not answer a request', error)
+      })
+  })
+
+  socket.on('pong', () => {
+    alive = true
+  })
+
+  const heartbeat = setInterval(() => {
+    if (!alive) {
+      socket.terminate()
+      return
+    }
+    alive = false
+    socket.ping()
+  }, HEARTBEAT_MS)
+
+  // `unref` so a stray interval cannot be the reason a daemon refuses to exit.
+  heartbeat.unref?.()
+
+  socket.on('close', () => {
+    clearInterval(heartbeat)
+  })
+
+  socket.on('error', (error: Error) => {
+    console.error('[web] socket error', error)
+  })
+}
+
+export const WEBSOCKET_HEARTBEAT_MS = HEARTBEAT_MS

--- a/src/core/web/__tests__/web-handler.test.ts
+++ b/src/core/web/__tests__/web-handler.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Coverage for the loopback gate and the file server behind it.
+ *
+ * The renderer is not what is under test here - it is the same renderer the
+ * window runs, and M1 is what makes that true. What is new in M3, and what
+ * these tests are about, is that a port on this machine now answers with
+ * repositories and comments instead of one inert page. Every case below is a
+ * way that port could be reached by something the user did not point at it:
+ * a page on another origin, a name that resolves to 127.0.0.1, a URL from a
+ * previous launch, a path with `..` in it.
+ *
+ * The last test is the one that says the whole thing works: a WebSocket, a
+ * request over it, and a real answer from the real dispatcher against a real
+ * database. If that passes, a browser tab is a GitWarren.
+ */
+import assert from 'node:assert/strict'
+import { createServer, request as httpRequest, type Server } from 'node:http'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, test } from 'node:test'
+import { WebSocket } from 'ws'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-web-'))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+const { createWebHandler } = await import('../handler.js')
+const { SESSION_COOKIE, TOKEN_PARAM, WEB_PATHS } = await import('../../../shared/web.js')
+const { closeDatabase } = await import('../../db/client.js')
+
+const MOUNT = '/app/'
+const TOKEN = 'a-test-token-that-is-long-enough'
+
+/** A web build, in the smallest form the server can tell apart from nothing. */
+const staticRoot = mkdtempSync(join(tmpdir(), 'gitwarren-web-build-'))
+mkdirSync(join(staticRoot, 'assets'))
+writeFileSync(join(staticRoot, 'index.html'), '<!doctype html><title>GitWarren</title>')
+writeFileSync(join(staticRoot, 'assets', 'main.js'), 'export const app = 1\n')
+
+const APP_INFO = {
+  version: '0.0.0-test',
+  instanceId: '00000000-0000-4000-8000-000000000000',
+  platform: process.platform,
+  packaged: false,
+  dataDirectory: dataDir,
+  databasePath: join(dataDir, 'gitwarren.db'),
+  linkPort: null,
+  mcp: {
+    command: '/nowhere/gitwarren-mcp',
+    args: [],
+    env: {},
+    available: false,
+    stable: true,
+    direct: { command: '/nowhere/gitwarren-mcp', args: [], env: {} }
+  }
+}
+
+let server: Server
+let port = 0
+let handler: ReturnType<typeof createWebHandler>
+
+before(async () => {
+  handler = createWebHandler({
+    mount: MOUNT,
+    staticRoot,
+    token: TOKEN,
+    appInfo: () => APP_INFO,
+    // The real port is fixed at 41427 and is very likely held by the developer's
+    // own GitWarren, so the handler is told which authority it is answering on.
+    port: 0
+  })
+
+  server = createServer((request, response) => {
+    if (!handler.request(request, response)) response.writeHead(404).end()
+  })
+  server.on('upgrade', (request, socket, head) => {
+    if (!handler.upgrade(request, socket, head)) socket.destroy()
+  })
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  port = typeof address === 'object' && address ? address.port : 0
+
+  // The handler was built before the port was known, which is the one thing a
+  // test can do that neither shell does. Rebuilt now that it is.
+  handler.close()
+  handler = createWebHandler({
+    mount: MOUNT,
+    staticRoot,
+    token: TOKEN,
+    appInfo: () => APP_INFO,
+    port
+  })
+})
+
+after(async () => {
+  handler.close()
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  closeDatabase()
+  rmSync(dataDir, { recursive: true, force: true })
+  rmSync(staticRoot, { recursive: true, force: true })
+})
+
+function origin(): string {
+  return `http://127.0.0.1:${port}`
+}
+
+/** A request that carries a valid session, as a browser would after the swap. */
+function withSession(headers: Record<string, string> = {}): Record<string, string> {
+  return { cookie: `${SESSION_COOKIE}=${TOKEN}`, ...headers }
+}
+
+async function get(path: string, headers: Record<string, string> = {}): Promise<Response> {
+  return fetch(`${origin()}${path}`, { headers, redirect: 'manual' })
+}
+
+/**
+ * A GET with headers exactly as given, `Host` included.
+ *
+ * `fetch` cannot do this: `Host` is a forbidden header name, so undici silently
+ * drops an override and the request arrives naming the real authority. That is
+ * the correct behaviour for a browser and useless for testing the one check
+ * that exists because a *browser* is what sends the header - hence the raw
+ * client for this case.
+ */
+function rawGet(path: string, headers: Record<string, string>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(
+      { host: '127.0.0.1', port, path, method: 'GET', headers },
+      (response) => {
+        response.resume()
+        resolve(response.statusCode ?? 0)
+      }
+    )
+    request.on('error', reject)
+    request.end()
+  })
+}
+
+test('a Host that is not the loopback authority is refused', async () => {
+  // What a DNS rebinding attack looks like from this side: the connection is on
+  // 127.0.0.1, and the browser still names the site it thinks it is talking to.
+  const status = await rawGet(MOUNT, withSession({ Host: 'evil.example' }))
+
+  assert.equal(status, 403)
+})
+
+test('the same request naming the real authority is served', async () => {
+  // The pair matters: without it the test above would pass just as well against
+  // a server that refused everything.
+  const status = await rawGet(MOUNT, withSession({ Host: `127.0.0.1:${port}` }))
+
+  assert.equal(status, 200)
+})
+
+test('a page on another origin is refused even with a session', async () => {
+  const response = await get(`${MOUNT}`, withSession({ origin: 'http://evil.example' }))
+
+  assert.equal(response.status, 403)
+})
+
+test('a navigation, which carries no Origin at all, is not refused for that', async () => {
+  const response = await get(`${MOUNT}`, withSession())
+
+  assert.equal(response.status, 200)
+})
+
+test('a write method is refused before anything else is considered', async () => {
+  const response = await fetch(`${origin()}${MOUNT}`, {
+    method: 'POST',
+    headers: withSession({ origin: origin() })
+  })
+
+  assert.equal(response.status, 405)
+  assert.equal(response.headers.get('allow'), 'GET, HEAD')
+})
+
+test('no session is 401 and a page that says how to get one', async () => {
+  const response = await get(MOUNT)
+  const body = await response.text()
+
+  assert.equal(response.status, 401)
+  assert.match(body, /needs its token/)
+  // The page must not be a way to learn the answer it is asking for.
+  assert.ok(!body.includes(TOKEN))
+})
+
+test('a token in the URL is exchanged for a cookie and taken back out', async () => {
+  const response = await get(`${MOUNT}?${TOKEN_PARAM}=${TOKEN}`)
+
+  assert.equal(response.status, 302)
+  assert.equal(response.headers.get('location'), MOUNT)
+
+  const cookie = response.headers.get('set-cookie') ?? ''
+  assert.match(cookie, new RegExp(`${SESSION_COOKIE}=${TOKEN}`))
+  assert.match(cookie, /HttpOnly/)
+  assert.match(cookie, /SameSite=Strict/)
+  assert.match(cookie, /Path=\//)
+})
+
+test('a token from a previous launch is refused', async () => {
+  const response = await get(`${MOUNT}?${TOKEN_PARAM}=an-old-token-of-the-same-len`)
+
+  assert.equal(response.status, 403)
+})
+
+test('the mount without its trailing slash redirects rather than serving', async () => {
+  // Asset URLs in the build are relative, so a document served at `/app` would
+  // send the browser looking for `/assets/…` one level too high.
+  const response = await get('/app', withSession())
+
+  assert.equal(response.status, 302)
+  assert.equal(response.headers.get('location'), MOUNT)
+})
+
+test('the document is served, and never cached', async () => {
+  const response = await get(MOUNT, withSession())
+
+  assert.equal(response.status, 200)
+  assert.match(response.headers.get('content-type') ?? '', /text\/html/)
+  assert.equal(response.headers.get('cache-control'), 'no-store')
+  assert.equal(response.headers.get('x-content-type-options'), 'nosniff')
+})
+
+test('a hashed asset is served as immutable', async () => {
+  const response = await get(`${MOUNT}assets/main.js`, withSession())
+
+  assert.equal(response.status, 200)
+  assert.match(response.headers.get('content-type') ?? '', /javascript/)
+  assert.match(response.headers.get('cache-control') ?? '', /immutable/)
+})
+
+test('a missing asset is a 404 and not the document', async () => {
+  // Answering HTML under a `.js` name is how a blank page with a baffling
+  // console error happens.
+  const response = await get(`${MOUNT}assets/not-here.js`, withSession())
+
+  assert.equal(response.status, 404)
+})
+
+test('a path that is not a file falls back to the document', async () => {
+  const response = await get(`${MOUNT}anything/at/all`, withSession())
+
+  assert.equal(response.status, 200)
+  assert.match(await response.text(), /GitWarren/)
+})
+
+test('a traversal out of the web build is refused however it is spelled', async () => {
+  // Encoded, so the URL parser does not normalise it away before it arrives -
+  // which is exactly why the confinement is checked on the resolved path
+  // rather than on the text of the request.
+  const response = await get(`${MOUNT}%2e%2e%2f%2e%2e%2fetc%2fpasswd`, withSession())
+
+  assert.equal(response.status, 403)
+})
+
+test('app-info describes this install, to a session and to nobody else', async () => {
+  const anonymous = await get(WEB_PATHS.appInfo)
+  assert.equal(anonymous.status, 401)
+
+  const response = await get(WEB_PATHS.appInfo, withSession())
+  assert.equal(response.status, 200)
+  assert.deepEqual(await response.json(), APP_INFO)
+})
+
+test('an unknown path under the shell prefix is a 404, not the document', async () => {
+  const response = await get('/gitwarren/nothing-here', withSession())
+
+  assert.equal(response.status, 404)
+})
+
+/** One socket, opened the way a browser opens it. */
+function connect(headers: Record<string, string>): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`ws://127.0.0.1:${port}${WEB_PATHS.socket}`, { headers })
+    socket.on('open', () => resolve(socket))
+    socket.on('error', reject)
+  })
+}
+
+test('the socket refuses an upgrade with no session', async () => {
+  await assert.rejects(connect({ origin: origin() }), /401/)
+})
+
+test('the socket refuses an upgrade from another origin', async () => {
+  await assert.rejects(
+    connect({ ...withSession(), origin: 'http://evil.example' }),
+    /403/
+  )
+})
+
+test('the socket requires an Origin, unlike a navigation', async () => {
+  // A handshake is never a top-level navigation, so a browser always sends one
+  // and anything that does not is not a browser.
+  await assert.rejects(connect(withSession()), /403/)
+})
+
+test('a request over the socket is answered by the real dispatcher', async () => {
+  const socket = await connect({ ...withSession(), origin: origin() })
+
+  const answer = await new Promise<{ id: number; result?: unknown; error?: unknown }>(
+    (resolve, reject) => {
+      socket.on('message', (data: Buffer) =>
+        resolve(JSON.parse(String(data)) as { id: number; result?: unknown; error?: unknown })
+      )
+      socket.on('error', reject)
+      socket.send(JSON.stringify({ id: 1, method: 'repositories.list' }))
+    }
+  )
+
+  socket.close()
+
+  assert.equal(answer.id, 1)
+  assert.equal(answer.error, undefined)
+  // A database created moments ago by this test, migrated on first use.
+  assert.deepEqual(answer.result, [])
+})
+
+test('a frame that is not a request is refused under an id it can be read with', async () => {
+  const socket = await connect({ ...withSession(), origin: origin() })
+
+  const answer = await new Promise<{ id: number; error?: { code: string } }>((resolve, reject) => {
+    socket.on('message', (data: Buffer) =>
+      resolve(JSON.parse(String(data)) as { id: number; error?: { code: string } })
+    )
+    socket.on('error', reject)
+    socket.send('{"this":"is not a request"}')
+  })
+
+  socket.close()
+
+  assert.equal(answer.id, 0)
+  assert.equal(answer.error?.code, 'INVALID_INPUT')
+})

--- a/src/core/web/handler.ts
+++ b/src/core/web/handler.ts
@@ -1,0 +1,286 @@
+/**
+ * The web view: the renderer, served on loopback, over the same dispatcher the
+ * window uses.
+ *
+ * This is a handler rather than a server, and that is the whole design. There
+ * are two processes that may hold the loopback port - the Electron app, which
+ * has been serving the "Open in GitWarren" page there since M2, and a
+ * `gitwarren serve` for someone who will not install an Electron app - and they
+ * must serve the *same* web build from the *same* port with the *same* gate.
+ * One handler, mounted by each of them, is how that stays true. `mount` is the
+ * only thing they disagree about:
+ *
+ *  - The app mounts at `/app/`, because `/` is the link page and that page is
+ *    verified behaviour a review link depends on.
+ *  - The daemon mounts at `/`, because there is no link page worth serving when
+ *    there is no protocol handler to hand a link to - and a `guiUrl` opening
+ *    the review directly, with no "Open in GitWarren" hop, is the thing M3 is
+ *    for.
+ *
+ * The mount always ends in `/`. Asset URLs in the build are relative, so the
+ * document's own path is what they resolve against, and a path without the
+ * trailing slash would resolve them one level too high. Routes are in the hash,
+ * so the path is *always* exactly the mount however deep the user has navigated
+ * - which is what makes relative assets safe here and would not be true of a
+ * history-API router.
+ *
+ * ## The gate, in the order a request meets it
+ *
+ * 1. `Host` must be the loopback authority, and `Origin` - when there is one -
+ *    must be ours. See `origin.ts`; neither check is about tokens.
+ * 2. `?token=…` on any path under the mount is exchanged for a session cookie
+ *    and redirected away, so the secret does not stay in the address bar, in
+ *    the history, or in a `Referer`.
+ * 3. Without a valid cookie, every path answers the same short page saying how
+ *    to get in. Not a 404: pretending the app is not there would be a lie the
+ *    user cannot act on, and the port is not a secret anyway - the token is.
+ *
+ * The socket is upgraded only after the same three, with `Origin` required
+ * rather than optional, because a WebSocket handshake is never a navigation.
+ */
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { Duplex } from 'node:stream'
+import { WebSocketServer } from 'ws'
+import { serveWebSocket } from '../rpc/websocket.js'
+import { isAllowedHost, isAllowedOrigin, loopbackAuthority } from './origin.js'
+import { LINK_SERVER_PORT } from '../../shared/link-port.js'
+import { serveStatic } from './static.js'
+import { isWebToken } from './token.js'
+import { SESSION_COOKIE, TOKEN_PARAM, WEB_PATHS, WEB_PREFIX } from '../../shared/web.js'
+import type { AppInfo } from '../../shared/api.js'
+
+export interface WebHandlerOptions {
+  /** Always ends in `/`. `/` for the daemon, `/app/` for the Electron app. */
+  mount: string
+  /** The directory holding the web build - `out/web`. */
+  staticRoot: string
+  /** This launch's token. See `token.ts`. */
+  token: string
+  /** Facts about this install, for the browser shell. Read per request. */
+  appInfo: () => AppInfo | Promise<AppInfo>
+  /**
+   * The port this handler is actually reachable on. Defaults to the fixed link
+   * port, which is the only one either shell serves it on.
+   *
+   * It exists because the `Host` and `Origin` checks are assertions about the
+   * authority *this* server was reached at, and a handler that hard-coded the
+   * number could not be exercised anywhere but on that one port - which on a
+   * developer's machine is usually held by their own running GitWarren.
+   */
+  port?: number
+}
+
+export interface WebHandler {
+  /** True when the request was answered here; false leaves it to the caller. */
+  request(request: IncomingMessage, response: ServerResponse): boolean
+  /** True when the upgrade was taken; false leaves it to the caller. */
+  upgrade(request: IncomingMessage, socket: Duplex, head: Buffer): boolean
+  close(): void
+}
+
+const NO_STORE = {
+  'Cache-Control': 'no-store',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'no-referrer'
+} as const
+
+/**
+ * Cookies, parsed only far enough to find one name.
+ *
+ * Deliberately not a general cookie parser: a browser sends what it sends, and
+ * the only question here is whether a value under our name is the token.
+ */
+function readCookie(header: string | undefined, name: string): string | undefined {
+  if (!header) return undefined
+  for (const part of header.split(';')) {
+    const separator = part.indexOf('=')
+    if (separator === -1) continue
+    if (part.slice(0, separator).trim() !== name) continue
+    return decodeURIComponent(part.slice(separator + 1).trim())
+  }
+  return undefined
+}
+
+/**
+ * The page shown to a request that has no session.
+ *
+ * Inert: no script, no form, no image, and a policy that permits none of the
+ * three. It tells the user how to get a URL that works and says nothing about
+ * the token itself - a page served to whoever asked is not the place to put a
+ * secret, which is the entire point of the page.
+ */
+const UNAUTHORIZED_PAGE =
+  '<!doctype html>\n<html lang="en"><head><meta charset="utf-8">' +
+  '<meta name="viewport" content="width=device-width, initial-scale=1">' +
+  '<meta name="robots" content="noindex"><title>GitWarren</title>' +
+  '<style>body{margin:0;min-height:100vh;display:grid;place-items:center;padding:1.5rem;' +
+  'font:14px/1.55 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;' +
+  'background:#fbfbfd;color:#1e2230}@media(prefers-color-scheme:dark){body{background:#14161d;' +
+  'color:#eef0f6}}main{max-width:30rem;text-align:center}code{font-family:ui-monospace,' +
+  'SFMono-Regular,Menlo,Consolas,monospace}</style></head><body><main>' +
+  '<h1>This GitWarren needs its token</h1>' +
+  '<p>Open the URL printed by <code>gitwarren serve</code>, or run ' +
+  '<code>gitwarren open</code> on this machine.</p>' +
+  '<p>The token is minted fresh each time GitWarren starts, so a link from an ' +
+  'earlier run will not work.</p></main></body></html>\n'
+
+const UNAUTHORIZED_HEADERS = {
+  ...NO_STORE,
+  'Content-Type': 'text/html; charset=utf-8',
+  'Content-Security-Policy':
+    "default-src 'none'; style-src 'unsafe-inline'; form-action 'none'; " +
+    "frame-ancestors 'none'; base-uri 'none'"
+} as const
+
+export function createWebHandler({
+  mount,
+  staticRoot,
+  token,
+  appInfo,
+  port = LINK_SERVER_PORT
+}: WebHandlerOptions): WebHandler {
+  if (!mount.endsWith('/')) throw new Error(`A web mount must end in "/", got ${mount}`)
+
+  // `noServer`: the HTTP server is not ours to own - the app's link server and
+  // the daemon each have one already, and both need the upgrade to pass through
+  // the same gate as a request before `ws` ever sees it.
+  const sockets = new WebSocketServer({ noServer: true })
+
+  /** Whether a pathname belongs to this handler at all. */
+  const mine = (pathname: string): boolean =>
+    pathname.startsWith(WEB_PREFIX) ||
+    pathname === mount.slice(0, -1) ||
+    pathname.startsWith(mount) ||
+    // `/` under a `/` mount is `mount` itself, already covered; this is the
+    // app's own mount typed without its slash, which is redirected below.
+    (mount === '/' && pathname === '')
+
+  const authorised = (request: IncomingMessage): boolean =>
+    isWebToken(token, readCookie(request.headers.cookie, SESSION_COOKIE))
+
+  return {
+    request(request, response) {
+      const url = new URL(request.url ?? '/', `http://${loopbackAuthority(port)}`)
+      const pathname = decodeURIComponent(url.pathname)
+      if (!mine(pathname)) return false
+
+      if (!isAllowedHost(request.headers.host, port)) {
+        response.writeHead(403, NO_STORE).end()
+        return true
+      }
+
+      // Reads may arrive as a navigation, which carries no Origin. Anything
+      // else is a page acting on its own behalf and must name itself.
+      const isRead = request.method === 'GET' || request.method === 'HEAD'
+      if (!isAllowedOrigin(request.headers.origin, { required: !isRead, port })) {
+        response.writeHead(403, NO_STORE).end()
+        return true
+      }
+
+      if (!isRead) {
+        response.writeHead(405, { ...NO_STORE, Allow: 'GET, HEAD' }).end()
+        return true
+      }
+
+      // The token, exchanged for a cookie and taken straight back out of the
+      // URL. `SameSite=Strict` is what makes a cross-site page unable to use
+      // the session even when it can guess the port; `HttpOnly` keeps the value
+      // out of reach of anything that manages to run script on the page.
+      const presented = url.searchParams.get(TOKEN_PARAM)
+      if (presented !== null) {
+        if (!isWebToken(token, presented)) {
+          response.writeHead(403, UNAUTHORIZED_HEADERS).end(UNAUTHORIZED_PAGE)
+          return true
+        }
+
+        url.searchParams.delete(TOKEN_PARAM)
+        // The fragment never reached this process - browsers do not send it -
+        // and it survives a 302 on its own, which is what lets a link with a
+        // route in it keep that route across the exchange.
+        response
+          .writeHead(302, {
+            ...NO_STORE,
+            'Set-Cookie':
+              `${SESSION_COOKIE}=${encodeURIComponent(presented)}; Path=/; HttpOnly; ` +
+              `SameSite=Strict`,
+            Location: `${url.pathname}${url.search}`
+          })
+          .end()
+        return true
+      }
+
+      if (!authorised(request)) {
+        response.writeHead(401, UNAUTHORIZED_HEADERS).end(UNAUTHORIZED_PAGE)
+        return true
+      }
+
+      if (pathname === WEB_PATHS.appInfo) {
+        void Promise.resolve(appInfo())
+          .then((info) => {
+            response
+              .writeHead(200, { ...NO_STORE, 'Content-Type': 'application/json; charset=utf-8' })
+              .end(request.method === 'HEAD' ? undefined : JSON.stringify(info))
+          })
+          .catch((error: unknown) => {
+            console.error('[web] could not describe this install', error)
+            response.writeHead(500, NO_STORE).end()
+          })
+        return true
+      }
+
+      // The socket path only exists as an upgrade. A plain GET to it is a
+      // mistake worth naming rather than a 404 among many.
+      if (pathname === WEB_PATHS.socket) {
+        response.writeHead(426, { ...NO_STORE, Upgrade: 'websocket' }).end()
+        return true
+      }
+
+      if (pathname.startsWith(WEB_PREFIX)) {
+        response.writeHead(404, NO_STORE).end()
+        return true
+      }
+
+      // `/app` without its slash. Relative asset URLs in the document would
+      // resolve against `/` from there, so the redirect is not cosmetic.
+      if (pathname === mount.slice(0, -1)) {
+        response.writeHead(302, { ...NO_STORE, Location: `${mount}${url.search}` }).end()
+        return true
+      }
+
+      const within = pathname.slice(mount.length - 1) || '/'
+      const { served } = serveStatic(staticRoot, within, request.method ?? 'GET', response)
+      if (!served) response.writeHead(404, NO_STORE).end()
+      return true
+    },
+
+    upgrade(request, socket, head) {
+      const url = new URL(request.url ?? '/', `http://${loopbackAuthority(port)}`)
+      if (decodeURIComponent(url.pathname) !== WEB_PATHS.socket) return false
+
+      // A refusal here is a socket write, not a response object: the connection
+      // has already left HTTP behind. Every one of them ends the connection
+      // rather than leaving a half-upgraded socket around.
+      const refuse = (status: string): true => {
+        socket.write(`HTTP/1.1 ${status}\r\nConnection: close\r\n\r\n`)
+        socket.destroy()
+        return true
+      }
+
+      if (!isAllowedHost(request.headers.host, port)) return refuse('403 Forbidden')
+      // Required, unlike on a read: an upgrade is never a top-level navigation,
+      // so a browser always sends it and a missing one is not a browser.
+      if (!isAllowedOrigin(request.headers.origin, { required: true, port }))
+        return refuse('403 Forbidden')
+      if (!authorised(request)) return refuse('401 Unauthorized')
+
+      sockets.handleUpgrade(request, socket, head, (websocket) => {
+        serveWebSocket(websocket)
+      })
+      return true
+    },
+
+    close() {
+      sockets.close()
+    }
+  }
+}

--- a/src/core/web/origin.ts
+++ b/src/core/web/origin.ts
@@ -1,0 +1,68 @@
+/**
+ * Who is allowed to be talking to this server at all, before a token is even
+ * looked at.
+ *
+ * Two headers, checked on every request and on every WebSocket upgrade. They
+ * guard different attacks and neither one covers for the other.
+ *
+ * ## `Host`, against DNS rebinding
+ *
+ * Binding to 127.0.0.1 stops other machines connecting. It does not stop a web
+ * page: an attacker's domain can be made to resolve to 127.0.0.1, at which
+ * point the browser considers `http://evil.example` and this server the same
+ * origin and hands the page everything, cookies included. The one thing the
+ * attacker cannot change is the `Host` header the browser sends, which still
+ * says `evil.example`. Requiring it to be the loopback authority we hand out is
+ * what closes that door - the same check `main/link-server.ts` has made since
+ * M2, for the same reason.
+ *
+ * Only `127.0.0.1:<port>` is accepted, not `localhost:<port>`. `localhost` is
+ * not attacker-controllable and would be safe to allow, but it is a *different*
+ * origin to a browser: a session cookie set on one is not sent to the other, so
+ * accepting both would mean a user who typed the wrong one got an unexplained
+ * "no session" page. One authority, named in every URL this app mints.
+ *
+ * ## `Origin`, against a page that already knows the port
+ *
+ * A cross-site page cannot read a response it is not allowed to read, but it
+ * can *make* the request, and a state-changing one is enough to be worth
+ * refusing. `SameSite=Strict` on the session cookie already means such a
+ * request arrives without credentials and is refused for that reason; the
+ * Origin check is the second lock, and the one that does not depend on a
+ * browser's cookie policy being what we think it is.
+ *
+ * An absent `Origin` is allowed for reads, and that is not a hole. Browsers
+ * omit it on top-level navigations - which is precisely how a person arrives
+ * here, by clicking a link in a terminal - and send it on every fetch, every
+ * form post and every WebSocket upgrade. So "absent" means "not a page acting
+ * on its own behalf", and the places where that would matter (writes, the
+ * socket) require it to be present and correct.
+ */
+import { LINK_SERVER_HOST, LINK_SERVER_PORT } from '../../shared/link-port.js'
+
+/** The one authority this server answers to. */
+export function loopbackAuthority(port: number = LINK_SERVER_PORT): string {
+  return `${LINK_SERVER_HOST}:${port}`
+}
+
+export function isAllowedHost(host: string | undefined, port?: number): boolean {
+  return host === loopbackAuthority(port)
+}
+
+/**
+ * Whether an `Origin` may act on this server.
+ *
+ * `required` is what separates a navigation from a fetch: reads that a person
+ * can reach by typing a URL tolerate an absent origin, and anything a page
+ * could have initiated on its own does not.
+ */
+export function isAllowedOrigin(
+  origin: string | undefined,
+  { required, port }: { required: boolean; port?: number } = { required: false }
+): boolean {
+  if (origin === undefined || origin === '') return !required
+  // `null` is what a sandboxed iframe or a `data:` document sends. It is an
+  // origin, it is not ours, and it is never allowed - which is why this is a
+  // string comparison against the one value we mint rather than a parse.
+  return origin === `http://${loopbackAuthority(port)}`
+}

--- a/src/core/web/static.ts
+++ b/src/core/web/static.ts
@@ -1,0 +1,180 @@
+/**
+ * Serving the web build off disk, with the two rules that matter for a file
+ * server pointed at a directory inside an application bundle.
+ *
+ * **Nothing outside the root, ever.** The path comes from a URL, and a URL can
+ * say `..`, can say it percent-encoded, and on Windows can say `..\`. The
+ * defence is not to sanitise the request but to resolve it and then check where
+ * it landed: `resolve()` collapses every traversal there is, and a result that
+ * is not under the root is refused whatever it looks like. This is the same
+ * shape as the worktree confinement M0 put on `core/git.ts`, and it is the only
+ * one worth trusting - a blocklist of dangerous spellings is a list someone
+ * will find a new entry for.
+ *
+ * **A single-page app needs an index fallback, and it must not become an open
+ * redirect to `index.html` for everything.** A request for a path with no file
+ * behind it is answered with the document, so a deep link into the app works on
+ * a cold load; a request for a *missing asset* is answered with 404, because
+ * handing back HTML with a `.js` content type is how a blank page with a
+ * baffling console error happens. The difference is whether the path looks like
+ * a file, which here means "the last segment has an extension".
+ *
+ * Read fresh on every request rather than cached in memory: the files are small
+ * and the OS page cache is better at this than a Map, and it means a dev build
+ * replaced on disk is served without restarting the process.
+ */
+import { createReadStream, statSync } from 'node:fs'
+import { extname, join, resolve, sep } from 'node:path'
+import type { ServerResponse } from 'node:http'
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.map': 'application/json; charset=utf-8'
+}
+
+/**
+ * `nosniff` is the load-bearing one: it is what stops a browser deciding for
+ * itself that something we labelled `text/plain` is really a script.
+ *
+ * There is no Content-Security-Policy here. The renderer is a React app with
+ * inline styles from Tailwind and dynamic imports, and a policy that permitted
+ * all of it would permit anything worth stopping. What contains this page is
+ * the origin it is served from: nothing else may talk to it (see `origin.ts`)
+ * and nothing may frame it.
+ */
+const COMMON_HEADERS = {
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'no-referrer',
+  'X-Frame-Options': 'DENY'
+} as const
+
+/**
+ * Hashed assets are immutable; the document never is.
+ *
+ * Vite puts a content hash in every filename under `assets/`, so those may be
+ * cached forever - a new build is a new name. `index.html` names them, so it
+ * must never be cached at all, or an updated app would keep loading the files
+ * the stale document points at.
+ */
+function cacheControlFor(pathname: string): string {
+  return pathname.includes('/assets/') ? 'public, max-age=31536000, immutable' : 'no-store'
+}
+
+function contentTypeFor(file: string): string {
+  return CONTENT_TYPES[extname(file).toLowerCase()] ?? 'application/octet-stream'
+}
+
+/** Whether a request is asking for a file rather than for a screen. */
+function looksLikeAFile(pathname: string): boolean {
+  const last = pathname.slice(pathname.lastIndexOf('/') + 1)
+  return last.includes('.')
+}
+
+/**
+ * The file on disk a pathname refers to, or null when it escapes the root.
+ *
+ * The pathname arrives already decoded, and a decoded segment may contain a
+ * `/` or a `\` that was encoded precisely so it would not be seen as a
+ * separator - so the check is on the resolved result, after `join` has had its
+ * way with it, and never on the input.
+ */
+function resolveWithin(root: string, pathname: string): string | null {
+  const candidate = resolve(join(root, pathname))
+  const rootWithSeparator = root.endsWith(sep) ? root : root + sep
+  if (candidate !== root && !candidate.startsWith(rootWithSeparator)) return null
+  return candidate
+}
+
+export interface StaticResult {
+  /** False when nothing was sent, so the caller can answer 404 in its own voice. */
+  served: boolean
+}
+
+/**
+ * Answer a request from `root`.
+ *
+ * `pathname` is relative to the mount, decoded, and always starts with `/`.
+ * Streaming rather than `readFileSync`: the diff bundle is not small and there
+ * is no reason to hold a copy of it per request.
+ */
+export function serveStatic(
+  root: string,
+  pathname: string,
+  method: string,
+  response: ServerResponse
+): StaticResult {
+  const target = resolveWithin(root, pathname)
+  if (target === null) {
+    response.writeHead(403, COMMON_HEADERS).end()
+    return { served: true }
+  }
+
+  const file = pickFile(target, pathname, root)
+  if (file === null) return { served: false }
+
+  response.writeHead(200, {
+    ...COMMON_HEADERS,
+    'Content-Type': contentTypeFor(file),
+    'Content-Length': statSync(file).size,
+    'Cache-Control': cacheControlFor(pathname)
+  })
+
+  if (method === 'HEAD') {
+    response.end()
+    return { served: true }
+  }
+
+  const stream = createReadStream(file)
+  // A read that fails after the head is written cannot be turned into a status
+  // code any more; destroying the socket is the only honest end, and it makes
+  // the failure visible to the client instead of leaving it waiting.
+  stream.on('error', (error) => {
+    console.error('[web] could not read a static file', error)
+    response.destroy()
+  })
+  stream.pipe(response)
+  return { served: true }
+}
+
+/**
+ * The file to send: the request's own, `index.html` inside a directory, or the
+ * app document for a route that has no file behind it.
+ */
+function pickFile(target: string, pathname: string, root: string): string | null {
+  const direct = statOrNull(target)
+  if (direct?.isFile()) return target
+
+  if (direct?.isDirectory()) {
+    const index = join(target, 'index.html')
+    if (statOrNull(index)?.isFile()) return index
+  }
+
+  // A missing *asset* is a 404 and not the document - see the note at the top.
+  if (looksLikeAFile(pathname)) return null
+
+  const index = join(root, 'index.html')
+  return statOrNull(index)?.isFile() ? index : null
+}
+
+function statOrNull(path: string): ReturnType<typeof statSync> | null {
+  try {
+    return statSync(path)
+  } catch {
+    return null
+  }
+}

--- a/src/core/web/token.ts
+++ b/src/core/web/token.ts
@@ -1,0 +1,104 @@
+/**
+ * The per-launch token that stands between a loopback port and everything on
+ * this machine that can reach it.
+ *
+ * Jupyter's arrangement, for Jupyter's reason. A port on 127.0.0.1 is not a
+ * private thing: every process the user runs can connect to it, and so can any
+ * web page the user happens to have open, since a browser will cheerfully issue
+ * requests to loopback from a page served by anyone at all. The link server
+ * could ignore that by being inert - it answers one static page and holds no
+ * capability worth stealing. A server that reads repositories and writes
+ * comments cannot, so it needs to know that whoever is asking was told the
+ * secret.
+ *
+ * Three properties, and each one is doing work:
+ *
+ *  - **Per launch, never persisted across one.** The token is minted in memory
+ *    at startup. Nothing has to expire it, revoking it is `quit`, and a token
+ *    left in a shell history is worthless by the next boot.
+ *  - **Written to a file only the user can read.** `gitwarren open` in M3.3 has
+ *    to find it without the user copying anything, and 0600 in the data
+ *    directory is how. It is deliberately not put in `daemon-runtime.json`,
+ *    which is a published fact about the machine written with ordinary
+ *    permissions; a secret does not belong in a file whose whole purpose is to
+ *    be read by other processes.
+ *  - **Compared in constant time.** The comparison is against a value an
+ *    attacker supplies and can retry, which is the exact shape a timing oracle
+ *    needs. `timingSafeEqual` costs nothing here and removes the question.
+ *
+ * What it is *not* is authentication of a person. Rule 5 says identity is a
+ * principal, and the principal on loopback is "whoever is at this machine".
+ * This gate answers a narrower question - was this request made by something
+ * the user pointed at GitWarren, or by a page that merely knows the port.
+ */
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import { chmodSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { ensureDataDirectory, getDataDirectory } from '../paths.js'
+
+/**
+ * 32 bytes. Long past any brute force over a socket, short enough that the URL
+ * it goes into is still one line in a terminal.
+ */
+const TOKEN_BYTES = 32
+
+const TOKEN_FILE_NAME = 'web-token'
+
+export function getWebTokenPath(): string {
+  return join(getDataDirectory(), TOKEN_FILE_NAME)
+}
+
+/** A fresh token. base64url so it survives a query string untouched. */
+export function mintWebToken(): string {
+  return randomBytes(TOKEN_BYTES).toString('base64url')
+}
+
+/**
+ * Publish the token for `gitwarren open` to find.
+ *
+ * `writeFileSync` with `mode` only applies the mode when it *creates* the file,
+ * so an existing file left by an earlier launch would keep whatever permissions
+ * it had. Removing it first is what makes the 0600 unconditional, and the
+ * explicit `chmodSync` covers the platforms where the umask still had its say.
+ * Windows ignores both, which is expected: there the file inherits the user
+ * profile's ACL, and that is the same protection by a different mechanism.
+ *
+ * Logged rather than thrown, like `writeDaemonRuntime`: a machine that cannot
+ * write this file has lost `gitwarren open`, not the server, and the URL is on
+ * stderr either way.
+ */
+export function publishWebToken(token: string): void {
+  try {
+    ensureDataDirectory()
+    const path = getWebTokenPath()
+    rmSync(path, { force: true })
+    writeFileSync(path, token, { encoding: 'utf8', mode: 0o600 })
+    chmodSync(path, 0o600)
+  } catch (error) {
+    console.error('[web] could not publish the session token', error)
+  }
+}
+
+/** Remove it on the way out. Missing is the same as gone. */
+export function clearWebToken(): void {
+  try {
+    rmSync(getWebTokenPath(), { force: true })
+  } catch (error) {
+    console.error('[web] could not remove the session token', error)
+  }
+}
+
+/**
+ * Whether a presented value is the token.
+ *
+ * The length check before `timingSafeEqual` is required rather than an
+ * optimisation - it throws on buffers of different lengths - and it leaks only
+ * the length of a value the caller already knows the length of.
+ */
+export function isWebToken(token: string, presented: string | undefined): boolean {
+  if (presented === undefined) return false
+  const expected = Buffer.from(token, 'utf8')
+  const actual = Buffer.from(presented, 'utf8')
+  if (expected.length !== actual.length) return false
+  return timingSafeEqual(expected, actual)
+}

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -31,22 +31,30 @@
  * quite reasonably running its own GitWarren too.
  *
  * Ownership is about who holds the loopback port and answers links, which in M2
- * is the GUI and in M3 will also be a *listening* `gitwarren serve`. That is
- * where the check belongs, and where it goes.
+ * is the GUI and since M3 is also a *listening* `gitwarren serve`. That is
+ * where the check belongs, and `listen.ts` next door is where it went: that
+ * mode binds a port, claims the runtime file and refuses to start beside a
+ * running app, none of which is true of the pipe this paragraph is about.
  */
 import { closeDatabase, getDatabase } from '../core/db/client.js'
 import { getInstanceId } from '../core/instance.js'
 import { getDatabasePath } from '../core/paths.js'
 import { serveStdio } from '../core/rpc/stdio.js'
 import { RPC_PROTOCOL_VERSION } from '../shared/rpc.js'
+import { runListen } from './listen.js'
 
 const USAGE = `gitwarren serve --stdio
+gitwarren serve --listen
 
-Answers GitWarren's message protocol on stdin and stdout, one JSON object per
-line. Intended to be spawned by a GitWarren app over a pipe - by hand it is a
-way to see what the protocol says:
+--stdio answers GitWarren's message protocol on stdin and stdout, one JSON
+object per line. Intended to be spawned by a GitWarren app over a pipe - by
+hand it is a way to see what the protocol says:
 
   echo '{"id":1,"method":"repositories.list"}' | gitwarren serve --stdio
+
+--listen serves the web view on loopback and prints a URL carrying this
+launch's token. It claims this machine's data directory, so it refuses to
+start while the app is running - see daemon/listen.ts.
 `
 
 /**
@@ -55,6 +63,12 @@ way to see what the protocol says:
  * different mode of its own - `main/index.ts` reuses this for `--serve`.
  */
 export function runDaemon(argv: readonly string[]): boolean {
+  // Checked before `--stdio` only because it is the mode that can *refuse*, and
+  // its refusals are sentences rather than a usage block. The two are exclusive:
+  // one binds a port and owns the machine, the other answers a pipe and owns
+  // nothing.
+  if (argv.includes('--listen')) return runListen()
+
   if (!argv.includes('--stdio')) {
     console.error(USAGE)
     return false

--- a/src/daemon/listen.ts
+++ b/src/daemon/listen.ts
@@ -1,0 +1,239 @@
+/**
+ * `gitwarren serve --listen`: GitWarren with a browser tab for a shell.
+ *
+ * The other carrier in this directory answers a pipe somebody else opened. This
+ * one binds a port, which makes it a completely different kind of process - it
+ * is a candidate for *owning* the machine, and ownership is the thing
+ * `core/daemon-runtime.ts` exists to arbitrate. A data directory has one owner;
+ * the second process to want it stands aside.
+ *
+ * So this refuses to start next to a running GUI, and says why. That is not the
+ * `--stdio` rule reversed for no reason: a stdio daemon binds nothing, answers
+ * one pipe and dies with its parent, so it is not competing for anything - and
+ * refusing *there* would break M4, where a Mac spawns a daemon on a PC that is
+ * quite reasonably running its own GitWarren. Here the two would be fighting
+ * over one port and one link, and the honest answer is that the app already
+ * has them.
+ *
+ * ## What it serves
+ *
+ * The web build, at `/`, gated by the token in `core/web/token.ts`. At `/`
+ * rather than under `/app/` because there is no Electron app here to hand a
+ * `gitwarren://` link to, so there is no "Open in GitWarren" page worth
+ * serving: an agent's `guiUrl` should simply *be* the review, which is the hop
+ * M3 exists to remove. The app mounts the identical handler one level down for
+ * the opposite reason - see `shared/web.ts`.
+ */
+import { createServer } from 'node:http'
+import { existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { closeDatabase, getDatabase } from '../core/db/client.js'
+import {
+  clearDaemonRuntime,
+  readLiveDaemonRuntime,
+  writeDaemonRuntime
+} from '../core/daemon-runtime.js'
+import { getInstanceId } from '../core/instance.js'
+import { getMcpLauncherPath } from '../core/mcp-launcher.js'
+import { getDatabasePath, getDataDirectory } from '../core/paths.js'
+import { createWebHandler } from '../core/web/handler.js'
+import { clearWebToken, mintWebToken, publishWebToken } from '../core/web/token.js'
+import { LINK_SERVER_HOST, LINK_SERVER_PORT } from '../shared/link-port.js'
+import { TOKEN_PARAM } from '../shared/web.js'
+import type { AppInfo, McpLaunchInfo } from '../shared/api.js'
+
+/** Stamped by `vite.daemon.config.ts`. Nothing reads a package.json out of a bundle. */
+declare const __APP_VERSION__: string
+
+/**
+ * `typeof` rather than the identifier: `tsx src/daemon/serve.ts --listen` runs
+ * this file with no build in front of it, so the define does not exist and a
+ * bare reference would be a crash on startup in the one mode used for
+ * development.
+ */
+const VERSION = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : '0.0.0-dev'
+
+/**
+ * Where the web build is, in the three places this process can be run from.
+ *
+ * The env var is first so a tarball that puts the files somewhere else - or
+ * someone debugging a build - can say so without a code change. Then the
+ * sibling of this file, which is `out/web` next to `out/daemon/serve.cjs`, and
+ * finally the repository's own `out/`, which is what `tsx src/daemon/serve.ts`
+ * has to fall back to.
+ *
+ * ## Why "has an index.html" is not the test
+ *
+ * Because `src/web` has one too - it is Vite's entry document, and it points at
+ * `./main.ts`, which no browser can execute. Run under tsx, the sibling of this
+ * file *is* that directory, so the obvious check picks the source tree, serves
+ * a page that fetches TypeScript, and produces a blank screen with a MIME error
+ * rather than an honest "no web build". A built document never mentions
+ * `main.ts` - Vite emits hashed names - so the absence of that file is what
+ * separates the two, and it is checked rather than assumed because the failure
+ * it prevents is silent.
+ */
+function isWebBuild(directory: string): boolean {
+  return existsSync(join(directory, 'index.html')) && !existsSync(join(directory, 'main.ts'))
+}
+
+function resolveWebRoot(): string | null {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const candidates = [
+    process.env.GITWARREN_WEB_ROOT,
+    join(here, '..', 'web'),
+    resolve(process.cwd(), 'out', 'web')
+  ]
+
+  for (const candidate of candidates) {
+    if (candidate && isWebBuild(candidate)) return resolve(candidate)
+  }
+  return null
+}
+
+/**
+ * What this install can tell a browser about itself.
+ *
+ * Thinner than the app's: there is no `app.getVersion()`, no updater and no
+ * `isPackaged`. The MCP launcher path is the one field worth getting exactly
+ * right, because the Agent Access panel prints it as a command to paste, and a
+ * daemon that named a different path from the app's would hand out an
+ * instruction that works on one of them - hence `core/mcp-launcher.ts`.
+ */
+function describeInstall(linkPort: number | null): AppInfo {
+  const launcher = getMcpLauncherPath()
+  const mcp: McpLaunchInfo = {
+    command: launcher,
+    args: [],
+    env: {},
+    available: existsSync(launcher),
+    stable: true,
+    // The daemon does not write the launcher - M3.3's `gitwarren service
+    // install` does - so it reports the same path and lets `available` say
+    // whether anything is there yet.
+    direct: { command: launcher, args: [], env: {} },
+    note: existsSync(launcher)
+      ? undefined
+      : 'No MCP launcher on this machine yet. `gitwarren service install` writes it.'
+  }
+
+  return {
+    version: VERSION,
+    instanceId: getInstanceId(),
+    platform: process.platform,
+    packaged: true,
+    dataDirectory: getDataDirectory(),
+    databasePath: getDatabasePath(),
+    linkPort,
+    mcp
+  }
+}
+
+/**
+ * Bind, publish, and print the one URL that works.
+ *
+ * Returns false when it could not start, so `serve.ts` can exit with something
+ * a script can read. Every refusal prints a sentence naming what to do about
+ * it: this is a command someone typed, and an exit code on its own is not an
+ * answer.
+ */
+export function runListen(): boolean {
+  const owner = readLiveDaemonRuntime()
+  if (owner) {
+    console.error(
+      `[gitwarren-serve] this machine's GitWarren is already being served by ` +
+        `${owner.owner === 'gui' ? 'the app' : 'another gitwarren serve'} (pid ${owner.pid}). ` +
+        `A data directory has one owner. Quit that first, or use the one that is running.`
+    )
+    process.exitCode = 1
+    return false
+  }
+
+  const webRoot = resolveWebRoot()
+  if (!webRoot) {
+    console.error(
+      '[gitwarren-serve] no web build found. Run `npm run build:web`, or set ' +
+        'GITWARREN_WEB_ROOT to the directory holding its index.html.'
+    )
+    process.exitCode = 1
+    return false
+  }
+
+  // Before the first request, so a browser's opening burst does not race the
+  // migrations - the same reason `daemon.ts` does it before the first frame.
+  getDatabase()
+
+  const token = mintWebToken()
+  publishWebToken(token)
+
+  let linkPort: number | null = null
+  const handler = createWebHandler({
+    mount: '/',
+    staticRoot: webRoot,
+    token,
+    appInfo: () => describeInstall(linkPort)
+  })
+
+  const server = createServer((request, response) => {
+    // Everything is the web handler's here; a path it does not claim is a 404
+    // rather than a fallback to some other page, because there is no other page.
+    if (!handler.request(request, response)) response.writeHead(404).end()
+  })
+
+  server.on('upgrade', (request, socket, head) => {
+    if (!handler.upgrade(request, socket, head)) socket.destroy()
+  })
+
+  server.on('error', (error: NodeJS.ErrnoException) => {
+    if (error.code === 'EADDRINUSE') {
+      console.error(
+        `[gitwarren-serve] port ${LINK_SERVER_PORT} is already in use. That port is the one ` +
+          `every GitWarren link names, so serving on a different one would mean serving where ` +
+          `nobody is looking. Free it and start again.`
+      )
+    } else {
+      console.error('[gitwarren-serve] the server failed', error)
+    }
+    shutdownListen()
+    process.exitCode = 1
+  })
+
+  server.listen(LINK_SERVER_PORT, LINK_SERVER_HOST, () => {
+    linkPort = LINK_SERVER_PORT
+    writeDaemonRuntime({
+      instanceId: getInstanceId(),
+      pid: process.pid,
+      linkPort,
+      owner: 'daemon'
+    })
+
+    // stderr, like every other diagnostic here: stdout belongs to the protocol
+    // in the other carrier and there is no reason for the two to disagree about
+    // which stream a human message goes on.
+    console.error(
+      `[gitwarren-serve] GitWarren is at\n\n` +
+        `    http://${LINK_SERVER_HOST}:${LINK_SERVER_PORT}/?${TOKEN_PARAM}=${token}\n\n` +
+        `The token is new each time this starts, and is exchanged for a session cookie the ` +
+        `first time the URL is opened.`
+    )
+  })
+
+  closeOnExit = () => {
+    handler.close()
+    server.close()
+  }
+
+  return true
+}
+
+let closeOnExit: (() => void) | null = null
+
+/** Release everything this mode claimed. Safe to call when it never started. */
+export function shutdownListen(): void {
+  closeOnExit?.()
+  closeOnExit = null
+  clearWebToken()
+  clearDaemonRuntime()
+  closeDatabase()
+}

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -7,11 +7,17 @@
  * it. Keeping the two apart is what lets that import happen without this file's
  * `process.exit` firing inside the Electron main process.
  */
-import { closeDatabase } from '../core/db/client.js'
 import { runDaemon } from './daemon.js'
+import { shutdownListen } from './listen.js'
 
+/**
+ * `shutdownListen` covers the stdio carrier too: it closes the database and is
+ * a no-op about everything the listening mode claimed when that mode never ran.
+ * One exit path rather than two, so a signal cannot leave a runtime file or a
+ * token behind depending on which flag the process was started with.
+ */
 function shutdown(): void {
-  closeDatabase()
+  shutdownListen()
   process.exit(0)
 }
 
@@ -19,5 +25,7 @@ process.on('SIGINT', shutdown)
 process.on('SIGTERM', shutdown)
 
 // 2 rather than 1: this is "you asked for something that is not a carrier",
-// which a caller can act on, not "the daemon fell over".
-if (!runDaemon(process.argv.slice(2))) process.exit(2)
+// which a caller can act on, not "the daemon fell over". A mode that refused
+// for a reason of its own has already said which by setting `exitCode`, and
+// that answer is more specific than this one.
+if (!runDaemon(process.argv.slice(2))) process.exit(process.exitCode === undefined ? 2 : 1)

--- a/src/main/app-info.ts
+++ b/src/main/app-info.ts
@@ -1,0 +1,28 @@
+/**
+ * What this install is, as one object.
+ *
+ * Lifted out of `ipc.ts` because since M3 it has two readers that must not
+ * disagree: the window, over IPC, and a browser tab, over HTTP. The tab is
+ * looking at the *same install* - same database, same instance id, same
+ * launcher - so it has to be told the same thing, and the only way to guarantee
+ * that is for there to be one place that says it.
+ */
+import { app } from 'electron'
+import { getInstanceId } from '../core/instance.js'
+import { getDataDirectory, getDatabasePath } from '../core/paths.js'
+import { getLinkServerPort } from './link-server.js'
+import { getMcpLaunchInfo } from './mcp-launch.js'
+import type { AppInfo } from '../shared/api.js'
+
+export function describeInstall(): AppInfo {
+  return {
+    version: app.getVersion(),
+    instanceId: getInstanceId(),
+    platform: process.platform,
+    packaged: app.isPackaged,
+    dataDirectory: getDataDirectory(),
+    databasePath: getDatabasePath(),
+    linkPort: getLinkServerPort(),
+    mcp: getMcpLaunchInfo()
+  }
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -22,21 +22,18 @@
  * If you find yourself adding logic to either kind, it almost certainly belongs
  * in a service instead.
  */
-import { BrowserWindow, dialog, ipcMain, shell, app } from 'electron'
+import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { dispatch } from '../core/rpc/dispatcher.js'
 import { traced } from '../core/trace.js'
 import { attachmentsService } from '../core/services/attachments.js'
-import { getDataDirectory, getDatabasePath } from '../core/paths.js'
-import { getInstanceId } from '../core/instance.js'
 import { AppError } from '../shared/errors.js'
 import { parseWithSchema as parse } from '../shared/validation.js'
 import { openReviewFileInputSchema } from '../shared/schemas.js'
 import { CHANNEL_METHODS, IPC_CHANNELS, type AppInfo } from '../shared/api.js'
 import type { RpcMethod, RpcOutcome, RpcParams } from '../shared/rpc.js'
+import { describeInstall } from './app-info.js'
 import { listEditors, openInEditor } from './editors.js'
-import { getLinkServerPort } from './link-server.js'
 import { isOpenAtLogin, setOpenAtLogin } from './login-item.js'
-import { getMcpLaunchInfo } from './mcp-launch.js'
 import { checkForUpdates, getUpdateStatus, quitAndInstall } from './updater.js'
 
 /**
@@ -156,16 +153,7 @@ export function registerIpcHandlers(): void {
     return setOpenAtLogin(input)
   })
 
-  handleShell(IPC_CHANNELS.systemAppInfo, (): AppInfo => ({
-    version: app.getVersion(),
-    instanceId: getInstanceId(),
-    platform: process.platform,
-    packaged: app.isPackaged,
-    dataDirectory: getDataDirectory(),
-    databasePath: getDatabasePath(),
-    linkPort: getLinkServerPort(),
-    mcp: getMcpLaunchInfo()
-  }))
+  handleShell(IPC_CHANNELS.systemAppInfo, (): AppInfo => describeInstall())
 
   handleShell(IPC_CHANNELS.updatesGetStatus, () => getUpdateStatus())
   handleShell(IPC_CHANNELS.updatesCheck, () => checkForUpdates({ userInitiated: true }))

--- a/src/main/link-server.ts
+++ b/src/main/link-server.ts
@@ -17,22 +17,28 @@
  * from the browser the user just clicked in inherits the right on all three
  * platforms. The click has to reach the OS, so it is a link, not a redirect.
  *
- * ## This server never does anything
+ * ## This page never does anything
  *
- * It answers every request with the same static page and has no other endpoint.
- * That is a property worth defending rather than an accident of it being small:
- * anything on loopback is reachable by every process on the machine and by any
- * web page the user happens to have open, so an endpoint here that mutated
- * state, read a repository or drove IPC would be a capability handed to
- * whatever the user visits next. Keep it an inert file server. The route it is
- * linking to never even reaches it - that rides in the URL fragment, which
- * browsers do not send.
+ * The page below is inert, and stays inert: no endpoint of its own, no state to
+ * mutate, nothing read out of a repository. The route it links to never even
+ * reaches this process - that rides in the URL fragment, which browsers do not
+ * send.
+ *
+ * Since M3 the *server* is no longer as empty as the page, and the distinction
+ * is the point. `/app/` and `/gitwarren/…` are handed to `core/web/handler.ts`,
+ * which serves the renderer and the WebSocket carrier behind a per-launch token
+ * - the whole apparatus in `core/web/token.ts` exists because that half of the
+ * port is emphatically not inert. Everything else still lands on the page, so
+ * the M2 behaviour a review link depends on is untouched: an agent's
+ * `http://127.0.0.1:41427/#h=…` gets the button, exactly as before, on exactly
+ * the same path.
  */
 import { createServer, type Server } from 'node:http'
 import { readFileSync } from 'node:fs'
 import { LINK_SERVER_HOST, LINK_SERVER_PORT } from '../shared/link-port.js'
 import { DEEP_LINK_SCHEME, LOOPBACK_HOST_PREFIX } from '../shared/deep-link.js'
 import { INSTANCE_ID_PATTERN } from '../shared/instance-id.js'
+import { startWebHandler, stopWebHandler } from './web-view.js'
 // `?asset` copies the file next to the bundle so it also exists at runtime -
 // the same mechanism the window icon uses. It is inlined into the page as a
 // data: URI because the page has to be self-contained: serving it as a second
@@ -311,8 +317,15 @@ export function startLinkServer(onSettled?: (port: number | null) => void): void
   if (server) return
 
   const page = buildPage()
+  const web = startWebHandler()
 
   const listening = createServer((request, response) => {
+    // The web view first, and only for the paths it owns - `/app/` and
+    // `/gitwarren/…`. It applies the same Host check plus a token before it
+    // answers anything; a request it does not claim falls through to the page
+    // below with nothing changed.
+    if (web?.request(request, response)) return
+
     // The only Host that can legitimately reach this is the one we handed out.
     // Cheap, and it forecloses DNS rebinding - a name that resolves to 127.0.0.1
     // would otherwise let a web page talk to this from its own origin.
@@ -326,9 +339,16 @@ export function startLinkServer(onSettled?: (port: number | null) => void): void
       return
     }
 
-    // Every path, deliberately: there is one page and no routing to get wrong.
+    // Every other path, deliberately: there is one page and no routing to get
+    // wrong.
     response.writeHead(200, HEADERS)
     response.end(request.method === 'HEAD' ? undefined : page)
+  })
+
+  // An upgrade on this port is the web view's carrier or it is nothing. The
+  // link page has no socket and never will - see the note at the top.
+  listening.on('upgrade', (request, socket, head) => {
+    if (!web?.upgrade(request, socket, head)) socket.destroy()
   })
 
   server = listening
@@ -363,4 +383,5 @@ export function stopLinkServer(): void {
   server?.close()
   server = null
   servedPort = null
+  stopWebHandler()
 }

--- a/src/main/mcp-launch.ts
+++ b/src/main/mcp-launch.ts
@@ -35,19 +35,16 @@
  * has changed - only how it is named.
  */
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
 import { join, relative } from 'node:path'
 import { app } from 'electron'
+import { getLauncherDirectory, getMcpLauncherPath } from '../core/mcp-launcher.js'
 import type { McpLaunchInfo } from '../shared/api.js'
 
-/** `~/.gitwarren/bin`. The same on Windows, where `~` is the user profile. */
-export function getLauncherDirectory(): string {
-  return join(homedir(), '.gitwarren', 'bin')
-}
-
-export function getMcpLauncherPath(): string {
-  return join(getLauncherDirectory(), process.platform === 'win32' ? 'gitwarren-mcp.cmd' : 'gitwarren-mcp')
-}
+// Where the launcher goes now lives in `core/mcp-launcher.ts`, because a
+// `gitwarren serve` with no Electron in it has to name the same path. Writing
+// the file is still this module's job, and still Electron's business - only
+// this process knows where its own MCP server ended up.
+export { getLauncherDirectory, getMcpLauncherPath }
 
 /** Where the built server actually is, for this install. */
 function scriptPath(): string {

--- a/src/main/web-view.ts
+++ b/src/main/web-view.ts
@@ -1,0 +1,103 @@
+/**
+ * The web view, as the Electron app serves it.
+ *
+ * All of the work is in `core/web/handler.ts`; this file supplies the three
+ * things only a packaged app knows - where the build ended up, what this
+ * install is, and when to let go - and mounts the result under `/app/` on the
+ * link server's port.
+ *
+ * ## Why the app serves it at all
+ *
+ * Because it owns the port. A `gitwarren serve` stands aside while the app is
+ * running (`daemon/listen.ts`), so if the app did not serve the web view, the
+ * browser shell would be reachable only when GitWarren was quit - which is the
+ * opposite of the arrangement M2 built, where the app is the thing that is
+ * always on. One owner, both shells.
+ *
+ * ## Where the files are
+ *
+ * `out/web` inside the app bundle, which in a packaged build is inside
+ * `app.asar`. Reading from an asar is ordinary `fs` - Electron patches it - so
+ * the static server needs to know nothing about it. What it does mean is that
+ * the archive has to *contain* `out/web`, which is `electron-builder.yml`'s
+ * `files` list, and that a `electron-vite dev` session has nothing there until
+ * `npm run build:web` has been run once. That case is logged rather than
+ * treated as a failure: the window works, and the browser shell is a second
+ * distribution, not a dependency of the first.
+ */
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { app } from 'electron'
+import { createWebHandler, type WebHandler } from '../core/web/handler.js'
+import { clearWebToken, mintWebToken, publishWebToken } from '../core/web/token.js'
+import { LINK_SERVER_HOST, LINK_SERVER_PORT } from '../shared/link-port.js'
+import { TOKEN_PARAM, WEB_APP_MOUNT } from '../shared/web.js'
+import { describeInstall } from './app-info.js'
+
+let handler: WebHandler | null = null
+
+/** The web build inside this install. */
+function webRoot(): string {
+  return join(app.getAppPath(), 'out', 'web')
+}
+
+/**
+ * The URL that opens the web view in a browser, token and all.
+ *
+ * Null when there is no web build to open. Read by the Agent Access panel in
+ * M3.4; for now it is what the console line below prints, which is how the
+ * milestone is verified.
+ */
+let entryUrl: string | null = null
+
+export function getWebViewUrl(): string | null {
+  return entryUrl
+}
+
+/**
+ * Mint a token and build the handler, or return null when there is nothing to
+ * serve. Called by `startLinkServer`, which owns the actual socket.
+ */
+export function startWebHandler(): WebHandler | null {
+  if (handler) return handler
+
+  const staticRoot = webRoot()
+  if (!existsSync(join(staticRoot, 'index.html'))) {
+    console.log(
+      `[web] no web build at ${staticRoot}, so ${WEB_APP_MOUNT} is not served. ` +
+        `Run \`npm run build:web\` to have it in a dev session.`
+    )
+    return null
+  }
+
+  const token = mintWebToken()
+  publishWebToken(token)
+
+  entryUrl =
+    `http://${LINK_SERVER_HOST}:${LINK_SERVER_PORT}${WEB_APP_MOUNT}/` +
+    `?${TOKEN_PARAM}=${token}`
+
+  handler = createWebHandler({
+    mount: `${WEB_APP_MOUNT}/`,
+    staticRoot,
+    token,
+    appInfo: describeInstall
+  })
+
+  console.log(`[web] the web view is at ${entryUrl}`)
+  return handler
+}
+
+/**
+ * Drop the token on the way out.
+ *
+ * The token is per launch, so a file left behind would name a secret nothing
+ * will ever accept again - harmless, and exactly the kind of harmless leftover
+ * that makes someone debug the wrong thing a month later.
+ */
+export function stopWebHandler(): void {
+  handler?.close()
+  handler = null
+  entryUrl = null
+  clearWebToken()
+}

--- a/src/shared/web.ts
+++ b/src/shared/web.ts
@@ -1,0 +1,73 @@
+/**
+ * The names the browser shell and the server both have to know.
+ *
+ * The web build is served by the same process that answers it, so every string
+ * in here is agreed on by exactly two files that could otherwise drift: a path
+ * the server routes on, and the same path typed again in the bootstrap. They
+ * are collected here for the same reason `shared/routes.ts` exists - one
+ * grammar, spoken by a Node process and by a browser, neither importing the
+ * other's world.
+ *
+ * Plain JS only. No Node, no Electron: this is compiled into a browser bundle.
+ *
+ * ## Why everything the shell needs lives under one prefix
+ *
+ * `/gitwarren/…` is reserved for the shell; everything else under the mount is
+ * a file from the web build. A single prefix is what lets the static server say
+ * "not mine" in one comparison, and it means a renderer asset can never shadow
+ * the socket by being named `socket`. It is deliberately not `/api`: nothing
+ * here is an API in the sense the dispatcher is - see the note on
+ * `WEB_PATHS.appInfo` below.
+ */
+
+/** Everything the browser shell talks to, under one reserved prefix. */
+export const WEB_PREFIX = '/gitwarren'
+
+export const WEB_PATHS = {
+  /**
+   * The WebSocket carrier. One socket per tab, every method over it.
+   *
+   * A path rather than a subprotocol so that an upgrade to anything else on
+   * this server is a refusal rather than a negotiation.
+   */
+  socket: `${WEB_PREFIX}/socket`,
+  /**
+   * Facts about the install serving this page: version, instance id, where its
+   * database is, how an agent starts its MCP server.
+   *
+   * Not on the dispatcher, and not an action. The dispatcher may not have
+   * capabilities (see `core/rpc/dispatcher.ts`), and this is not one: it reads
+   * nothing but what the process already knows about itself. The line that
+   * matters, and the one to hold when the phone arrives in M6, is that a *fact
+   * about the host* may travel and a *capability of the host* may not.
+   * Revealing a folder or launching an editor stays with the machine the person
+   * is sitting at, which in a browser tab means it is simply absent.
+   */
+  appInfo: `${WEB_PREFIX}/app-info`
+} as const
+
+/**
+ * The cookie the session lives in, once a token has been exchanged for it.
+ *
+ * `__Host-` is the prefix that would normally belong here, and it is left off
+ * deliberately: browsers only honour it on secure origins, and loopback http is
+ * not one. The properties the prefix would have guaranteed are set explicitly
+ * instead - `Path=/`, no `Domain`, `SameSite=Strict` - and the Host check on
+ * every request is what closes the gap the missing `Secure` leaves.
+ */
+export const SESSION_COOKIE = 'gitwarren_session'
+
+/** How a token is handed over the first time: `?token=…` on any web path. */
+export const TOKEN_PARAM = 'token'
+
+/**
+ * Where the Electron app mounts the web build.
+ *
+ * The app cannot serve it at `/`, because `/` on the loopback port is the
+ * "Open in GitWarren" page an agent's link lands on, and that page is verified
+ * behaviour since M2. A `gitwarren serve` with no app next to it has no such
+ * page to protect and no protocol handler to hand a link to, so it serves the
+ * web build at `/` instead and a link opens the review directly - which is the
+ * hop M3 exists to remove. Same server, same files, two landings.
+ */
+export const WEB_APP_MOUNT = '/app'

--- a/src/web/__tests__/loopback-fragment.test.ts
+++ b/src/web/__tests__/loopback-fragment.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Coverage for the link an agent hands out, as a browser tab reads it.
+ *
+ * This is the one piece of M3 with a bug already to its name: the translated
+ * route was being written back with a `#` that `hrefFor` had already supplied,
+ * so the hash became `##/reviews/2/files`, `parseRoute` saw a first segment of
+ * `#`, and every link quietly opened the repository list instead of the review.
+ * Nothing threw, nothing was logged, and the screen it landed on is a
+ * completely plausible one - which is exactly why the round trip below asserts
+ * on `parseRoute(hrefFor(...))` rather than on the route alone.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { isLoopbackFragment, routeForLoopbackFragment } from '../loopback-fragment.js'
+import { hrefFor, parseRoute } from '../../shared/routes.js'
+
+const OURS = '22f2aac3-13f1-4f94-a180-35803e32ef61'
+const THEIRS = '11111111-1111-4111-8111-111111111111'
+
+test('an ordinary app hash is not a loopback fragment and is left alone', () => {
+  assert.equal(isLoopbackFragment('#/reviews/2/files'), false)
+  assert.equal(routeForLoopbackFragment('#/reviews/2/files', OURS), null)
+})
+
+test("a link for this install becomes that install's own local route", () => {
+  const route = routeForLoopbackFragment(`#h=${OURS}/review/2/files`, OURS)
+
+  assert.deepEqual(route, { name: 'review', reviewId: 2, tab: 'files' })
+  // No host key at all, rather than one set to undefined.
+  assert.ok(route && !('host' in route))
+})
+
+test('the translated route survives being written back out and read again', () => {
+  // The regression that started this file. `hrefFor` already begins with `#`.
+  const route = routeForLoopbackFragment(`#h=${OURS}/review/2/files`, OURS)
+  const href = hrefFor(route!)
+
+  assert.equal(href, '#/reviews/2/files')
+  assert.deepEqual(parseRoute(href), { name: 'review', reviewId: 2, tab: 'files' })
+})
+
+test('a file path with slashes in it survives the round trip', () => {
+  const fragment = `#h=${OURS}/review/2/files/${encodeURIComponent('src/core/web/handler.ts')}/head/42`
+  const route = routeForLoopbackFragment(fragment, OURS)
+
+  assert.deepEqual(parseRoute(hrefFor(route!)), {
+    name: 'review',
+    reviewId: 2,
+    tab: 'files',
+    focus: { filePath: 'src/core/web/handler.ts', side: 'head', line: 42 }
+  })
+})
+
+test("a link for another install does not open this one's review of that number", () => {
+  // The failure this rule exists to prevent: review ids are per host, so
+  // honouring the number would show the wrong review with no sign of it.
+  const route = routeForLoopbackFragment(`#h=${THEIRS}/review/2/files`, OURS)
+
+  assert.deepEqual(route, { name: 'repositories' })
+})
+
+test('a fragment addressed to us but malformed inside lands somewhere harmless', () => {
+  const route = routeForLoopbackFragment(`#h=${OURS}/nonsense/here`, OURS)
+
+  assert.deepEqual(route, { name: 'repositories' })
+})
+
+test('a fragment with no instance id at all is the pre-M2 form, and is local', () => {
+  const route = routeForLoopbackFragment('#h=review/2/files', OURS)
+
+  assert.deepEqual(parseRoute(hrefFor(route!)), { name: 'review', reviewId: 2, tab: 'files' })
+})

--- a/src/web/bootstrap.ts
+++ b/src/web/bootstrap.ts
@@ -1,0 +1,53 @@
+/**
+ * What the preload script is, for a tab.
+ *
+ * `window.gitwarren` is the whole contract between the renderer and whatever is
+ * hosting it - a carrier and a shell, and nothing else (`shared/api.ts`). The
+ * preload builds one over Electron IPC; this builds one over a WebSocket, and
+ * every screen above `lib/api.ts` is unable to tell which it got. That was the
+ * promise M1 made when it drew the line; this file is where it is collected.
+ *
+ * The bridge is installed *synchronously*, before the renderer module is
+ * evaluated, because `lib/api.ts` reads `window.gitwarren` at module scope and
+ * throws if it is missing. The socket underneath it is still connecting at that
+ * moment, which is fine and deliberate - see `carrier.ts` on queueing.
+ */
+import { createWebCarrier } from './carrier'
+import { createWebShell } from './shell'
+import { isLoopbackFragment, routeForLoopbackFragment } from './loopback-fragment'
+import { hrefFor } from '@shared/routes'
+import type { GitWarrenBridge } from '@shared/api'
+
+export function installBridge(): GitWarrenBridge {
+  const bridge: GitWarrenBridge = {
+    carrier: createWebCarrier(),
+    shell: createWebShell()
+  }
+
+  window.gitwarren = bridge
+  return bridge
+}
+
+/**
+ * Put the initial location into the app's own grammar, before the router reads
+ * it.
+ *
+ * Only a loopback link needs this, which is a link's first load and nothing
+ * else - see `loopback-fragment.ts` for the rules, which are the ones
+ * `main/deep-link.ts` applies in the other shell.
+ *
+ * `replace` rather than an assignment: the URL the agent handed out should not
+ * become a back-button target, and there is nothing behind it to go back to on
+ * a cold load anyway. `hrefFor` returns a string that already begins with `#`,
+ * so it is passed through untouched.
+ */
+export async function normaliseInitialLocation(bridge: GitWarrenBridge): Promise<void> {
+  if (!isLoopbackFragment(window.location.hash)) return
+
+  // The one thing a browser tab cannot know without asking: which install is
+  // serving it. One request, and only ever on a link's first load.
+  const { instanceId } = await bridge.shell.system.appInfo()
+
+  const route = routeForLoopbackFragment(window.location.hash, instanceId)
+  if (route) window.location.replace(hrefFor(route))
+}

--- a/src/web/carrier.ts
+++ b/src/web/carrier.ts
@@ -1,0 +1,189 @@
+/**
+ * The carrier, from the browser's side.
+ *
+ * The preload's carrier has an easy job: `ipcRenderer.invoke` pairs a request
+ * with its answer, and the other end is a process that cannot go away without
+ * taking this one with it. Here there is a socket, so three things it never had
+ * to think about have to be decided.
+ *
+ * **A request made before the socket is open.** The page renders immediately
+ * and asks for the repository list in its first effect, which is long before a
+ * WebSocket handshake completes. Those requests are queued and flushed on open.
+ * The alternative - making `window.gitwarren` appear only once connected - would
+ * mean the renderer's own "the bridge is missing" guard firing during a normal
+ * load.
+ *
+ * **A request in flight when the socket closes.** Every one is rejected. Not
+ * retried: a retry of `comments.reply` after an answer we did not see is a
+ * second comment, and no carrier may decide that on the caller's behalf. This
+ * is rule 2 of the plan in miniature - nothing is cached across a disconnect,
+ * and a connection that is gone is shown as gone rather than papered over.
+ *
+ * **Getting back.** The socket reconnects with a backoff, so a laptop that
+ * slept comes back on its own and SWR's next revalidation succeeds. Reconnect
+ * is about the *next* request, never about the ones that were lost.
+ *
+ * Read coalescing is carried over from the preload unchanged, and matters more
+ * here: two components asking the same question in the same tick is one frame
+ * on the wire instead of two.
+ */
+import { AppError } from '@shared/errors'
+import {
+  isReadMethod,
+  resultOf,
+  type Carrier,
+  type RpcMethod,
+  type RpcOutcome,
+  type RpcParams,
+  type RpcRequest,
+  type RpcResponse,
+  type RpcResult
+} from '@shared/rpc'
+import { WEB_PATHS } from '@shared/web'
+
+/** Backoff between reconnects: quick at first, then out of the way. */
+const RETRY_MS = [250, 500, 1000, 2000, 5000] as const
+
+interface Pending {
+  resolve: (outcome: RpcOutcome) => void
+  reject: (error: unknown) => void
+}
+
+function socketUrl(): string {
+  // Same origin as the page, by construction: the server that sent this
+  // document is the only one that will accept the upgrade, and building the URL
+  // from `location` rather than from a constant is what keeps that true if the
+  // app is ever mounted somewhere else.
+  const scheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${scheme}//${window.location.host}${WEB_PATHS.socket}`
+}
+
+export interface WebCarrier extends Carrier {
+  /** Whether the socket is currently up, for the UI to show. */
+  connected(): boolean
+  /** Notified whenever that changes. Returns an unsubscribe function. */
+  onConnectionChange(listener: (connected: boolean) => void): () => void
+}
+
+export function createWebCarrier(): WebCarrier {
+  let socket: WebSocket | null = null
+  let attempt = 0
+  let nextId = 1
+
+  const pending = new Map<number, Pending>()
+  const queued: RpcRequest[] = []
+  const listeners = new Set<(connected: boolean) => void>()
+
+  const announce = (connected: boolean): void => {
+    for (const listener of listeners) listener(connected)
+  }
+
+  const send = (request: RpcRequest): void => {
+    if (socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify(request))
+    else queued.push(request)
+  }
+
+  const failAllPending = (): void => {
+    const lost = [...pending.values()]
+    pending.clear()
+    for (const entry of lost) {
+      entry.reject(
+        new AppError(
+          'INTERNAL',
+          'The connection to GitWarren was lost before this finished. Nothing was retried; try again.'
+        )
+      )
+    }
+  }
+
+  const connect = (): void => {
+    const opening = new WebSocket(socketUrl())
+    socket = opening
+
+    opening.addEventListener('open', () => {
+      attempt = 0
+      // Anything that arrived while the socket was opening. Splice rather than
+      // iterate: a request queued by a listener during the flush belongs to the
+      // socket that is now open, not to this loop.
+      const backlog = queued.splice(0, queued.length)
+      for (const request of backlog) opening.send(JSON.stringify(request))
+      announce(true)
+    })
+
+    opening.addEventListener('message', (event: MessageEvent<string>) => {
+      let decoded: unknown
+      try {
+        decoded = JSON.parse(event.data)
+      } catch {
+        console.error('[carrier] a message from GitWarren was not JSON')
+        return
+      }
+
+      const response = decoded as RpcResponse
+      if (!response || typeof response.id !== 'number') return
+
+      const entry = pending.get(response.id)
+      // No entry means an answer to a request this page has already given up
+      // on - after a reconnect, or a duplicate. Dropping it is correct; there
+      // is nobody left to hand it to.
+      if (!entry) return
+      pending.delete(response.id)
+      entry.resolve(response)
+    })
+
+    const dropped = (): void => {
+      if (socket !== opening) return
+      socket = null
+      failAllPending()
+      announce(false)
+
+      const delay = RETRY_MS[Math.min(attempt, RETRY_MS.length - 1)]
+      attempt += 1
+      window.setTimeout(connect, delay)
+    }
+
+    opening.addEventListener('close', dropped)
+    // `error` is always followed by `close`, so the reconnect is scheduled
+    // there and this only stops the console from swallowing the reason.
+    opening.addEventListener('error', () => {
+      console.error('[carrier] the connection to GitWarren failed')
+    })
+  }
+
+  connect()
+
+  const inFlight = new Map<string, Promise<unknown>>()
+
+  const ask = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
+    const id = nextId++
+    const answered = new Promise<RpcOutcome>((resolve, reject) => {
+      pending.set(id, { resolve, reject })
+      send({ id, method, params })
+    })
+
+    // A response carries whatever its method returns, and the socket cannot
+    // know which method that was - the id is the only thing tying the two
+    // together. `RpcResult<M>` is recovered here, at the one point where `M` is
+    // still in scope, exactly as the preload's `invoke` does it.
+    return answered.then((outcome) => resultOf(outcome) as RpcResult<M>)
+  }
+
+  return {
+    request<M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> {
+      if (!isReadMethod(method)) return ask(method, params)
+
+      const key = `${method}:${JSON.stringify(params ?? null)}`
+      const existing = inFlight.get(key) as Promise<RpcResult<M>> | undefined
+      if (existing) return existing
+
+      const promise = ask(method, params).finally(() => inFlight.delete(key))
+      inFlight.set(key, promise)
+      return promise
+    },
+    connected: () => socket?.readyState === WebSocket.OPEN,
+    onConnectionChange(listener) {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }
+  }
+}

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      The same lockdown as the Electron window, with one difference that is the
+      whole of M3 in a header.
+
+      `connect-src 'self'` still means "this origin and nothing else", and in a
+      browser that now has to cover the WebSocket as well: CSP level 3 matches a
+      same-origin `ws://` against `'self'`, which is exactly the carrier this
+      shell uses and exactly nothing more. No remote origin can be reached from
+      this page whatever a comment body asks for.
+
+      `img-src` keeps `data:` - image diffs arrive as data URLs from
+      `reviews.image` - and drops the `gitwarren:` scheme, which is a custom
+      protocol only the Electron main process serves. Attachments in markdown
+      come over HTTP from this same origin in M3.2; until then they are the one
+      thing in a comment body that does not render in a tab.
+    -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"
+    />
+    <title>GitWarren</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/web/loopback-fragment.ts
+++ b/src/web/loopback-fragment.ts
@@ -1,0 +1,62 @@
+/**
+ * Turning a loopback link's fragment into a location this app understands.
+ *
+ * An agent hands out `http://127.0.0.1:41427/#h=<instance>/review/4/files/…`.
+ * That fragment is the *deep link* grammar - what the "Open in GitWarren" page
+ * pastes `gitwarren://` onto - and it is not the app's hash grammar, which says
+ * `#/reviews/4/files`. In the Electron shell the translation happens in
+ * `main/deep-link.ts`, on a string the window never sees. In a browser the URL
+ * is already in the address bar, so it happens on the way in.
+ *
+ * Kept apart from `bootstrap.ts` because it is the only part of that file with
+ * no DOM in it, and therefore the only part that can be tested the way
+ * everything else here is tested - as a node program. The rules it encodes are
+ * the ones `localise` states in `main/deep-link.ts`, and they have to stay
+ * identical in both shells:
+ *
+ *  - a fragment that is not a loopback fragment is left alone, which is every
+ *    navigation after the first;
+ *  - the fragment is *parsed* to a `Route` and written back out from that, so
+ *    nothing an outside party wrote is ever assigned to `location.hash`;
+ *  - this install's own id is dropped, so the router is handed the route it
+ *    would have been handed anyway;
+ *  - another install's id lands on the home screen rather than opening *our*
+ *    review 4 because the link said 4. Reviews on other hosts arrive in M4.
+ */
+// Relative rather than through the `@shared` alias, unlike its neighbours in
+// this directory. They are only ever built by Vite; this one is also *run* by
+// the test runner, which is a node program with no bundler in front of it and
+// no alias to resolve. The other tested renderer modules get away with `@shared`
+// because they import nothing but types, which are erased before anything has
+// to be found on disk.
+import { LOOPBACK_HOST_PREFIX, parseDeepLink } from '../shared/deep-link.js'
+import { HOME, type Route } from '../shared/routes.js'
+
+/** Whether a hash is one of the links an agent hands out. */
+export function isLoopbackFragment(hash: string): boolean {
+  return hash.replace(/^#/, '').startsWith(LOOPBACK_HOST_PREFIX)
+}
+
+/**
+ * The route a loopback fragment means on the install whose id is `instanceId`.
+ *
+ * Null when the hash is not a loopback fragment at all - the caller should
+ * leave the location exactly as it found it, rather than rewrite it to
+ * something equivalent.
+ */
+export function routeForLoopbackFragment(hash: string, instanceId: string): Route | null {
+  const fragment = hash.replace(/^#/, '')
+  if (!fragment.startsWith(LOOPBACK_HOST_PREFIX)) return null
+
+  const route = parseDeepLink(`gitwarren://${fragment.slice(LOOPBACK_HOST_PREFIX.length)}`)
+  // Addressed to us and malformed inside: the app opens on something harmless
+  // rather than swallowing the click.
+  if (!route) return HOME
+  if (route.host === undefined) return route
+  if (route.host !== instanceId) return HOME
+
+  // Rebuilt without the key rather than set to undefined - `hrefFor` and route
+  // equality both read the presence of the property, not its value.
+  const { host: _host, ...local } = route
+  return local
+}

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -1,0 +1,22 @@
+/**
+ * The web build's entry point: install the bridge, then hand over to the
+ * renderer that has always assumed one was there.
+ *
+ * The order is the entire content of this file, and it is not decorative.
+ * `renderer/src/lib/api.ts` reads `window.gitwarren` while its module is being
+ * evaluated - not in an effect, not on first render - so the bridge has to
+ * exist before that module is *imported*, which a top-level `import` of the
+ * renderer would not guarantee across a bundler's hoisting. A dynamic import
+ * says it in a way that cannot be reordered: this line, then that one.
+ *
+ * The `await` before it is for a link's first load only. When the hash carries
+ * a loopback fragment (`#h=<instance>/…`) it has to be resolved against this
+ * install before the router reads it, or the app paints the home screen and
+ * jumps - see `bootstrap.ts`.
+ */
+import { installBridge, normaliseInitialLocation } from './bootstrap'
+
+const bridge = installBridge()
+
+await normaliseInitialLocation(bridge)
+await import('@/main')

--- a/src/web/shell.ts
+++ b/src/web/shell.ts
@@ -1,0 +1,113 @@
+/**
+ * The browser's shell: what a tab can do for the person in front of it, and an
+ * honest refusal for everything else.
+ *
+ * `ShellApi` is the Electron-only surface (see `shared/api.ts`) - pickers,
+ * revealing a path, launching an editor, the updater. A browser tab has none of
+ * those, and the interesting question is not how to emulate them but which ones
+ * may be answered by the *server* instead. The line, which M6 will lean on hard
+ * when the phone connects to a host over the tailnet:
+ *
+ *  - **A fact about the host may travel.** `appInfo` is version numbers, an
+ *    instance id and paths. Reading it over HTTP is not a capability.
+ *  - **A capability of the host may not.** Revealing a folder or launching an
+ *    editor acts on the machine the daemon is on, which is not necessarily the
+ *    machine the person is at, and a request that could start a process there
+ *    would make this very different software. So they are absent here, and they
+ *    stay absent - the browser gets its own versions in M3.2 (a `vscode://`
+ *    link, a file input) which act on the machine holding the keyboard.
+ *
+ * Refusals throw `AppError` rather than resolving to something empty, so the
+ * UI's existing error paths show a sentence a user can act on. What is still
+ * missing in M3.1 is the *shell capability flag* that lets a screen hide a
+ * control instead of offering one that explains itself when pressed; that is
+ * the first thing M3.2 does, and until then a toggle with no meaning in a
+ * browser says so when it is used rather than before.
+ */
+import { AppError } from '@shared/errors'
+import { WEB_PATHS } from '@shared/web'
+import type { AppInfo, EditorList, ShellApi, UpdateStatus } from '@shared/api'
+
+/** Nothing to unsubscribe from. Returned by the subscriptions a tab cannot have. */
+const NO_SUBSCRIPTION = (): void => {}
+
+/**
+ * A refusal, as a rejected promise rather than a thrown error.
+ *
+ * The distinction matters at a bridge: every caller of these methods `await`s
+ * them, and a function that throws synchronously before returning its promise
+ * escapes a `.catch()` that a rejection would have landed in. So the refusals
+ * are rejections, and the methods are deliberately not `async`.
+ */
+function unsupported<T>(what: string, instead: string): Promise<T> {
+  return Promise.reject(
+    new AppError('FORBIDDEN', `${what} is not available in a browser tab. ${instead}`)
+  )
+}
+
+async function readAppInfo(): Promise<AppInfo> {
+  // Same-origin, so the session cookie rides along without being asked for -
+  // and `same-origin` is stated rather than left to the default, because the
+  // default is the one thing about `fetch` that has changed under everyone's
+  // feet before.
+  const response = await fetch(WEB_PATHS.appInfo, {
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' }
+  })
+
+  if (!response.ok) {
+    throw new AppError(
+      'INTERNAL',
+      `GitWarren could not describe this install (HTTP ${response.status}).`
+    )
+  }
+
+  return (await response.json()) as AppInfo
+}
+
+const NO_EDITORS: EditorList = { editors: [], defaultId: null }
+
+const UPDATES_UNSUPPORTED: UpdateStatus = {
+  state: 'unsupported',
+  reason:
+    'GitWarren in a browser is updated by whatever installed it - Homebrew, npm, or the ' +
+    'tarball it was unpacked from.'
+}
+
+export function createWebShell(): ShellApi {
+  return {
+    system: {
+      // No native folder picker, and no attempt at one. The path field next to
+      // the button is a text input, so a repository is added by typing or
+      // pasting its path - which is also what someone reaching a remote host in
+      // M4 will do, since a picker there would browse the wrong machine.
+      pickDirectory: () => Promise.resolve(null),
+      revealPath: () => unsupported('Revealing a folder', 'Copy the path and open it yourself.'),
+      appInfo: readAppInfo,
+      editors: () => Promise.resolve(NO_EDITORS),
+      // False rather than a refusal: the question "does GitWarren start with
+      // this machine" has a true answer for a browser tab, and it is no.
+      // Turning it *on* is `gitwarren service install`, which arrives in M3.3.
+      getOpenAtLogin: () => Promise.resolve(false),
+      setOpenAtLogin: () =>
+        unsupported('Starting at login', 'Run `gitwarren service install` on this machine.')
+    },
+    updates: {
+      getStatus: () => Promise.resolve(UPDATES_UNSUPPORTED),
+      check: () => Promise.resolve(UPDATES_UNSUPPORTED),
+      installNow: () =>
+        unsupported('Installing an update', 'Update GitWarren the way you installed it.'),
+      subscribe: () => NO_SUBSCRIPTION
+    },
+    navigation: {
+      // Deep links need no channel here. The route is in the hash, the router
+      // already listens for `hashchange`, and a link clicked while the tab is
+      // open is simply a navigation - the whole mechanism `main/deep-link.ts`
+      // exists to reproduce is what a browser does natively.
+      onDeepLink: () => NO_SUBSCRIPTION
+    },
+    pickAttachment: () => Promise.resolve(null),
+    openInEditor: () =>
+      unsupported('Opening a file in an editor', 'Open it from the repository on this machine.')
+  }
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -34,9 +34,13 @@
     "src/renderer/src/lib/__tests__/fuzzy.test.ts",
     "src/renderer/src/features/reviews/diff-search.ts",
     "src/renderer/src/features/reviews/__tests__/diff-search.test.ts",
+    "src/web/loopback-fragment.ts",
+    "src/web/__tests__/loopback-fragment.test.ts",
     "electron.vite.config.ts",
     "vite.mcp.config.ts",
     "vite.daemon.config.ts",
+    "vite.web.config.ts",
+    "vite.ws-define.ts",
     "drizzle.config.ts",
     "scripts/**/*.ts"
   ]

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -19,7 +19,8 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.web.tsbuildinfo",
     "paths": {"@/*": ["./src/renderer/src/*"], "@shared/*": ["./src/shared/*"]}
   },
-  "include": ["src/renderer/src/**/*", "src/shared/**/*"],
+  "//web": "src/web is the browser shell: the twenty lines that put a WebSocket-backed `window.gitwarren` in front of the same renderer the preload serves. It is compiled for a browser, so it belongs here and not in the node config.",
+  "include": ["src/renderer/src/**/*", "src/web/**/*", "src/shared/**/*"],
   "//": "Tests are node programs - they import node:test and node:assert - so they are checked by tsconfig.node.json, which has the node types. Without this the renderer build fails on a test file it has no business compiling.",
   "exclude": ["src/**/__tests__/**"]
 }

--- a/vite.daemon.config.ts
+++ b/vite.daemon.config.ts
@@ -1,5 +1,18 @@
+import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { defineConfig } from 'vite'
+import { WS_PURE_JS } from './vite.ws-define.js'
+
+/**
+ * The app's version, inlined.
+ *
+ * The daemon tells a browser what it is running, and `app.getVersion()` - which
+ * is where the Electron process gets the same string - does not exist here.
+ * Reading a package.json at runtime is not an option either: there is not one
+ * next to a single-file bundle inside a tarball. So the build stamps it, which
+ * is the only moment the two are guaranteed to agree.
+ */
+const { version } = JSON.parse(readFileSync(resolve('package.json'), 'utf8')) as { version: string }
 
 /**
  * Build for the headless daemon.
@@ -23,6 +36,10 @@ import { defineConfig } from 'vite'
  * daemon speaks GitWarren's own protocol, not MCP. Agents never talk to it.
  */
 export default defineConfig({
+  define: {
+    ...WS_PURE_JS,
+    __APP_VERSION__: JSON.stringify(version)
+  },
   resolve: {
     alias: {
       '@core': resolve('src/core'),

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -1,0 +1,46 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+/**
+ * The renderer, built for a browser instead of for a window.
+ *
+ * Every line of the app is the same; what changes is the twenty lines in front
+ * of it. `src/web/main.ts` installs a `window.gitwarren` built on a WebSocket
+ * where the preload installs one built on Electron IPC, and then imports
+ * exactly the same `renderer/src/main.tsx`. That is why this config exists as a
+ * sibling of `electron.vite.config.ts`'s renderer section rather than as a mode
+ * inside it: two roots, two entry points, one source tree.
+ *
+ * ## `base: './'`, and why it is safe here
+ *
+ * The Electron app serves this build under `/app/` and a `gitwarren serve`
+ * serves it under `/`. Absolute asset URLs would have to pick one; relative
+ * ones resolve against the document's own path and work under both. That is
+ * only sound because routing is in the *hash* - `#/reviews/4/files` - so the
+ * path of the document is always exactly the mount, however deep the user has
+ * navigated. A history-API router would break this immediately, which is worth
+ * knowing before anyone changes one.
+ *
+ * The trailing slash on the mount is load-bearing for the same reason, and the
+ * server redirects `/app` to `/app/` rather than trusting anyone to type it.
+ */
+export default defineConfig({
+  root: resolve('src/web'),
+  base: './',
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': resolve('src/renderer/src'),
+      '@shared': resolve('src/shared')
+    }
+  },
+  build: {
+    outDir: resolve('out/web'),
+    emptyOutDir: true,
+    rollupOptions: {
+      input: resolve('src/web/index.html')
+    }
+  }
+})

--- a/vite.ws-define.ts
+++ b/vite.ws-define.ts
@@ -1,0 +1,44 @@
+/**
+ * Keep `ws` on its pure-JavaScript path, in every bundle that contains it.
+ *
+ * `ws` ships optional native accelerators - `bufferutil` for masking, and
+ * `utf-8-validate` - and reaches for them at the bottom of two of its modules
+ * like this:
+ *
+ * ```js
+ * if (!process.env.WS_NO_BUFFER_UTIL) {
+ *   try {
+ *     const bufferUtil = require('bufferutil')
+ *     module.exports.unmask = (buffer, mask) => { … }   // reassignment
+ *   } catch (e) {}
+ * }
+ * ```
+ *
+ * Neither package is installed here, so at runtime that `require` throws, the
+ * `catch` swallows it, and the pure-JS implementation stands. Inside a bundle it
+ * is not so simple: the reassignment of `module.exports.unmask` is a CommonJS
+ * pattern with no ESM equivalent, and Rollup's ESM output turns the module's
+ * own later reference to it into `bufferUtil$1.unmask`, which is `undefined`.
+ * The first client frame then dies with
+ *
+ *     TypeError: bufferUtil$1.unmask is not a function
+ *
+ * inside `Receiver._write`, before anything of ours runs. Every frame a browser
+ * sends is masked, so the effect is a socket that connects perfectly, accepts
+ * everything, and answers nothing - an upgrade that looks entirely healthy from
+ * both ends and a UI that simply never loads.
+ *
+ * This bit the Electron main bundle and not the daemon, because the main
+ * process is built as ESM and `out/daemon/serve.cjs` is CommonJS. That is a
+ * distinction no one should have to remember, so both builds set this rather
+ * than the one that happened to break.
+ *
+ * Defining the variables here makes each `if` a constant false at build time,
+ * so the optional block is removed entirely and there is no reassignment left
+ * to mistranslate. It costs nothing: the accelerators were never installed, and
+ * masking a loopback frame in JavaScript is not a cost worth measuring.
+ */
+export const WS_PURE_JS = {
+  'process.env.WS_NO_BUFFER_UTIL': '"1"',
+  'process.env.WS_NO_UTF_8_VALIDATE': '"1"'
+} as const


### PR DESCRIPTION
First of five changes making up M3. The renderer, served on loopback and driven
over a WebSocket, with **no change to a single line of it** — `lib/api.ts` was
the only file that ever touched `window.gitwarren`, so a browser shell is a
different bridge under the same app rather than a second app. That was the whole
point of M1.

## What is here

**One handler, mounted twice.** `core/web/handler.ts` is mounted by the Electron
app at `/app/` and by `gitwarren serve --listen` at `/`. The app cannot serve it
at `/` because that is the "Open in GitWarren" page a review link has depended on
since M2, and that behaviour is verified. The daemon has no protocol handler to
hand a link to, so it serves the app at `/` and an agent's `guiUrl` opens the
review directly with no hop — the thing this milestone exists for.

**The gate**: `Host`, then `Origin`, then a per-launch token exchanged for a
`SameSite=Strict` cookie and taken back out of the URL. The token is written to
`web-token` at mode 0600 rather than into `daemon-runtime.json`, which is a
published fact about the machine and no place for a secret.

**Ownership**: `--listen` claims the runtime file and refuses to start beside a
running app. That is the check `daemon.ts` said belonged here rather than on the
`--stdio` carrier, which binds nothing and must keep working next to another
GitWarren for M4.

## Verified

In Chrome, against both shells, with a scratch data directory: the renderer
paints, the socket connects, a repository added *in the browser* lands in SQLite,
`app-info` answers over HTTP, an agent's `#h=<instance>/review/N/files` link opens
the review, a link for another install does not open ours of the same number, and
a refusal a tab must give — reveal a folder — arrives as a sentence. No console
errors and no failed requests in either run.

28 new tests (350 total, all green): the gate, path traversal, the SPA fallback,
the token exchange, and a real WebSocket → dispatcher → SQLite round trip.

## Two bugs worth keeping

**A doubled `#`.** `hrefFor` already returns a leading `#`, so the translated
route was written back as `##/reviews/2/files`; `parseRoute` read a first segment
of `#` and every agent link quietly opened the repository list. Nothing threw.
The translation now lives in `web/loopback-fragment.ts`, apart from the DOM so it
can be tested, and the test asserts on `parseRoute(hrefFor(...))`.

**`ws` losing `unmask`.** Its optional native accelerators are wired up by
reassigning `module.exports`; Rollup's ESM output turns the module's own later
reference into `bufferUtil$1.unmask`, which is `undefined`. Every frame a browser
sends is masked, so the socket connected, accepted everything and answered
nothing. It hit the Electron main bundle and not the daemon purely because main
is ESM and `serve.cjs` is CommonJS. Both builds now compile the optional block
away (`vite.ws-define.ts`).

## Not here, on purpose

M3.2 handles what a tab lacks (attachments over HTTP, `vscode://` open-in-editor,
and a shell capability flag so screens hide controls instead of refusing them);
M3.3 is the CLI and distribution; M3.4 the Agent Access page; M3.5 the responsive
pass. `GitWarren --serve --listen` from inside the packaged app is not supported —
`out/web` is in the asar and the app serves the web view itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQeMprLA9tcs2hZmt8SLYD
