### PR TITLE
M3.2 - What the browser shell lacks

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -900,6 +900,7 @@ each mergeable on its own:
 2. **What the browser shell lacks.** Attachments over HTTP, open-in-editor as a
    `vscode://` link, and a shell *capability flag* so a screen can hide a
    control instead of offering one that explains itself when pressed.
+   *(done — see below.)*
 3. **The `gitwarren` CLI and distribution.** `serve`, `open`,
    `service install`; the S3 tarball, a Homebrew formula, `npx gitwarren`.
 4. **The Agent Access page**, one-sentence prompt leading.
@@ -952,6 +953,79 @@ only `out/daemon` is unpacked, and the app serves the web view itself anyway.
 The browser shell's missing capabilities are honest refusals rather than hidden
 controls until M3.2 gives it the capability flag. Attachments in markdown do not
 render in a tab yet — that is the HTTP blob endpoint, also M3.2.
+
+**M3.2, done on the Mac, 10 September.** The three things a tab could not do,
+each done the way a tab can rather than by asking the server to do it for the
+person — which is the line M6 will need and is easiest to draw now, while the
+browser and the daemon are on the same machine and nobody would notice it being
+crossed.
+
+**Attachments over HTTP.** `/gitwarren/attachments/<sha>.<ext>`, behind the same
+cookie as everything else, reading the same content-addressed store the custom
+scheme reads. A comment body still holds `gitwarren://attachment/…` whoever
+reads it — it is stored text and must not depend on which shell renders it — so
+the rewrite happens at the `<img src>` and nowhere else, through a new
+`shell.attachmentSrc`. The window passes the token through; a tab turns it into
+a path on its own origin, which `img-src 'self'` already covered, so the CSP did
+not have to be loosened to make pictures appear. The token grammar moved to
+`shared/attachments.ts` on the way, because the store's first line asks for
+`node:crypto` and a browser bundle cannot import it to learn what a name looks
+like.
+
+**A capability flag.** `shell.capabilities` — `pickDirectory`, `revealPath`,
+`openAtLogin` — read synchronously at module scope, so a screen leaves a control
+out rather than offering one that explains itself when pressed. Deliberately
+flags and not a shell *name*: `if (shell === 'web')` spreads a list of what each
+shell happens to lack across every screen that asks, and M4's remote hosts will
+answer some of these differently again. The refusals from M3.1 stay underneath
+as the backstop for a caller that did not look.
+
+**Open in an editor.** Two halves, joined in the opposite order from
+`main/ipc.ts`: `reviews.filePath` is a read on the dispatcher — *which* file is
+review knowledge — and the `vscode://file/…:line` navigation happens in the tab.
+Nothing asks the daemon to start a process, which is the rule that makes this
+software rather than a remote shell. The URL forms moved to `shared/editors.ts`
+so both shells open the same string; detection stayed in `main/editors.ts`,
+keyed by an id union so an editor added without detection is a type error. A tab
+offers every editor with a scheme as a *choice* rather than a finding, since it
+cannot look at the filesystem — and the picker in the files tab already existed
+because the detected default was never more than a guess either.
+
+**A pasted screenshot never arrived.** The one that would have cost an
+afternoon. `attachments.ingest` is handed an `ArrayBuffer`, which structured
+clone carries perfectly and which `JSON.stringify` turns into `{}` without a
+word. Over the socket the image reached the dispatcher as an empty object,
+failed the format sniff, and the user was told their PNG is not a PNG — a
+failure that reads as being about the file rather than about the wire. The
+carrier now base64s bytes before framing (`web/wire.ts`, apart from the socket
+so it can be tested, as `loopback-fragment.ts` is), which is the encoding
+`toIngestSource` has taken since M2 for the stdio carrier. `btoa` needs the
+bytes in slices, or a four-megabyte screenshot overflows the call stack in
+`String.fromCharCode`. `AttachmentIngestParams` was also narrower than what the
+dispatcher accepted — it omitted the typed-array form the dispatcher has a
+branch for — and now says all four.
+
+Verified in Chrome and in the Electron window against one scratch data
+directory, on a review whose description and first comment both hold an
+attachment: both images paint in both shells; `reviews.filePath` answers with
+the right absolute path and the editor URL leaves the page where it is; an
+`ArrayBuffer` ingest over the socket comes back with a real sha. Side by side on
+the repository screens, the browser shows zero reveal buttons, no Browse and no
+start-at-login switch where the window shows one of each, and the path field,
+the edit buttons and the cards are all still there — controls removed, not
+screens. No console errors and no failed requests beyond Chrome's own
+`favicon.ico` probe, which the web build has nothing to answer with; an icon is
+polish for M3.5 rather than a gap in this change.
+
+**Not done in M3.2, and why.** The other half of the "Blobs over HTTP" bullet —
+*very large file reads use GET past a size threshold* — is untouched.
+`reviews.file` and `reviews.image` still answer over the socket in both shells,
+which is fine on loopback where the socket is a memcpy, and the threshold is a
+number that should be chosen against a real network rather than guessed here.
+It belongs with M6, where a file crosses the tailnet and the cost is visible.
+Drag-and-drop and paste already worked in a tab and needed only the carrier fix;
+what M3.2 added is the file *input*, so the composer's attach button means the
+same thing in both shells.
 
 ### M4 — SSH hosts
 

--- a/src/core/rpc/dispatcher.ts
+++ b/src/core/rpc/dispatcher.ts
@@ -101,9 +101,8 @@ function toIngestSource(params: unknown): { bytes: Buffer; originalName?: string
   // A typed array, which is what a `Uint8Array` sent over structured clone
   // arrives as. Its own byte range, not the whole underlying buffer.
   if (ArrayBuffer.isView(bytes)) {
-    const view = bytes as ArrayBufferView
     return {
-      bytes: Buffer.from(view.buffer, view.byteOffset, view.byteLength),
+      bytes: Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength),
       ...name
     }
   }

--- a/src/core/services/attachments.ts
+++ b/src/core/services/attachments.ts
@@ -29,6 +29,7 @@ import { eq, inArray } from 'drizzle-orm'
 import { getDatabase } from '../db/client.js'
 import { attachments, comments, reviews } from '../db/schema.js'
 import { getDataDirectory } from '../paths.js'
+import { attachmentUrl, parseAttachmentUrl } from '../../shared/attachments.js'
 import { AppError } from '../../shared/errors.js'
 import type { Attachment } from '../../shared/schemas.js'
 
@@ -41,20 +42,21 @@ import type { Attachment } from '../../shared/schemas.js'
  */
 export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024
 
-/** The URL scheme and host the renderer fetches attachments through. */
-export const ATTACHMENT_URL_PREFIX = 'gitwarren://attachment/'
-
 /**
- * Filenames the custom protocol will serve.
+ * The token grammar, which since M3.2 lives in `shared/attachments.ts`.
  *
- * Exported because the protocol handler in the main process tests against this
- * exact expression, and it is the security boundary there: comment bodies are
- * agent-writable, so `gitwarren://attachment/../../../../etc/passwd` is a URL
- * that will genuinely be requested one day. A hash and a short extension is the
- * entire vocabulary of a legitimate name, so anything else is refused rather
- * than resolved and checked.
+ * It moved because a browser tab now serves attachments over HTTP and has to
+ * recognise a token to rewrite it, and a browser cannot import this file - the
+ * first line of it asks for `node:crypto`. Re-exported here so that every
+ * caller that reached for it through the store still does.
  */
-export const ATTACHMENT_FILE_NAME = /^[a-f0-9]{64}\.[a-z0-9]{2,4}$/
+export {
+  ATTACHMENT_FILE_NAME,
+  ATTACHMENT_URL_PREFIX,
+  attachmentName,
+  attachmentUrl,
+  parseAttachmentUrl
+} from '../../shared/attachments.js'
 
 interface ImageFormat {
   ext: string
@@ -195,19 +197,6 @@ function attachmentsRoot(): string {
 /** Where the bytes for `<sha>.<ext>` live. Sharded so no directory grows huge. */
 export function attachmentPath(sha: string, ext: string): string {
   return join(attachmentsRoot(), sha.slice(0, 2), `${sha}.${ext}`)
-}
-
-export function attachmentUrl(sha: string, ext: string): string {
-  return `${ATTACHMENT_URL_PREFIX}${sha}.${ext}`
-}
-
-/** Pull the `<sha>.<ext>` out of a token, or null if it is not one. */
-export function parseAttachmentUrl(url: string): { sha: string; ext: string } | null {
-  if (!url.startsWith(ATTACHMENT_URL_PREFIX)) return null
-  const name = url.slice(ATTACHMENT_URL_PREFIX.length)
-  if (!ATTACHMENT_FILE_NAME.test(name)) return null
-  const dot = name.lastIndexOf('.')
-  return { sha: name.slice(0, dot), ext: name.slice(dot + 1) }
 }
 
 function toAttachment(row: {

--- a/src/core/web/__tests__/web-handler.test.ts
+++ b/src/core/web/__tests__/web-handler.test.ts
@@ -25,7 +25,10 @@ const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-web-'))
 process.env.GITWARREN_DATA_DIR = dataDir
 
 const { createWebHandler } = await import('../handler.js')
-const { SESSION_COOKIE, TOKEN_PARAM, WEB_PATHS } = await import('../../../shared/web.js')
+const { SESSION_COOKIE, TOKEN_PARAM, WEB_PATHS, webAttachmentSrc } = await import(
+  '../../../shared/web.js'
+)
+const { attachmentsService } = await import('../../services/attachments.js')
 const { closeDatabase } = await import('../../db/client.js')
 
 const MOUNT = '/app/'
@@ -265,6 +268,78 @@ test('app-info describes this install, to a session and to nobody else', async (
 
 test('an unknown path under the shell prefix is a 404, not the document', async () => {
   const response = await get('/gitwarren/nothing-here', withSession())
+
+  assert.equal(response.status, 404)
+})
+
+/* -------------------------------------------------------------------------- */
+/* Attachments                                                                */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The half of M3.2 that has a URL.
+ *
+ * A comment body holds `gitwarren://attachment/<sha>.<ext>`, which the window
+ * serves over a custom scheme and a tab cannot. These tests are about the HTTP
+ * form of the same store, and the case that matters most is the last one: the
+ * name in that URL comes out of a comment body, comment bodies are written by
+ * agents, and an agent may have just read untrusted content out of the
+ * repository under review.
+ */
+
+/** A 1x1 PNG, the smallest thing that is really an image. */
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+test('an attachment is served to a session, and to nobody else', async () => {
+  const stored = await attachmentsService.ingest({ bytes: PNG, originalName: 'shot.png' })
+  const path = webAttachmentSrc(stored.url)
+
+  // The rewrite the browser shell does, asserted here rather than trusted: the
+  // string the renderer puts in an `<img src>` is the one this server routes on.
+  assert.equal(path, `${WEB_PATHS.attachments}${stored.sha}.png`)
+
+  const anonymous = await get(path)
+  assert.equal(anonymous.status, 401)
+
+  const response = await get(path, withSession())
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get('content-type'), 'image/png')
+  assert.equal(response.headers.get('x-content-type-options'), 'nosniff')
+  // Content-addressed: the name is the hash of the bytes, so they cannot change.
+  assert.match(response.headers.get('cache-control') ?? '', /immutable/)
+  assert.deepEqual(Buffer.from(await response.arrayBuffer()), PNG)
+})
+
+test('a token whose bytes are gone is a 404 rather than a broken stream', async () => {
+  // What the sweep leaves behind: a body still refers to an image nobody kept.
+  const response = await get(`${WEB_PATHS.attachments}${'a'.repeat(64)}.png`, withSession())
+
+  assert.equal(response.status, 404)
+})
+
+test('a name that is not a hash and an extension never reaches the filesystem', async () => {
+  // Encoded, so nothing normalises it away before it arrives. The defence is
+  // the whitelist rather than a traversal filter, so each of these fails on
+  // being read rather than on where it resolved to.
+  for (const name of [
+    '%2e%2e%2f%2e%2e%2fetc%2fpasswd',
+    `${'a'.repeat(64)}.png%2f..%2f..%2fetc%2fpasswd`,
+    `${'A'.repeat(64)}.png`,
+    `${'a'.repeat(63)}.png`
+  ]) {
+    const response = await get(`${WEB_PATHS.attachments}${name}`, withSession())
+    assert.equal(response.status, 400, name)
+  }
+})
+
+test('a well-formed name for a format the store cannot hold is refused', async () => {
+  // Passes the whitelist and is still not something an `<img>` should be handed.
+  // A 404 rather than a 400: the name is well-formed, there is simply no such
+  // attachment - the store only ever mints one of four extensions.
+  const response = await get(`${WEB_PATHS.attachments}${'a'.repeat(64)}.exe`, withSession())
 
   assert.equal(response.status, 404)
 })

--- a/src/core/web/attachments.ts
+++ b/src/core/web/attachments.ts
@@ -1,0 +1,126 @@
+/**
+ * Attachment bytes over HTTP, for the shell that has no custom scheme.
+ *
+ * The Electron window serves these through `gitwarren://attachment/…`, which a
+ * browser tab cannot register and would not be allowed to fetch if it could.
+ * This is the same store, the same names and the same whitelist, answered on
+ * the loopback origin the tab was already served from - which is also why the
+ * renderer's `img-src 'self'` covers it without a new source being added to the
+ * policy.
+ *
+ * ## What makes this safe to point at a directory
+ *
+ * Nothing here builds a path out of a URL. The name is matched against
+ * `ATTACHMENT_FILE_NAME` first - 64 hex characters, a dot, a short extension -
+ * and only a name that *is* that is handed to `attachmentPath`, which does the
+ * sharding itself. So there is no traversal to defend against rather than a
+ * traversal defended against: `..`, an encoded separator and a Windows `\` all
+ * fail the pattern before any filesystem call happens. That is the same
+ * reasoning `main/attachment-protocol.ts` states, and it matters for the same
+ * reason - comment bodies are written by agents, and an agent may have just
+ * read untrusted content out of the repository under review.
+ *
+ * The content type comes from the extension, which is not the usual mistake:
+ * the extension was chosen at ingest by sniffing the bytes (see
+ * `core/services/attachments.ts`), so it is this app's own conclusion about the
+ * file rather than a claim made by whoever supplied it. An extension that is
+ * somehow not one of the four is refused instead of being served as
+ * `application/octet-stream`, because the only thing that reads this endpoint
+ * is an `<img>`.
+ */
+import { createReadStream, statSync } from 'node:fs'
+import type { ServerResponse } from 'node:http'
+import { attachmentPath } from '../services/attachments.js'
+import { attachmentNameFromWebPath, WEB_PATHS } from '../../shared/web.js'
+
+/**
+ * The formats the store can hold, and nothing else.
+ *
+ * Kept in step with `FORMATS` in the store by being smaller than it: a format
+ * that can be ingested but not listed here would 404 rather than be served as
+ * the wrong type, which is the failure worth having.
+ */
+const CONTENT_TYPES: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp'
+}
+
+const HEADERS = {
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'no-referrer',
+  'X-Frame-Options': 'DENY',
+  /**
+   * Content-addressed, so the bytes behind a name can never change: the name is
+   * the hash of them. `private` rather than `public` because a shared cache has
+   * no business holding a review's screenshots, even though on loopback there
+   * is not one.
+   */
+  'Cache-Control': 'private, max-age=31536000, immutable'
+} as const
+
+export interface AttachmentResult {
+  /** False when the path was not an attachment at all - not when it was missing. */
+  served: boolean
+}
+
+/**
+ * Answer a request under the attachments prefix.
+ *
+ * A path that is not one is left alone (`served: false`) so the caller can go
+ * on routing. A path that *is* one is always answered here, including when the
+ * name is malformed or the file has been swept away - those are this endpoint's
+ * own 400 and 404 rather than the caller's.
+ */
+export function serveAttachment(
+  pathname: string,
+  method: string,
+  response: ServerResponse
+): AttachmentResult {
+  if (!pathname.startsWith(WEB_PATHS.attachments)) return { served: false }
+
+  const name = attachmentNameFromWebPath(pathname)
+  if (name === null) {
+    response.writeHead(400, HEADERS).end()
+    return { served: true }
+  }
+
+  const dot = name.lastIndexOf('.')
+  const contentType = CONTENT_TYPES[name.slice(dot + 1)]
+  if (contentType === undefined) {
+    response.writeHead(404, HEADERS).end()
+    return { served: true }
+  }
+
+  const file = attachmentPath(name.slice(0, dot), name.slice(dot + 1))
+  let size: number
+  try {
+    const stats = statSync(file)
+    if (!stats.isFile()) throw new Error('not a file')
+    size = stats.size
+  } catch {
+    // A token whose bytes the sweep has already collected. The comment still
+    // refers to it, so this happens in ordinary use and is not worth logging.
+    response.writeHead(404, HEADERS).end()
+    return { served: true }
+  }
+
+  response.writeHead(200, { ...HEADERS, 'Content-Type': contentType, 'Content-Length': size })
+
+  if (method === 'HEAD') {
+    response.end()
+    return { served: true }
+  }
+
+  const stream = createReadStream(file)
+  // Past the head there is no status code left to send; destroying the socket
+  // is the only honest end, and it makes the failure visible to the browser
+  // rather than leaving it waiting on a half-written image.
+  stream.on('error', (error) => {
+    console.error('[web] could not read an attachment', error)
+    response.destroy()
+  })
+  stream.pipe(response)
+  return { served: true }
+}

--- a/src/core/web/handler.ts
+++ b/src/core/web/handler.ts
@@ -35,6 +35,11 @@
  *    to get in. Not a 404: pretending the app is not there would be a lie the
  *    user cannot act on, and the port is not a secret anyway - the token is.
  *
+ * Everything behind the gate is a read: the web build, `app-info`, and since
+ * M3.2 the attachment bytes an `<img>` in a comment body needs. Writes happen
+ * over the socket and nowhere else, which is what keeps the whole of this file
+ * answering `GET` and `HEAD` and refusing every other method outright.
+ *
  * The socket is upgraded only after the same three, with `Origin` required
  * rather than optional, because a WebSocket handshake is never a navigation.
  */
@@ -42,6 +47,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Duplex } from 'node:stream'
 import { WebSocketServer } from 'ws'
 import { serveWebSocket } from '../rpc/websocket.js'
+import { serveAttachment } from './attachments.js'
 import { isAllowedHost, isAllowedOrigin, loopbackAuthority } from './origin.js'
 import { LINK_SERVER_PORT } from '../../shared/link-port.js'
 import { serveStatic } from './static.js'
@@ -227,6 +233,11 @@ export function createWebHandler({
           })
         return true
       }
+
+      // Images in comment bodies. Behind the same cookie as everything else -
+      // an attachment is review content, and a port that handed screenshots out
+      // to whoever asked would be a hole the token exists to close.
+      if (serveAttachment(pathname, request.method ?? 'GET', response).served) return true
 
       // The socket path only exists as an upgrade. A plain GET to it is a
       // mistake worth naming rather than a 404 among many.

--- a/src/main/editors.ts
+++ b/src/main/editors.ts
@@ -12,6 +12,8 @@
  *  - **A URL scheme** (`vscode://file/...`), handed to `shell.openExternal`.
  *    Registered by the application itself at install time, so it works without
  *    the user ever having installed a shell command, and it carries the line.
+ *    The forms themselves live in `shared/editors.ts` since M3.2, because a
+ *    browser tab opens the same URLs and cannot import this file.
  *  - **A CLI on PATH** (`code -g file:line`), for editors with no scheme worth
  *    using and for the `GITWARREN_EDITOR` escape hatch.
  *
@@ -26,81 +28,75 @@ import { access, constants } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { shell } from 'electron'
+import { EDITOR_LINKS, type EditorId, type EditorLink } from '../shared/editors.js'
 import { AppError } from '../shared/errors.js'
 import type { EditorInfo } from '../shared/api.js'
 
-interface EditorDefinition {
-  id: string
-  label: string
+interface EditorDefinition extends EditorLink {
   /** macOS application bundle, looked for in the usual two places. */
   appBundle?: string
   /** Windows application path, relative to a well-known root. */
   windowsPath?: string
   /** Command to look for on PATH. */
   bin?: string
-  /** Preferred launch: a URL the application registered for itself. */
-  url?: (path: string, line: number) => string
   /** Fallback launch: arguments for `bin`. */
   cliArgs?: (path: string, line: number) => string[]
 }
 
 /**
- * Order is the order the UI offers them in, and the first one found is the
- * default. It is a judgement call rather than a fact; the picker exists so the
- * judgement does not have to be right.
+ * How to find each editor on this machine, keyed by the id it has in
+ * `shared/editors.ts`.
+ *
+ * The ids, the labels and the URL forms live there because a browser tab in
+ * M3.2 offers the same editors and opens the same URLs, with no way to look at
+ * a filesystem. What is left here is everything Node can do and a tab cannot,
+ * and the two halves are merged below - so an editor is added by adding it in
+ * one place, and gains detection here only if there is detection to be had.
  */
-const EDITORS: EditorDefinition[] = [
-  {
-    id: 'vscode',
-    label: 'VS Code',
+const DETECTION: Record<EditorId, Omit<EditorDefinition, 'id' | 'label' | 'url'>> = {
+  vscode: {
     appBundle: 'Visual Studio Code.app',
     windowsPath: 'Microsoft VS Code\\Code.exe',
     bin: 'code',
-    url: (path, line) => `vscode://file${encodeURI(path)}:${line}`,
     cliArgs: (path, line) => ['--goto', `${path}:${line}`]
   },
-  {
-    id: 'cursor',
-    label: 'Cursor',
+  cursor: {
     appBundle: 'Cursor.app',
     windowsPath: 'cursor\\Cursor.exe',
     bin: 'cursor',
-    url: (path, line) => `cursor://file${encodeURI(path)}:${line}`,
     cliArgs: (path, line) => ['--goto', `${path}:${line}`]
   },
-  {
-    id: 'windsurf',
-    label: 'Windsurf',
+  windsurf: {
     appBundle: 'Windsurf.app',
     bin: 'windsurf',
-    url: (path, line) => `windsurf://file${encodeURI(path)}:${line}`,
     cliArgs: (path, line) => ['--goto', `${path}:${line}`]
   },
-  {
-    id: 'zed',
-    label: 'Zed',
+  zed: {
     appBundle: 'Zed.app',
     bin: 'zed',
-    url: (path, line) => `zed://file${encodeURI(path)}:${line}`,
     cliArgs: (path, line) => [`${path}:${line}`]
   },
-  {
-    id: 'sublime',
-    label: 'Sublime Text',
+  sublime: {
     appBundle: 'Sublime Text.app',
     windowsPath: 'Sublime Text\\sublime_text.exe',
     bin: 'subl',
-    // Sublime's scheme wants the path as a query parameter, not a path segment.
-    url: (path, line) => `subl://open?url=file://${encodeURIComponent(path)}&line=${line}`,
     cliArgs: (path, line) => [`${path}:${line}`]
   },
-  {
-    id: 'jetbrains',
-    label: 'JetBrains IDE',
+  jetbrains: {
     bin: process.platform === 'win32' ? 'idea64.exe' : 'idea',
     cliArgs: (path, line) => ['--line', String(line), path]
   }
-]
+}
+
+/**
+ * Order is the order the UI offers them in, and the first one found is the
+ * default - both inherited from `EDITOR_LINKS`, so the two shells offer the
+ * same editors in the same order.
+ */
+const EDITORS: EditorDefinition[] = EDITOR_LINKS.map((link) => ({
+  ...link,
+  ...DETECTION[link.id]
+}))
 
 /** What an editor turned out to support on this machine. */
 interface DetectedEditor extends EditorInfo {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -69,6 +69,13 @@ const carrier: Carrier = {
 const bridge: GitWarrenBridge = {
   carrier,
   shell: {
+    // A desktop app with the machine underneath it. Every one of these is true
+    // and stays true; the interesting column is the browser's, in `web/shell.ts`.
+    capabilities: {
+      pickDirectory: true,
+      revealPath: true,
+      openAtLogin: true
+    },
     system: {
       pickDirectory: () => invoke<string | null>(IPC_CHANNELS.systemPickDirectory),
       revealPath: (path: string) => invoke<void>(IPC_CHANNELS.systemRevealPath, path),
@@ -97,6 +104,9 @@ const bridge: GitWarrenBridge = {
       }
     },
     pickAttachment: () => invoke<Attachment | null>(IPC_CHANNELS.attachmentsPick),
+    // The token as stored. This window has a custom scheme registered for it -
+    // see `main/attachment-protocol.ts` - so there is nothing to rewrite.
+    attachmentSrc: (url: string) => url,
     openInEditor: (input: OpenReviewFileInput) =>
       invoke<void>(IPC_CHANNELS.reviewsOpenInEditor, input)
   }

--- a/src/renderer/src/components/markdown.tsx
+++ b/src/renderer/src/components/markdown.tsx
@@ -31,6 +31,10 @@
  * cannot; rendering the link instead means the reader still sees that an image
  * was referenced, and still gets to decide whether to open it.
  *
+ * That is still true in a browser tab, where the token is rewritten to a path
+ * on the page's own origin: `img-src 'self'` is not a loosening of the rule but
+ * the same rule spelled the way that shell spells it.
+ *
  * Repo-relative paths land in the same branch. Rendering those live against the
  * repository is worth doing later, but it needs repository context down here
  * that the renderer does not have, so for now they read as links rather than as
@@ -38,6 +42,8 @@
  */
 import ReactMarkdown, { defaultUrlTransform, type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { ATTACHMENT_URL_PREFIX } from '@shared/attachments'
+import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
 
 /**
@@ -45,12 +51,13 @@ import { cn } from '@/lib/utils'
  *
  * react-markdown strips URLs whose protocol it does not recognise, which is the
  * behaviour that keeps `javascript:` out of an href - so the default is kept
- * for every other URL and only `gitwarren:` is added. The scheme resolves to a
- * file this app copied into its own store and serves itself; see
- * `main/attachment-protocol.ts`.
+ * for every other URL and only `gitwarren:` is added. The token names a file
+ * this app copied into its own store and serves itself, over a custom scheme in
+ * the window (`main/attachment-protocol.ts`) and over HTTP in a browser tab
+ * (`core/web/attachments.ts`).
  */
 function urlTransform(url: string): string {
-  return url.startsWith('gitwarren://attachment/') ? url : defaultUrlTransform(url)
+  return url.startsWith(ATTACHMENT_URL_PREFIX) ? url : defaultUrlTransform(url)
 }
 
 /**
@@ -169,7 +176,7 @@ const components: Components = {
 
   img: ({ node: _node, src, alt, title, className, ...props }) => {
     const url = typeof src === 'string' ? src : ''
-    if (!url.startsWith('gitwarren://')) {
+    if (!url.startsWith(ATTACHMENT_URL_PREFIX)) {
       return (
         <a
           href={url}
@@ -184,7 +191,11 @@ const components: Components = {
     }
     return (
       <img
-        src={url}
+        // The one place a stored token becomes something fetchable, and the
+        // only place that differs between the two shells: the window has a
+        // custom scheme registered and passes it through, a tab rewrites it to
+        // a path on its own origin. See `ShellApi.attachmentSrc`.
+        src={api.attachments.src(url)}
         alt={alt ?? ''}
         title={title}
         className={cn('my-2 max-w-full rounded-md border border-border', className)}

--- a/src/renderer/src/features/comments/comment-composer.tsx
+++ b/src/renderer/src/features/comments/comment-composer.tsx
@@ -287,11 +287,12 @@ export function CommentComposer({
   }
 
   /**
-   * Open the native picker.
+   * Open the shell's file picker.
    *
-   * The dialog and the copy both happen in the main process - the renderer has
-   * no filesystem access, so it never learns the path of the file that was
-   * chosen, only the token it turned into.
+   * A native dialog in the window and an `<input type="file">` in a browser
+   * tab; either way the renderer never learns the path of what was chosen, only
+   * the token it turned into. Which is why this needs no capability flag - both
+   * shells can ask for a file, they just ask differently.
    */
   const pickFile = useCallback(async (): Promise<void> => {
     const state = readState()

--- a/src/renderer/src/features/repositories/repository-card.tsx
+++ b/src/renderer/src/features/repositories/repository-card.tsx
@@ -59,17 +59,22 @@ export function RepositoryCard({ repository, onEdit, onRemove }: RepositoryCardP
         onKeyDown={(event) => event.stopPropagation()}
         role="presentation"
       >
-        <Tooltip label={missing ? 'Folder is missing' : 'Show in file manager'}>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Show in file manager"
-            disabled={missing}
-            onClick={() => void api.system.revealPath(repository.path)}
-          >
-            <FolderOpen />
-          </Button>
-        </Tooltip>
+        {/* Absent rather than disabled in a browser tab: a disabled button is a
+            promise the shell cannot keep, and there is no file manager to put
+            in front of someone reading this over loopback in Chrome. */}
+        {api.capabilities.revealPath && (
+          <Tooltip label={missing ? 'Folder is missing' : 'Show in file manager'}>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Show in file manager"
+              disabled={missing}
+              onClick={() => void api.system.revealPath(repository.path)}
+            >
+              <FolderOpen />
+            </Button>
+          </Tooltip>
+        )}
         <Tooltip label="Edit this repository">
           <Button
             variant="ghost"

--- a/src/renderer/src/features/repositories/repository-detail.tsx
+++ b/src/renderer/src/features/repositories/repository-detail.tsx
@@ -45,19 +45,25 @@ export function RepositoryDetail({ repositoryId }: { repositoryId: number }) {
                 icon: Pencil,
                 run: () => setEditing(true)
               },
-              {
-                id: 'repository:reveal',
-                label: 'Show in file manager',
-                group: 'Repository',
-                hint: repository.path,
-                keys: 'o',
-                keywords: 'finder explorer folder open reveal',
-                icon: FolderOpen,
-                // A missing folder cannot be revealed, and saying so in the
-                // palette beats a key that silently does nothing.
-                disabled: !repository.git.exists,
-                run: () => void api.system.revealPath(repository.path)
-              }
+              // A shell with no file manager to reach contributes no command
+              // and no `o` key, rather than one that answers with a sentence.
+              ...(api.capabilities.revealPath
+                ? ([
+                    {
+                      id: 'repository:reveal',
+                      label: 'Show in file manager',
+                      group: 'Repository',
+                      hint: repository.path,
+                      keys: 'o',
+                      keywords: 'finder explorer folder open reveal',
+                      icon: FolderOpen,
+                      // A missing folder cannot be revealed, and saying so in
+                      // the palette beats a key that silently does nothing.
+                      disabled: !repository.git.exists,
+                      run: () => void api.system.revealPath(repository.path)
+                    }
+                  ] satisfies Command[])
+                : [])
             ],
       [repository]
     )
@@ -129,17 +135,19 @@ export function RepositoryDetail({ repositoryId }: { repositoryId: number }) {
           </div>
 
           <div className="flex shrink-0 items-center gap-1">
-            <Tooltip label={missing ? 'Folder is missing' : 'Show in file manager'}>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Show in file manager"
-                disabled={missing}
-                onClick={() => void api.system.revealPath(repository.path)}
-              >
-                <FolderOpen />
-              </Button>
-            </Tooltip>
+            {api.capabilities.revealPath && (
+              <Tooltip label={missing ? 'Folder is missing' : 'Show in file manager'}>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Show in file manager"
+                  disabled={missing}
+                  onClick={() => void api.system.revealPath(repository.path)}
+                >
+                  <FolderOpen />
+                </Button>
+              </Tooltip>
+            )}
             <Tooltip label="Edit repository">
               <Button
                 variant="ghost"

--- a/src/renderer/src/features/repositories/repository-form-dialog.tsx
+++ b/src/renderer/src/features/repositories/repository-form-dialog.tsx
@@ -132,7 +132,11 @@ function RepositoryForm({ repository, onDone }: RepositoryFormProps) {
         <DialogDescription>
           {isEditing
             ? 'Rename this repository, or point it at a new location if you moved it.'
-            : 'Choose any folder inside a git repository. GitWarren stores the repository root.'}
+            : api.capabilities.pickDirectory
+              ? 'Choose any folder inside a git repository. GitWarren stores the repository root.'
+              : // No Browse button to choose with, so the sentence says what the
+                // remaining half of the form actually wants.
+                'Type the path of any folder inside a git repository. GitWarren stores the repository root.'}
         </DialogDescription>
       </DialogHeader>
 
@@ -150,15 +154,20 @@ function RepositoryForm({ repository, onDone }: RepositoryFormProps) {
               autoComplete="off"
               spellCheck={false}
             />
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => void browse()}
-              className="shrink-0"
-            >
-              <FolderOpen />
-              Browse
-            </Button>
+            {/* A tab has no folder picker, so the field beside this is the
+                whole of the interaction there - which is also what adding a
+                repository on a remote host will look like in M4. */}
+            {api.capabilities.pickDirectory && (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void browse()}
+                className="shrink-0"
+              >
+                <FolderOpen />
+                Browse
+              </Button>
+            )}
           </div>
           <FieldError>{pathError}</FieldError>
           {!pathError && (

--- a/src/renderer/src/features/settings/settings-panel.tsx
+++ b/src/renderer/src/features/settings/settings-panel.tsx
@@ -10,6 +10,11 @@
  * there is no copy in the database. The user can turn this off in System
  * Settings or by deleting a `.desktop` file, and a switch showing a remembered
  * value would then be lying about their machine.
+ *
+ * A browser tab has no OS to ask, so the whole panel is absent there rather
+ * than showing a switch that is permanently off - "GitWarren does not start
+ * with this machine" is true of the tab and useless as a control. Turning it on
+ * is `gitwarren service install` at a terminal, which arrives in M3.3.
  */
 import { useState } from 'react'
 import useSWR from 'swr'
@@ -32,11 +37,19 @@ function description(platform: string): string {
 
 export function SettingsPanel() {
   const { data: info } = useSWR(CACHE_KEYS.appInfo, () => api.system.appInfo())
-  const { data: openAtLogin, mutate } = useSWR(CACHE_KEYS.openAtLogin, () =>
-    api.system.getOpenAtLogin()
+  const { data: openAtLogin, mutate } = useSWR(
+    // A shell that cannot answer is not asked. `null` is SWR's way of saying
+    // "no key, no fetch", and it keeps the read out of the network log of a
+    // browser tab that would only have been told false.
+    api.capabilities.openAtLogin ? CACHE_KEYS.openAtLogin : null,
+    () => api.system.getOpenAtLogin()
   )
   const [busy, setBusy] = useState(false)
 
+  // The only setting on the panel, so a shell without it has no panel. When the
+  // second setting arrives this becomes a row that is left out rather than a
+  // card that is.
+  if (!api.capabilities.openAtLogin) return null
   if (!info || openAtLogin === undefined) return null
 
   async function toggle(next: boolean): Promise<void> {

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -36,6 +36,11 @@ function once<T>(read: () => Promise<T>): () => Promise<T> {
 }
 
 export const api: GitWarrenApi = {
+  // Read once, at module scope, because it is read during render and cannot
+  // change while the page is open. A screen asks `api.capabilities.revealPath`
+  // and leaves the button out; see `ShellCapabilities` on why that is better
+  // than a button that explains itself when pressed.
+  capabilities: shell.capabilities,
   repositories: {
     list: () => carrier.request('repositories.list', undefined),
     get: (input) => carrier.request('repositories.get', input),
@@ -71,7 +76,8 @@ export const api: GitWarrenApi = {
   },
   attachments: {
     ingest: (input) => carrier.request('attachments.ingest', input),
-    pick: () => shell.pickAttachment()
+    pick: () => shell.pickAttachment(),
+    src: (url) => shell.attachmentSrc(url)
   },
   system: {
     pickDirectory: () => shell.system.pickDirectory(),

--- a/src/shared/__tests__/editors.test.ts
+++ b/src/shared/__tests__/editors.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Coverage for the editor URLs, which are now opened by two shells.
+ *
+ * The Electron app hands these to `shell.openExternal` and a browser tab
+ * navigates to them; either way what the operating system receives is this
+ * string, and it is the only part of "open this file at this line" that is not
+ * observable from inside GitWarren - the editor either lands on the line or it
+ * does not, somewhere else entirely. Spike S4 in docs/across-hosts.md is where
+ * these forms were checked against real editors; this is what stops them being
+ * edited into something else afterwards.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { EDITOR_LINKS, editorLink, linkableEditors } from '../editors.js'
+
+test('the URL forms are the ones spike S4 landed on', () => {
+  const path = '/home/xfor/github.com/klarluft/gitwarren-app/README.md'
+
+  assert.equal(editorLink('vscode')?.url?.(path, 5), `vscode://file${path}:5`)
+  assert.equal(editorLink('cursor')?.url?.(path, 5), `cursor://file${path}:5`)
+  assert.equal(
+    editorLink('sublime')?.url?.(path, 5),
+    `subl://open?url=file://${encodeURIComponent(path)}&line=5`
+  )
+})
+
+test('a path with a space in it is escaped rather than truncated', () => {
+  // The failure this prevents is silent: an unescaped space ends the URL, and
+  // the editor opens the first half of the path or nothing at all.
+  const url = editorLink('vscode')?.url?.('/Users/me/My Projects/app/src/index.ts', 12)
+
+  assert.equal(url, 'vscode://file/Users/me/My%20Projects/app/src/index.ts:12')
+})
+
+test('an editor nobody asked for is not invented', () => {
+  assert.equal(editorLink('emacs'), undefined)
+  assert.equal(editorLink(undefined), undefined)
+})
+
+test('a shell that can only navigate is offered every editor with a scheme', () => {
+  const offered = linkableEditors()
+
+  // JetBrains is launched by `idea --line` and has nothing to navigate to, so
+  // it is the one entry a browser tab does not get.
+  assert.deepEqual(
+    offered.map((editor) => editor.id),
+    ['vscode', 'cursor', 'windsurf', 'zed', 'sublime']
+  )
+  assert.equal(
+    offered.length,
+    EDITOR_LINKS.length - 1,
+    'an editor was added without deciding whether a browser can open it'
+  )
+})

--- a/src/shared/__tests__/web.test.ts
+++ b/src/shared/__tests__/web.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Coverage for the two strings a browser tab and the server that answers it
+ * both have to spell the same way.
+ *
+ * `webAttachmentSrc` is compiled into a browser bundle and `attachmentNameFrom
+ * WebPath` runs in the process serving it, and between them sits an `<img>`
+ * whose only symptom of disagreement is a picture that does not appear. That is
+ * the same class of failure as the doubled `#` M3.1 shipped and had to find
+ * afterwards - nothing throws, nothing is logged, and the page looks plausible.
+ * So the pair is asserted as a round trip rather than one function at a time.
+ *
+ * The refusals are the other half. The name in the URL comes out of a comment
+ * body, and comment bodies are written by agents that may have just read
+ * untrusted content out of the repository under review.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { attachmentUrl } from '../attachments.js'
+import { attachmentNameFromWebPath, webAttachmentSrc, WEB_PATHS } from '../web.js'
+
+const SHA = 'a'.repeat(64)
+
+test('a token becomes a path on this origin, and reads back as the same file', () => {
+  const path = webAttachmentSrc(attachmentUrl(SHA, 'png'))
+
+  assert.equal(path, `${WEB_PATHS.attachments}${SHA}.png`)
+  assert.equal(attachmentNameFromWebPath(path), `${SHA}.png`)
+})
+
+test('every format the store can hold survives the round trip', () => {
+  for (const ext of ['png', 'jpg', 'gif', 'webp']) {
+    const name = attachmentNameFromWebPath(webAttachmentSrc(attachmentUrl(SHA, ext)))
+    assert.equal(name, `${SHA}.${ext}`, ext)
+  }
+})
+
+test('a URL that is not one of our tokens is handed back untouched', () => {
+  // The caller still gets to decide what a foreign URL means - `markdown.tsx`
+  // renders it as a visible link rather than fetching it.
+  for (const url of [
+    'https://example.com/cat.png',
+    'data:image/png;base64,iVBORw0KGgo=',
+    './screenshot.png',
+    'gitwarren://attachment/../../etc/passwd',
+    'gitwarren://other/aaa.png'
+  ]) {
+    assert.equal(webAttachmentSrc(url), url)
+  }
+})
+
+test('a path under the prefix that is not a legitimate name is not a name', () => {
+  for (const name of [
+    '../../etc/passwd',
+    `${SHA}.png/../../etc/passwd`,
+    `${'A'.repeat(64)}.png`,
+    `${'a'.repeat(63)}.png`,
+    `${SHA}.toolongext`,
+    SHA,
+    ''
+  ]) {
+    assert.equal(attachmentNameFromWebPath(`${WEB_PATHS.attachments}${name}`), null, name)
+  }
+})
+
+test('a path outside the prefix is not an attachment request at all', () => {
+  assert.equal(attachmentNameFromWebPath(`/attachments/${SHA}.png`), null)
+  assert.equal(attachmentNameFromWebPath(WEB_PATHS.appInfo), null)
+})

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -266,6 +266,11 @@ export type UpdateStatus =
   | { state: 'error'; message: string }
 
 export interface GitWarrenApi {
+  /**
+   * What this shell can do, so a screen can leave a control out rather than
+   * offer one that only explains itself when pressed. See `ShellCapabilities`.
+   */
+  capabilities: ShellCapabilities
   repositories: {
     list(): Promise<RepositoryWithGitState[]>
     get(input: GetRepositoryInput): Promise<RepositoryWithGitState>
@@ -342,8 +347,10 @@ export interface GitWarrenApi {
    */
   attachments: {
     ingest(input: AttachmentIngestParams): Promise<Attachment>
-    /** Opens the native image picker and ingests the choice. Null if cancelled. */
+    /** Opens an image picker and ingests the choice. Null if cancelled. */
     pick(): Promise<Attachment | null>
+    /** The token in a body, as a `src` this shell can draw. See `ShellApi`. */
+    src(url: string): string
   }
   system: {
     /** Opens the native folder picker. Resolves to null if cancelled. */
@@ -401,6 +408,42 @@ export interface GitWarrenBridge {
 }
 
 /**
+ * What this shell can do, answered before anyone tries.
+ *
+ * Every method on `ShellApi` exists in every shell - that is what keeps
+ * `lib/api.ts` and the screens above it shell-agnostic. But some of them can
+ * only refuse in a browser tab, and a control that explains itself when pressed
+ * is a worse answer than a control that was never offered: the user reads a
+ * button as a promise. So a screen asks here *before* rendering, and the
+ * refusals stay as the backstop for a caller that did not ask.
+ *
+ * Deliberately a plain object rather than a promise. It is read during render,
+ * it cannot change while the page is open, and a capability that arrived a tick
+ * late would show every one of these controls for one frame.
+ *
+ * Deliberately capabilities and not a shell *name*. `if (shell === 'web')`
+ * spreads a list of what each shell happens to lack to every screen that asks;
+ * a flag per capability says what is actually being decided, and M4's remote
+ * hosts will answer some of these differently again without a screen changing.
+ */
+export interface ShellCapabilities {
+  /**
+   * A native folder picker for adding a repository. Without one the path field
+   * beside it is the whole of the interaction - which is also what a remote
+   * host in M4 will need, since a picker there would browse the wrong machine.
+   */
+  pickDirectory: boolean
+  /** Showing a path in Finder, Explorer or the desktop's file manager. */
+  revealPath: boolean
+  /**
+   * Whether GitWarren can be made to start with the machine from in here. False
+   * in a tab: the answer to "does this start at login" is a true and useful no,
+   * and turning it on is `gitwarren service install` at a terminal.
+   */
+  openAtLogin: boolean
+}
+
+/**
  * The Electron-only surface.
  *
  * Each of these does something to *this* machine: puts a window in front of the
@@ -408,13 +451,30 @@ export interface GitWarrenBridge {
  * method on the dispatcher, and none of them may become one - a request that
  * could start a process on a host across the network would make this a very
  * different piece of software. See the note in `core/rpc/dispatcher.ts`.
+ *
+ * "Electron-only" is the origin of this interface rather than a description of
+ * it any more: since M3 a browser tab supplies one too, doing what a tab can do
+ * and saying so through `capabilities`.
  */
 export interface ShellApi {
+  capabilities: ShellCapabilities
   system: GitWarrenApi['system']
   updates: GitWarrenApi['updates']
   navigation: GitWarrenApi['navigation']
-  /** Native picker, then straight into `attachments.ingest`. */
+  /** A picker, then straight into `attachments.ingest`. */
   pickAttachment(): Promise<Attachment | null>
+  /**
+   * The `src` this shell can actually draw an attachment token from.
+   *
+   * A comment body holds `gitwarren://attachment/<sha>.<ext>` whoever reads it,
+   * because the body is stored text and must not depend on which shell renders
+   * it. Turning that into something fetchable is the shell's job and happens at
+   * the `<img>` and nowhere else: the window passes it through to its custom
+   * scheme, and a tab rewrites it to a path on its own origin.
+   *
+   * Synchronous, and it has to be: it is called during render, once per image.
+   */
+  attachmentSrc(url: string): string
   /**
    * Ask the owning host where the file is, then open it here.
    *

--- a/src/shared/attachments.ts
+++ b/src/shared/attachments.ts
@@ -1,0 +1,65 @@
+/**
+ * The attachment token: how an image is named in a comment body.
+ *
+ * A body never holds a filesystem path. It holds
+ * `gitwarren://attachment/<sha256>.<ext>`, and the bytes live in a
+ * content-addressed store the app owns - see `core/services/attachments.ts` for
+ * why copying is the only shape that works. What lives *here* is only the
+ * grammar of that token, because by M3.2 four unrelated worlds have to agree on
+ * it:
+ *
+ *  - the store, which mints one (Node);
+ *  - the Electron main process, which serves it over a custom scheme (Node);
+ *  - the loopback server, which serves it over HTTP (Node);
+ *  - the renderer, which puts it in an `<img src>` (a browser bundle).
+ *
+ * The last one is why this is `shared/` rather than an export of the service:
+ * the service reaches for `node:crypto` and `node:fs` on its first line, and a
+ * browser cannot import it to learn what a token looks like. The grammar is a
+ * handful of characters and no behaviour, so it moves here and the service
+ * keeps re-exporting it.
+ *
+ * Plain JS only. No Node, no Electron.
+ */
+
+/** The URL scheme and host an attachment is named by. */
+export const ATTACHMENT_URL_PREFIX = 'gitwarren://attachment/'
+
+/**
+ * Filenames anything serving attachments will accept.
+ *
+ * This is a security boundary rather than a tidiness check, and it is why the
+ * expression is a whitelist rather than a traversal filter. Comment bodies are
+ * agent-writable, so `gitwarren://attachment/../../../../etc/passwd` is a URL
+ * that will genuinely be requested one day - over the custom scheme in the app,
+ * and now over HTTP in a browser tab too. A hash and a short extension is the
+ * entire vocabulary of a legitimate name, so anything else is refused outright
+ * rather than resolved and then reasoned about.
+ */
+export const ATTACHMENT_FILE_NAME = /^[a-f0-9]{64}\.[a-z0-9]{2,4}$/
+
+export function attachmentUrl(sha: string, ext: string): string {
+  return `${ATTACHMENT_URL_PREFIX}${sha}.${ext}`
+}
+
+/**
+ * The `<sha>.<ext>` a token names, or null when the URL is not one of ours.
+ *
+ * Separate from `parseAttachmentUrl` because whoever is *serving* the file
+ * wants the name back as a name - it is a path segment and a filename in the
+ * store, and splitting it into two halves only to join them again is where a
+ * `.` goes missing.
+ */
+export function attachmentName(url: string): string | null {
+  if (!url.startsWith(ATTACHMENT_URL_PREFIX)) return null
+  const name = url.slice(ATTACHMENT_URL_PREFIX.length)
+  return ATTACHMENT_FILE_NAME.test(name) ? name : null
+}
+
+/** Pull the `<sha>.<ext>` out of a token, or null if it is not one. */
+export function parseAttachmentUrl(url: string): { sha: string; ext: string } | null {
+  const name = attachmentName(url)
+  if (name === null) return null
+  const dot = name.lastIndexOf('.')
+  return { sha: name.slice(0, dot), ext: name.slice(dot + 1) }
+}

--- a/src/shared/editors.ts
+++ b/src/shared/editors.ts
@@ -1,0 +1,99 @@
+/**
+ * The editors GitWarren knows how to point at a line, and the URL each one
+ * registered for itself.
+ *
+ * Two shells launch editors and they do it by different means, which is exactly
+ * why the *forms* live in one place. The Electron app detects what is installed
+ * and can fall back to a CLI on PATH; a browser tab can do neither - it cannot
+ * look at the filesystem and it cannot spawn a process, and it must not ask a
+ * server to spawn one either (see the note at the top of `core/rpc/
+ * dispatcher.ts`). What a tab *can* do is navigate to a URL scheme, which the
+ * operating system hands to the application that claimed it. So the tab offers
+ * this list as a choice rather than as a detection, and the same string that
+ * `main/editors.ts` would have opened is the one the browser opens.
+ *
+ * Detection lives in `main/editors.ts` and stays there: application bundles,
+ * `PATH` lookups and `cliArgs` are Node's business. This file is the half both
+ * shells need, and it is the half a browser bundle can import.
+ *
+ * Plain JS only. No Node, no Electron.
+ */
+import type { EditorInfo } from './api.js'
+
+export interface EditorLink extends EditorInfo {
+  /**
+   * The URL that opens `path` at `line`, or absent when the editor has no
+   * scheme worth using and can only be launched from a command line.
+   */
+  url?: (path: string, line: number) => string
+}
+
+/**
+ * Order is the order a picker offers them in, and the first one is what a shell
+ * with nothing better to go on will use. It is a judgement call rather than a
+ * fact; the picker exists so the judgement does not have to be right.
+ */
+export const EDITOR_LINKS = [
+  {
+    id: 'vscode',
+    label: 'VS Code',
+    url: (path, line) => `vscode://file${encodeURI(path)}:${line}`
+  },
+  {
+    id: 'cursor',
+    label: 'Cursor',
+    url: (path, line) => `cursor://file${encodeURI(path)}:${line}`
+  },
+  {
+    id: 'windsurf',
+    label: 'Windsurf',
+    url: (path, line) => `windsurf://file${encodeURI(path)}:${line}`
+  },
+  {
+    id: 'zed',
+    label: 'Zed',
+    url: (path, line) => `zed://file${encodeURI(path)}:${line}`
+  },
+  {
+    id: 'sublime',
+    label: 'Sublime Text',
+    // Sublime's scheme wants the path as a query parameter, not a path segment.
+    url: (path, line) => `subl://open?url=file://${encodeURIComponent(path)}&line=${line}`
+  },
+  {
+    id: 'jetbrains',
+    label: 'JetBrains IDE'
+  }
+] as const satisfies readonly EditorLink[]
+
+/**
+ * The ids, as a union rather than as `string`.
+ *
+ * `main/editors.ts` keys its detection table by this, so an editor added here
+ * without detection - or a key misspelled there - is a type error rather than
+ * an editor that quietly stops being found on disk. That is the one failure the
+ * split into two tables makes possible, so it is the one the types close.
+ */
+export type EditorId = (typeof EDITOR_LINKS)[number]['id']
+
+export function editorLink(id: string | undefined): EditorLink | undefined {
+  return id === undefined ? undefined : EDITOR_LINKS.find((editor) => editor.id === id)
+}
+
+/**
+ * The editors a shell with no way to look at the filesystem can offer.
+ *
+ * Everything with a URL scheme, which is every entry but the JetBrains IDEs -
+ * those are launched by `idea --line`, and there is nothing for a browser to
+ * navigate to. Offering an editor that turns out not to be installed costs the
+ * user a dismissed "open with?" dialog, which is a better failure than a
+ * missing entry for the editor they actually use.
+ */
+export function linkableEditors(): EditorInfo[] {
+  // Widened to `EditorLink` first: the literal type of the table knows which
+  // entries have a `url` and which do not, and the filter is exactly the
+  // question that distinction cannot be asked as.
+  return (EDITOR_LINKS as readonly EditorLink[])
+    .filter((editor) => editor.url !== undefined)
+    .map(({ id, label }) => ({ id, label }))
+}

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -209,10 +209,15 @@ export interface ReviewOpen {
  * naive `JSON.stringify` of a byte array produces, but it costs about four
  * bytes per byte and exists for compatibility rather than as a recommendation.
  *
- * Whoever answers accepts all three.
+ * `ArrayBufferView` - a `Uint8Array` and its relatives - is the shape an
+ * `ArrayBuffer` comes out of structured clone as, and is taken over its own
+ * byte range rather than over the buffer behind it.
+ *
+ * Whoever answers accepts all four; see `toIngestSource` in
+ * `core/rpc/dispatcher.ts`, which is the one place that decides.
  */
 export interface AttachmentIngestParams {
-  bytes: ArrayBuffer | number[] | string
+  bytes: ArrayBuffer | ArrayBufferView | number[] | string
   /** Only ever used for display and default alt text; the format is sniffed. */
   originalName?: string
 }

--- a/src/shared/web.ts
+++ b/src/shared/web.ts
@@ -20,6 +20,8 @@
  * `WEB_PATHS.appInfo` below.
  */
 
+import { ATTACHMENT_FILE_NAME, attachmentName } from './attachments.js'
+
 /** Everything the browser shell talks to, under one reserved prefix. */
 export const WEB_PREFIX = '/gitwarren'
 
@@ -43,8 +45,59 @@ export const WEB_PATHS = {
    * Revealing a folder or launching an editor stays with the machine the person
    * is sitting at, which in a browser tab means it is simply absent.
    */
-  appInfo: `${WEB_PREFIX}/app-info`
+  appInfo: `${WEB_PREFIX}/app-info`,
+  /**
+   * Attachment bytes, one file per name: `…/attachments/<sha>.<ext>`.
+   *
+   * A prefix rather than a path, and the one thing under here that is not a
+   * single endpoint. It exists because `gitwarren://attachment/…` is a custom
+   * scheme only the Electron main process can serve, and a tab needs the same
+   * images. Serving them over HTTP rather than inlining them as `data:` URLs in
+   * the comment body keeps the cache, the range requests and the memory
+   * behaviour a browser already has for images, and keeps a body the same
+   * string in both shells.
+   *
+   * A read, and only a read - the way *in* is `attachments.ingest` on the
+   * dispatcher, which is where the size limit and the format sniff live. There
+   * is no upload endpoint here and there should not be one.
+   */
+  attachments: `${WEB_PREFIX}/attachments/`
 } as const
+
+/**
+ * The same image, addressed the way a browser tab can fetch it.
+ *
+ * A comment body holds `gitwarren://attachment/<name>` whoever reads it - the
+ * body is stored text and must not depend on which shell renders it. So the
+ * rewrite happens at the `<img src>` and nowhere else: the Electron window
+ * passes the token through to its custom scheme, and a tab turns it into a path
+ * on this origin.
+ *
+ * Anything that is not one of our tokens comes back unchanged, so the caller's
+ * own decision about what to do with a foreign URL - render it as a link, per
+ * `components/markdown.tsx` - is still the caller's to make.
+ */
+export function webAttachmentSrc(url: string): string {
+  const name = attachmentName(url)
+  return name === null ? url : `${WEB_PATHS.attachments}${name}`
+}
+
+/**
+ * The store filename a request under the attachments prefix is asking for, or
+ * null when the path is not one.
+ *
+ * The other half of `webAttachmentSrc`, and the reason both live here: this is
+ * the pair of functions most able to drift apart, and one of them is compiled
+ * into a browser bundle while the other runs in the server that answers it.
+ *
+ * `pathname` arrives decoded, so a name that decoded into a `/` fails the
+ * pattern rather than becoming two segments.
+ */
+export function attachmentNameFromWebPath(pathname: string): string | null {
+  if (!pathname.startsWith(WEB_PATHS.attachments)) return null
+  const name = pathname.slice(WEB_PATHS.attachments.length)
+  return ATTACHMENT_FILE_NAME.test(name) ? name : null
+}
 
 /**
  * The cookie the session lives in, once a token has been exchanged for it.

--- a/src/web/__tests__/wire.test.ts
+++ b/src/web/__tests__/wire.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Coverage for the encoding that makes pasting a screenshot into a browser tab
+ * work at all.
+ *
+ * `JSON.stringify` turns an `ArrayBuffer` into `{}` and says nothing about it.
+ * The image then reaches the dispatcher as an empty object, fails the format
+ * sniff, and the user is told their PNG is not a PNG - a failure that reads as
+ * being about the file rather than about the wire, which is the kind that costs
+ * an afternoon. So the first test asserts the bytes survive, and the last one
+ * asserts the size at which the naive implementation of base64 stops working.
+ *
+ * The decode side is the dispatcher's `toIngestSource`, which has taken base64
+ * since M2 for the stdio carrier. Nothing new is being agreed here; this is the
+ * browser end learning to speak what the daemon already listened for.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { frame } from '../wire.js'
+import type { RpcRequest } from '../../shared/rpc.js'
+
+/** What the dispatcher does with what arrives, in one line. */
+function bytesOf(text: string): Buffer {
+  const { params } = JSON.parse(text) as { params: { bytes: string } }
+  return Buffer.from(params.bytes, 'base64')
+}
+
+test('an ArrayBuffer of image bytes arrives as base64, not as an empty object', () => {
+  const png = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    'base64'
+  )
+  const request: RpcRequest = {
+    id: 1,
+    method: 'attachments.ingest',
+    params: { bytes: png.buffer.slice(png.byteOffset, png.byteOffset + png.byteLength) }
+  }
+
+  const text = frame(request)
+
+  assert.ok(!text.includes('"bytes":{}'), 'the bytes were stringified away')
+  assert.deepEqual(bytesOf(text), png)
+})
+
+test('a typed array is sent over its own range and not the buffer behind it', () => {
+  // A view of part of a larger allocation is ordinary, and sending the rest of
+  // that allocation would be sending memory nobody asked for.
+  const backing = new Uint8Array([0, 0, 1, 2, 3, 0, 0])
+  const view = backing.subarray(2, 5)
+
+  const text = frame({ id: 2, method: 'attachments.ingest', params: { bytes: view } })
+
+  assert.deepEqual(bytesOf(text), Buffer.from([1, 2, 3]))
+})
+
+test('everything alongside the bytes is carried through untouched', () => {
+  const text = frame({
+    id: 3,
+    method: 'attachments.ingest',
+    params: { bytes: new Uint8Array([1]), originalName: 'Screenshot 2026-09-10 at 14.02.png' }
+  })
+
+  const decoded = JSON.parse(text) as RpcRequest & { params: { originalName: string } }
+  assert.equal(decoded.id, 3)
+  assert.equal(decoded.method, 'attachments.ingest')
+  assert.equal(decoded.params.originalName, 'Screenshot 2026-09-10 at 14.02.png')
+})
+
+test('a request with no bytes in it is ordinary JSON', () => {
+  // Which is nearly every request. The scan must not change what they look like.
+  const params = { id: 7, path: 'src/index.ts', changes: 'all' }
+  const text = frame({ id: 4, method: 'reviews.file', params })
+
+  assert.equal(text, JSON.stringify({ id: 4, method: 'reviews.file', params }))
+})
+
+test('params that are undefined survive being framed', () => {
+  // `repositories.list` takes none, and the carrier sends the request anyway.
+  assert.equal(
+    frame({ id: 5, method: 'repositories.list', params: undefined }),
+    JSON.stringify({ id: 5, method: 'repositories.list', params: undefined })
+  )
+})
+
+test('an image large enough to overflow a call stack still encodes', () => {
+  // The reason the encoder works in slices. Four megabytes is an ordinary
+  // retina screenshot and about a hundred times the argument limit that
+  // `String.fromCharCode(...bytes)` dies at.
+  const big = new Uint8Array(4 * 1024 * 1024)
+  for (let index = 0; index < big.length; index += 1) big[index] = index % 256
+
+  const text = frame({ id: 6, method: 'attachments.ingest', params: { bytes: big } })
+
+  assert.deepEqual(bytesOf(text), Buffer.from(big))
+})

--- a/src/web/bootstrap.ts
+++ b/src/web/bootstrap.ts
@@ -19,9 +19,14 @@ import { hrefFor } from '@shared/routes'
 import type { GitWarrenBridge } from '@shared/api'
 
 export function installBridge(): GitWarrenBridge {
+  // The shell is handed the carrier, which the preload's never needed. Two of
+  // the things a tab does for itself - attaching an image, opening a file in an
+  // editor - are half a question for the host and half an action here, and the
+  // host half is an ordinary method. See `shell.ts` on where that line falls.
+  const carrier = createWebCarrier()
   const bridge: GitWarrenBridge = {
-    carrier: createWebCarrier(),
-    shell: createWebShell()
+    carrier,
+    shell: createWebShell(carrier)
   }
 
   window.gitwarren = bridge

--- a/src/web/carrier.ts
+++ b/src/web/carrier.ts
@@ -26,6 +26,9 @@
  * Read coalescing is carried over from the preload unchanged, and matters more
  * here: two components asking the same question in the same tick is one frame
  * on the wire instead of two.
+ *
+ * A request is turned into text by `wire.ts` rather than by `JSON.stringify`,
+ * because one of them holds an image. See the note there.
  */
 import { AppError } from '@shared/errors'
 import {
@@ -40,6 +43,7 @@ import {
   type RpcResult
 } from '@shared/rpc'
 import { WEB_PATHS } from '@shared/web'
+import { frame } from './wire'
 
 /** Backoff between reconnects: quick at first, then out of the way. */
 const RETRY_MS = [250, 500, 1000, 2000, 5000] as const
@@ -79,7 +83,7 @@ export function createWebCarrier(): WebCarrier {
   }
 
   const send = (request: RpcRequest): void => {
-    if (socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify(request))
+    if (socket?.readyState === WebSocket.OPEN) socket.send(frame(request))
     else queued.push(request)
   }
 
@@ -106,7 +110,7 @@ export function createWebCarrier(): WebCarrier {
       // iterate: a request queued by a listener during the flush belongs to the
       // socket that is now open, not to this loop.
       const backlog = queued.splice(0, queued.length)
-      for (const request of backlog) opening.send(JSON.stringify(request))
+      for (const request of backlog) opening.send(frame(request))
       announce(true)
     })
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -15,9 +15,11 @@
 
       `img-src` keeps `data:` - image diffs arrive as data URLs from
       `reviews.image` - and drops the `gitwarren:` scheme, which is a custom
-      protocol only the Electron main process serves. Attachments in markdown
-      come over HTTP from this same origin in M3.2; until then they are the one
-      thing in a comment body that does not render in a tab.
+      protocol only the Electron main process serves. Attachments reach this
+      shell over HTTP instead, from `/gitwarren/attachments/…` on this very
+      origin, so `'self'` already covers them and no source had to be added.
+      Note what is still absent: no remote `img-src`, so an image in a comment
+      body cannot reach the network in a tab either.
     -->
     <meta
       http-equiv="Content-Security-Policy"

--- a/src/web/shell.ts
+++ b/src/web/shell.ts
@@ -2,31 +2,43 @@
  * The browser's shell: what a tab can do for the person in front of it, and an
  * honest refusal for everything else.
  *
- * `ShellApi` is the Electron-only surface (see `shared/api.ts`) - pickers,
- * revealing a path, launching an editor, the updater. A browser tab has none of
- * those, and the interesting question is not how to emulate them but which ones
- * may be answered by the *server* instead. The line, which M6 will lean on hard
- * when the phone connects to a host over the tailnet:
+ * `ShellApi` is the surface the dispatcher may not have (see `shared/api.ts`) -
+ * pickers, revealing a path, launching an editor, the updater. A browser tab
+ * has none of those natively, and the interesting question is not how to
+ * emulate them but where each one may be answered from instead. The line, which
+ * M6 will lean on hard when the phone connects to a host over the tailnet:
  *
  *  - **A fact about the host may travel.** `appInfo` is version numbers, an
- *    instance id and paths. Reading it over HTTP is not a capability.
- *  - **A capability of the host may not.** Revealing a folder or launching an
+ *    instance id and paths; `reviews.filePath` is where a file of this review
+ *    lives. Reading either over the carrier is not a capability.
+ *  - **A capability of the host may not.** Revealing a folder or spawning an
  *    editor acts on the machine the daemon is on, which is not necessarily the
  *    machine the person is at, and a request that could start a process there
- *    would make this very different software. So they are absent here, and they
- *    stay absent - the browser gets its own versions in M3.2 (a `vscode://`
- *    link, a file input) which act on the machine holding the keyboard.
+ *    would make this very different software. So nothing here asks the server
+ *    to *do* anything to its machine.
  *
- * Refusals throw `AppError` rather than resolving to something empty, so the
- * UI's existing error paths show a sentence a user can act on. What is still
- * missing in M3.1 is the *shell capability flag* that lets a screen hide a
- * control instead of offering one that explains itself when pressed; that is
- * the first thing M3.2 does, and until then a toggle with no meaning in a
- * browser says so when it is used rather than before.
+ * What that leaves is a tab doing these things itself, with the browser's own
+ * tools, on the machine holding the keyboard:
+ *
+ *  - **Attaching an image** is a file input, and the bytes go through
+ *    `attachments.ingest` - the same method an agent's path goes through.
+ *  - **Opening a file in an editor** is a `vscode://file/…:line` navigation.
+ *    The path is asked for over the carrier and the URL is opened here, which
+ *    is the same two halves `main/ipc.ts` joins, joined in the other order.
+ *  - **Rendering an attachment** is a rewrite of the token to a path on this
+ *    origin, which the server answers from the same store.
+ *
+ * Three things genuinely cannot be done, and rather than being offered and
+ * explaining themselves when pressed, they are declared absent in
+ * `capabilities` so the screens leave them out. The refusals below stay as the
+ * backstop for a caller that did not look.
  */
 import { AppError } from '@shared/errors'
-import { WEB_PATHS } from '@shared/web'
+import { editorLink, linkableEditors } from '@shared/editors'
+import { WEB_PATHS, webAttachmentSrc } from '@shared/web'
 import type { AppInfo, EditorList, ShellApi, UpdateStatus } from '@shared/api'
+import type { Attachment, OpenReviewFileInput } from '@shared/schemas'
+import type { Carrier } from '@shared/rpc'
 
 /** Nothing to unsubscribe from. Returned by the subscriptions a tab cannot have. */
 const NO_SUBSCRIPTION = (): void => {}
@@ -65,7 +77,18 @@ async function readAppInfo(): Promise<AppInfo> {
   return (await response.json()) as AppInfo
 }
 
-const NO_EDITORS: EditorList = { editors: [], defaultId: null }
+/**
+ * Every editor with a URL scheme, offered as a choice rather than as a finding.
+ *
+ * The Electron app lists what it detected on disk; a tab cannot look, so it
+ * lists what it knows how to address and lets the reviewer say. `defaultId` is
+ * the first of them, which is a guess - and the picker in the files tab appears
+ * precisely because more than one entry means the guess can be corrected.
+ */
+function editorChoices(): EditorList {
+  const editors = linkableEditors()
+  return { editors, defaultId: editors[0]?.id ?? null }
+}
 
 const UPDATES_UNSUPPORTED: UpdateStatus = {
   state: 'unsupported',
@@ -74,20 +97,125 @@ const UPDATES_UNSUPPORTED: UpdateStatus = {
     'tarball it was unpacked from.'
 }
 
-export function createWebShell(): ShellApi {
+/**
+ * The file picker, as a browser has one.
+ *
+ * An `<input type="file">` clicked from script, which is the only way to open a
+ * file dialog on the web and is why this is not simply absent: the composer
+ * already has an "attach" button, and it can go on meaning the same thing.
+ *
+ * Cancellation is the awkward part. A dialog that is dismissed fires `cancel`
+ * in current browsers, and fired nothing at all in browsers that are still
+ * around - which would leave the composer's `busy` flag set for the life of the
+ * page. So `cancel` settles it when it comes, and the first `focus` back on the
+ * window is the fallback: whichever happens first wins, and `change` beats both
+ * because it is dispatched before focus returns.
+ */
+function pickImageFile(): Promise<File | null> {
+  return new Promise((resolve) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = 'image/png,image/jpeg,image/gif,image/webp'
+    // Off-screen rather than `display:none`: a hidden input is not clickable in
+    // every browser, and the click is the whole point.
+    input.style.position = 'fixed'
+    input.style.left = '-9999px'
+    document.body.append(input)
+
+    let settled = false
+    const settle = (file: File | null): void => {
+      if (settled) return
+      settled = true
+      window.removeEventListener('focus', onFocus)
+      input.remove()
+      resolve(file)
+    }
+
+    // A frame's grace after focus comes back, so a `change` that is already on
+    // its way is not overtaken by the fallback.
+    const onFocus = (): void => {
+      window.setTimeout(() => settle(input.files?.[0] ?? null), 300)
+    }
+
+    input.addEventListener('change', () => settle(input.files?.[0] ?? null))
+    input.addEventListener('cancel', () => settle(null))
+    window.addEventListener('focus', onFocus)
+
+    input.click()
+  })
+}
+
+export function createWebShell(carrier: Carrier): ShellApi {
+  /**
+   * Ask the host where the file is, then hand the URL to this machine.
+   *
+   * `reviews.filePath` is a read on the dispatcher - it answers *which* file,
+   * which is review knowledge - and the navigation is this shell's own. The
+   * path is an absolute path on the machine the daemon is on, which today is
+   * always the machine the browser is on too: the handler binds loopback and
+   * checks `Host`, so there is no way to be looking at this page from
+   * elsewhere. When M6 makes that untrue, this is one of the places that has to
+   * learn the difference, and the editor URL grows a remote authority per S4.
+   */
+  const openInEditor = async (input: OpenReviewFileInput): Promise<void> => {
+    const { id, path, changes, line, editorId } = input
+    const editor = editorLink(editorId) ?? editorLink(editorChoices().defaultId ?? undefined)
+    if (!editor?.url) {
+      return unsupported(
+        'Opening a file in an editor',
+        'No editor with a URL scheme was chosen for this tab.'
+      )
+    }
+
+    const absolute = await carrier.request('reviews.filePath', { id, path, changes })
+
+    // `location.href` rather than `window.open`: a scheme the browser hands to
+    // the OS does not open a document, so a popup would be an empty tab left
+    // behind, and a top-level navigation to an external scheme leaves this page
+    // where it is. A scheme nothing has claimed shows the browser's own "no
+    // application" dialog, which is a better answer than anything this code
+    // could invent.
+    // `line` is optional on the way in and defaulted by the schema on the way
+    // through the dispatcher, which this call does not go through.
+    window.location.href = editor.url(absolute, line ?? 1)
+  }
+
+  /**
+   * A picked file, ingested exactly as a pasted one is.
+   *
+   * The bytes go over the carrier to `attachments.ingest`, so the size limit,
+   * the format sniff and the content addressing are the store's, not this
+   * shell's - the same service an agent's file path reaches. The one thing a
+   * tab knows that the Electron picker does not is that it never learns a path,
+   * which is fine: a path was never what got stored.
+   */
+  const pickAttachment = async (): Promise<Attachment | null> => {
+    const file = await pickImageFile()
+    if (file === null) return null
+    return await carrier.request('attachments.ingest', {
+      bytes: await file.arrayBuffer(),
+      originalName: file.name
+    })
+  }
+
   return {
-    system: {
+    capabilities: {
       // No native folder picker, and no attempt at one. The path field next to
-      // the button is a text input, so a repository is added by typing or
-      // pasting its path - which is also what someone reaching a remote host in
-      // M4 will do, since a picker there would browse the wrong machine.
-      pickDirectory: () => Promise.resolve(null),
-      revealPath: () => unsupported('Revealing a folder', 'Copy the path and open it yourself.'),
-      appInfo: readAppInfo,
-      editors: () => Promise.resolve(NO_EDITORS),
+      // where the button would be is a text input, so a repository is added by
+      // typing or pasting its path - which is also what someone reaching a
+      // remote host in M4 will do.
+      pickDirectory: false,
+      revealPath: false,
       // False rather than a refusal: the question "does GitWarren start with
       // this machine" has a true answer for a browser tab, and it is no.
       // Turning it *on* is `gitwarren service install`, which arrives in M3.3.
+      openAtLogin: false
+    },
+    system: {
+      pickDirectory: () => Promise.resolve(null),
+      revealPath: () => unsupported('Revealing a folder', 'Copy the path and open it yourself.'),
+      appInfo: readAppInfo,
+      editors: () => Promise.resolve(editorChoices()),
       getOpenAtLogin: () => Promise.resolve(false),
       setOpenAtLogin: () =>
         unsupported('Starting at login', 'Run `gitwarren service install` on this machine.')
@@ -106,8 +234,8 @@ export function createWebShell(): ShellApi {
       // exists to reproduce is what a browser does natively.
       onDeepLink: () => NO_SUBSCRIPTION
     },
-    pickAttachment: () => Promise.resolve(null),
-    openInEditor: () =>
-      unsupported('Opening a file in an editor', 'Open it from the repository on this machine.')
+    pickAttachment,
+    attachmentSrc: webAttachmentSrc,
+    openInEditor
   }
 }

--- a/src/web/wire.ts
+++ b/src/web/wire.ts
@@ -1,0 +1,81 @@
+/**
+ * One request, as text on the wire.
+ *
+ * Apart from the socket so it can be tested, for the same reason
+ * `loopback-fragment.ts` is: what it gets wrong, it gets wrong silently.
+ *
+ * The reason this is not `JSON.stringify` is bytes. `attachments.ingest` is
+ * handed an `ArrayBuffer` by the composer - which is what the Electron carrier
+ * wants, because structured clone carries it perfectly - and it is also the one
+ * thing `JSON.stringify` destroys without complaining, turning it into `{}`.
+ * The image then arrives at the dispatcher as an empty object and fails the
+ * format sniff, which reaches the user as "that file is not a PNG, JPEG, GIF or
+ * WebP image" about a file that certainly was one.
+ *
+ * base64 is what the dispatcher already documents for a carrier over a byte
+ * stream - see `toIngestSource` in `core/rpc/dispatcher.ts`, which accepts it
+ * alongside an array of byte values and an `ArrayBuffer` - so this is a choice
+ * among the encodings that end is known to take, not a new one.
+ *
+ * Plain JS and no DOM: `btoa` is the one global it needs, and it is a global in
+ * Node too.
+ */
+import type { RpcRequest } from '../shared/rpc.js'
+
+/**
+ * `btoa` wants a string of char codes, and a call stack to build it with.
+ *
+ * A screenshot is a few megabytes, and spreading that many arguments into
+ * `String.fromCharCode` overflows the stack - so the bytes go in slices. This
+ * is the difference between pasting an image working and the tab throwing
+ * `RangeError: Maximum call stack size exceeded` on the one path where the
+ * payload is large by definition.
+ */
+const CHUNK = 0x8000
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let offset = 0; offset < bytes.length; offset += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + CHUNK))
+  }
+  return btoa(binary)
+}
+
+/**
+ * Encode a request for the socket, base64-ing any bytes in its params.
+ *
+ * The scan is one level deep on purpose. Params are flat objects, the protocol
+ * has exactly one field that ever holds bytes, and a recursive walk would be a
+ * general serialiser - a thing with its own edge cases to maintain, in the
+ * carrier, which is the layer least allowed to have any.
+ */
+export function frame(request: RpcRequest): string {
+  const { params } = request
+  if (typeof params !== 'object' || params === null) return JSON.stringify(request)
+
+  let encoded: Record<string, unknown> | null = null
+  for (const [key, value] of Object.entries(params)) {
+    const bytes = asBytes(value)
+    if (bytes === null) continue
+    encoded ??= { ...params }
+    encoded[key] = toBase64(bytes)
+  }
+
+  return JSON.stringify(encoded === null ? request : { ...request, params: encoded })
+}
+
+/**
+ * A value's bytes, when it is bytes.
+ *
+ * A typed array is taken over its own range rather than over the whole buffer
+ * behind it - a `Uint8Array` that is a view of part of a larger allocation is
+ * ordinary, and sending the rest of that allocation would be sending memory
+ * nobody asked for.
+ */
+function asBytes(value: unknown): Uint8Array | null {
+  if (value instanceof ArrayBuffer) return new Uint8Array(value)
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+  }
+  return null
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -36,6 +36,8 @@
     "src/renderer/src/features/reviews/__tests__/diff-search.test.ts",
     "src/web/loopback-fragment.ts",
     "src/web/__tests__/loopback-fragment.test.ts",
+    "src/web/wire.ts",
+    "src/web/__tests__/wire.test.ts",
     "electron.vite.config.ts",
     "vite.mcp.config.ts",
     "vite.daemon.config.ts",


### PR DESCRIPTION
Second of the five changes M3 is going in as. Stacked on #40 — **base is `worktree-m3-web-view`**, so review it after that one, or read the diff of the single commit.

M3.1 left the browser shell able to do everything except three things, and refusing them in a sentence when pressed. This does them, each the way a tab can rather than by asking the server to do it for the person. That line is easiest to draw now, while the browser and the daemon are on the same machine and nobody would notice it being crossed — M6 is where it starts to matter.

## Attachments over HTTP

`/gitwarren/attachments/<sha>.<ext>`, behind the same cookie as everything else, reading the same content-addressed store the Electron custom scheme reads.

A comment body still holds `gitwarren://attachment/…` whoever reads it — it is stored text and must not depend on which shell renders it — so the rewrite happens at the `<img src>` and nowhere else, through a new `shell.attachmentSrc`. `img-src 'self'` already covered the result, so nothing in the CSP was loosened to make pictures appear.

The token grammar moved to `shared/attachments.ts`: the store's first line asks for `node:crypto`, and a browser bundle cannot import it to learn what a legitimate name looks like. The whitelist (`ATTACHMENT_FILE_NAME`) is what the new endpoint checks before touching the filesystem — the name comes out of an agent-writable comment body, so `../../../../etc/passwd` is a request this app will genuinely receive.

## A capability flag

`shell.capabilities` — `pickDirectory`, `revealPath`, `openAtLogin` — read synchronously at module scope, so a screen leaves a control out rather than offering one that explains itself when pressed. A button is a promise.

Flags rather than a shell *name*: `if (shell === 'web')` spreads a list of what each shell happens to lack across every screen that asks, and M4's remote hosts will answer some of these differently again without a screen changing. The M3.1 refusals stay underneath as the backstop for a caller that did not look.

## Open in an editor

Two halves joined in the opposite order from `main/ipc.ts`: `reviews.filePath` is a read on the dispatcher — *which* file is review knowledge — and the `vscode://file/…:line` navigation happens in the tab. Nothing here asks the daemon to start a process, which is the rule that keeps this software rather than a remote shell.

The URL forms moved to `shared/editors.ts` so both shells open the same string; detection stayed in `main/editors.ts`, keyed by an id union so an editor added without detection is a type error rather than an editor that quietly stops being found on disk.

## The bug: a pasted screenshot never arrived

`attachments.ingest` is handed an `ArrayBuffer`, which structured clone carries perfectly and which `JSON.stringify` turns into `{}` without a word. Over the socket the image reached the dispatcher as an empty object, failed the format sniff, and the user was told their PNG is not a PNG — a failure that reads as being about the file rather than about the wire.

The carrier now base64s bytes before framing (`web/wire.ts`, apart from the socket so it can be tested, as `loopback-fragment.ts` is), which is the encoding `toIngestSource` has taken since M2 for the stdio carrier. `btoa` needs the bytes in slices, or a four-megabyte screenshot overflows the call stack inside `String.fromCharCode`. `AttachmentIngestParams` was also narrower than what the dispatcher accepted — it omitted the typed-array form the dispatcher has a branch for — and now says all four.

## Verified

In Chrome and in the Electron window against one scratch data directory, on a review whose description and first comment both hold an attachment:

- both images paint in both shells;
- `reviews.filePath` answers with the right absolute path, and the editor URL leaves the page where it is;
- an `ArrayBuffer` ingest over the socket comes back with a real sha.

Side by side on the repository screens, the browser shows zero reveal buttons, no Browse and no start-at-login switch where the window shows one of each — and the path field, the edit buttons and the cards are all still there. Controls removed, not screens.

No console errors and no failed requests beyond Chrome's own `favicon.ico` probe, which the web build has nothing to answer with. An icon is polish for M3.5 rather than a gap here.

19 new tests: the attachment endpoint and its refusals, the `webAttachmentSrc` ↔ `attachmentNameFromWebPath` round trip, the editor URL forms against spike S4, and the byte framing including the size at which the naive base64 stops working. 369 pass, lint and both typechecks clean.

## Not done, and why

The other half of the "Blobs over HTTP" bullet — *very large file reads use GET past a size threshold* — is untouched. `reviews.file` and `reviews.image` still answer over the socket in both shells, which is fine on loopback where the socket is a memcpy, and the threshold is a number that should be chosen against a real network rather than guessed here. It belongs with M6.

`docs/across-hosts.md` carries all of the above, as the source of truth for this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbPbgJ7g8w1QF5Jq1FGnBS
