### PR TITLE
M4.1 - Hosts, the SSH carrier and the connection pool

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -1534,6 +1534,121 @@ the uncommitted work Claude Code left there, comment; the agent in WSL reads
 the comment over its local MCP and replies; the reply appears on the Mac after
 refresh. Pull the network cable mid-review and plug it back.
 
+#### How it is being built, and where it has got to
+
+Five changes, each mergeable on its own, in the order that keeps every one of
+them verifiable against the real `pc-wsl` node rather than against a mock:
+
+1. **The hosts table, the carrier and the pool.** What it takes to reach
+   another machine at all. *(done — see below.)*
+2. **The Hosts screen and the installer over SSH.** `uname -sm`, the tarball
+   fetched once and streamed in, the launchers maintained, and the screen that
+   drives it.
+3. **Repositories on hosts.** `fs.list`, the host segment in routes, reviews
+   listed under their host, clones grouped by root commit across hosts.
+4. **Attachments, editors and agent access per host.**
+5. **Disconnection.** The stale banner and the silent refetch.
+
+**M4.1, done on the Mac against the WSL node, 10 September.** The novelty is
+one file and an argument vector. Everything else M4 needs had already been
+built to accept it: `shared/rpc.ts` is the protocol, `core/rpc/ndjson.ts` is
+the framing, `core/rpc/stdio-client.ts` is the asking side, and what answers on
+the far end is the same `gitwarren serve --stdio` M2 shipped. `core/hosts/ssh.ts`
+contributes a child process, and that is genuinely all.
+
+Everything below was proved by hand against `pc-wsl` *before* any of it was
+written, which is the order this milestone rewards: the 44 MB tarball streamed
+into `~/.gitwarren/daemon/<version>/` over the pipe in 2.5 seconds on a box
+with nothing but git, and `{"id":1,"method":"repositories.list"}` came back
+`{"id":1,"result":[]}` — with the two responses arriving *out of order*, which
+is the property the `id` field exists for and the first thing a hand-rolled
+client would have got wrong. `stdout` is pure protocol; the `ready` banner is
+on stderr, where framing cannot be hurt by it.
+
+**The framing moved before it was copied.** M2 read frames in `stdio.ts`
+because only the daemon read them. M4 has a client too, and two implementations
+of "where does a frame end" produce a *hang* rather than an error — both ends
+healthy, both waiting, nothing logged. So `ndjson.ts` came out first and both
+sides are users of it.
+
+**The client's most important decision is not to be clever.** When a connection
+dies mid-flight there is no way to tell "the daemon never saw it" from "it did
+the work and the reply died on the way back". Retrying is safe in the first
+case and posts a second comment in the second, so every in-flight request fails
+with `HOST_OFFLINE` and none is resent; reconnection is about the *next*
+request. The web carrier settled this identically at M3.
+
+**Backoff belongs to the host, not the request.** A screen polling every
+fifteen seconds against a machine that is switched off must not spawn four
+`ssh` processes a minute for an hour, so a failed host refuses immediately for
+a while rather than hopefully — fast is kinder than hopeful, and M4.5's banner
+needs something to render. The one deliberate exception is an explicit probe: a
+person pressing "try now" knows something the timer does not, usually that they
+have just switched the machine on. Ten idle minutes closes the pipe, matching
+`ControlPersist` so the multiplexing master and the daemon expire together, and
+"idle" is measured from when a request *finished* — a naive timer hangs up on a
+large `reviews.diff` halfway through its own answer.
+
+**`hosts.*` is answered here and never forwarded.** A host's list of hosts is
+its own business, and routing these onward would turn a hub and its spokes into
+a mesh where removing a machine from one list could remove it from another.
+`isLocalOnly` in `ssh.ts` refuses to send them, so the rule is structural
+rather than a comment; M4.3's router is where the general local-versus-remote
+decision will live.
+
+**Two things bit, and both are worth keeping.**
+
+*The useful half of a failure arrives after the failure.* The protocol notices
+a dead connection when the far end's stdout ends — which for a failing `ssh` is
+a moment *before* the `exit` that carries the status code and after which
+stderr is complete. Reading the reason at the instant the request failed
+therefore reported "The connection to the host closed." for a hostname that
+does not resolve: true, useless, and exactly the message a person would have
+been left with. `diagnostics()` is now a promise that waits briefly for the
+exit already on its way, and the same host now says `ssh could not connect to
+xfor@no-such-host-here. ssh: Could not resolve hostname no-such-host-here`.
+This was found by running the thing against a real machine and reading the
+output rather than by a test passing.
+
+*`BatchMode=yes` is what turns a hang into an error.* Without it `ssh` waits at
+a passphrase or host-key prompt on a stdin carrying JSON and no human, and the
+GUI spins forever. Key management stays the person's own, in their SSH agent
+and config; GitWarren never asks for a password and has nowhere to keep one.
+
+`instance_id` on a host row is nullable on purpose. Someone types a target and
+presses Add, and at that moment nobody knows which machine that is, or whether
+it answers — so NULL is the honest record of a host *described* but not yet
+*met*, and the identity is learned on the first successful connect and written
+back. It is what catches one machine added twice under two names (`pc-wsl` and
+`xfor@100.78.0.23`), which neither label nor target can see and which is
+reported rather than merged.
+
+Verified end to end against `pc-wsl` through the shipping code, not by hand:
+the host reachable in 178 ms cold and 4 ms warm on the multiplexed channel, its
+instance id learned and written back, a `NOT_FOUND` surviving the wire as
+itself while leaving the host marked up, `hosts.list` refused by the carrier, a
+deliberate hang-up starting no backoff and the host reachable again after it,
+and an unreachable machine failing in 18 ms with what `ssh` actually said. A
+host that answers `ssh` but has no GitWarren exits 127 and is told so by name,
+which is the single most likely outcome of adding a host until M4.2 lands.
+
+The whole protocol contract in `rpc/__tests__/dispatcher.test.ts` now runs a
+third time, through `stdio-client.ts` against `stdio.ts` — so the thing under
+test is the thing that ships, and the test's own hand-rolled client is gone.
+Four assertions about the response *envelope* are skipped for it rather than
+faked: a client that assigns its own ids and unwraps its own outcomes cannot
+ask a question under a chosen id, and a `send` built on top of it would echo
+back whatever the test passed in and assert nothing.
+
+**Not done in M4.1, and why.** There is no Hosts screen yet, so a host is added
+through the dispatcher and not by anyone using the app — that and the installer
+are M4.2, which is why they are one slice: the screen's main job is to drive
+the install. Nothing installs the daemon on a host, so it has to be put there
+by hand for now. Repositories on hosts are M4.3, so `hosts.remove` deliberately
+leaves any repository rows pointing at that host alone rather than cascading —
+a cascade written now would have to be unpicked once there is a remote
+repository to have an opinion about.
+
 ### M5 — WSL from Windows
 
 *Ships: the Windows app reviews WSL repos.*

--- a/drizzle/0008_hosts.sql
+++ b/drizzle/0008_hosts.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `hosts` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`instance_id` text,
+	`label` text NOT NULL,
+	`kind` text DEFAULT 'ssh' NOT NULL,
+	`target` text NOT NULL,
+	`editor_target` text,
+	`last_seen_at` text,
+	`created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `hosts_kind_target_idx` ON `hosts` (`kind`,`target`);--> statement-breakpoint
+CREATE UNIQUE INDEX `hosts_instance_idx` ON `hosts` (`instance_id`) WHERE "hosts"."instance_id" is not null;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,731 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "591c5ede-c25b-4cf8-a00a-d1566c7cd6c4",
+  "prevId": "23340602-c612-4c96-97ac-111f749d7e6d",
+  "tables": {
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_threads": {
+      "name": "comment_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_text": {
+          "name": "anchor_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_sha": {
+          "name": "anchor_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_snapshot": {
+          "name": "anchor_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "comment_threads_review_idx": {
+          "name": "comment_threads_review_idx",
+          "columns": [
+            "review_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "comment_threads_file_idx": {
+          "name": "comment_threads_file_idx",
+          "columns": [
+            "review_id",
+            "file_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_threads_review_id_reviews_id_fk": {
+          "name": "comment_threads_review_id_reviews_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_label": {
+          "name": "author_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_session": {
+          "name": "author_session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "comments_thread_idx": {
+          "name": "comments_thread_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_thread_id_comment_threads_id_fk": {
+          "name": "comments_thread_id_comment_threads_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comment_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_author_id_principals_id_fk": {
+          "name": "comments_author_id_principals_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hosts": {
+      "name": "hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ssh'"
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "editor_target": {
+          "name": "editor_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "hosts_kind_target_idx": {
+          "name": "hosts_kind_target_idx",
+          "columns": [
+            "kind",
+            "target"
+          ],
+          "isUnique": true
+        },
+        "hosts_instance_idx": {
+          "name": "hosts_instance_idx",
+          "columns": [
+            "instance_id"
+          ],
+          "isUnique": true,
+          "where": "\"hosts\".\"instance_id\" is not null"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "principals": {
+      "name": "principals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "principals_identity_idx": {
+          "name": "principals_identity_idx",
+          "columns": [
+            "kind",
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "repositories_name_idx": {
+          "name": "repositories_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repositories_host_path_idx": {
+          "name": "repositories_host_path_idx",
+          "columns": [
+            "host_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "repositories_local_path_idx": {
+          "name": "repositories_local_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true,
+          "where": "\"repositories\".\"host_id\" is null"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviewed_files": {
+      "name": "reviewed_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_digest": {
+          "name": "content_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "reviewed_files_path_idx": {
+          "name": "reviewed_files_path_idx",
+          "columns": [
+            "review_id",
+            "file_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reviewed_files_review_id_reviews_id_fk": {
+          "name": "reviewed_files_review_id_reviews_id_fk",
+          "tableFrom": "reviewed_files",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reviews_repository_idx": {
+          "name": "reviews_repository_idx",
+          "columns": [
+            "repository_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_repository_id_repositories_id_fk": {
+          "name": "reviews_repository_id_repositories_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1789030274674,
       "tag": "0007_hosts_and_principals",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1789074697080,
+      "tag": "0008_hosts",
+      "breakpoints": true
     }
   ]
 }

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -3,10 +3,15 @@ import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { WS_PURE_JS } from './vite.ws-define.js'
+import { version } from './package.json'
 
 export default defineConfig({
   main: {
-    define: WS_PURE_JS,
+    // `__APP_VERSION__` is what `core/version.ts` reads, and from M4 the main
+    // process needs it too: `app.instance` reports this install's version to a
+    // GUI on another machine, and the answer has to be the same string the
+    // daemon build has stamped in since M3.3.
+    define: { ...WS_PURE_JS, __APP_VERSION__: JSON.stringify(version) },
     plugins: [externalizeDepsPlugin()],
     resolve: {
       alias: {

--- a/src/core/__tests__/hosts.test.ts
+++ b/src/core/__tests__/hosts.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The host service: what a row means before and after a machine is met.
+ *
+ * Nothing here connects to anything. `hosts.probe` is the only function that
+ * would, and it is exercised against a fake pool in `core/hosts/__tests__`;
+ * what is left for this file is the part that lives in SQLite, which is where
+ * the two duplicate rules and the identity write-back are.
+ *
+ * The interesting tests are the two about identity. A host added twice under
+ * two different names is not something a form can detect - `pc-wsl` and
+ * `xfor@100.78.0.23` are different strings and might well be different machines
+ * - so the collision is only visible once the machine has said who it is, and
+ * it has to be reported rather than quietly merged.
+ *
+ * These read synchronously because better-sqlite3 is synchronous and the
+ * service stopped pretending otherwise; only `probe` waits for anything.
+ */
+import assert from 'node:assert/strict'
+import { eq } from 'drizzle-orm'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, beforeEach, test } from 'node:test'
+
+import type { AppError as AppErrorInstance } from '../../shared/errors.js'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-hosts-'))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+const { hostsService } = await import('../services/hosts.js')
+const { getDatabase, closeDatabase } = await import('../db/client.js')
+const { hosts } = await import('../db/schema.js')
+const { AppError } = await import('../../shared/errors.js')
+
+beforeEach(() => {
+  getDatabase().delete(hosts).run()
+})
+
+after(() => {
+  closeDatabase()
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+function expectError(run: () => unknown): AppErrorInstance {
+  try {
+    run()
+  } catch (error) {
+    assert.ok(error instanceof AppError)
+    return error
+  }
+  throw new Error('Expected an AppError.')
+}
+
+test('a host is described before it is met', () => {
+  const host = hostsService.add({ target: 'xfor@pc-wsl' })
+
+  // Never connected, so nothing is claimed about which machine this is.
+  assert.equal(host.instanceId, null)
+  assert.equal(host.lastSeenAt, null)
+  assert.equal(host.state.connected, false)
+  assert.equal(host.kind, 'ssh')
+})
+
+test('the label defaults to the machine, not to the login', () => {
+  // A list where every entry begins with the same username has stopped
+  // distinguishing anything.
+  assert.equal(hostsService.add({ target: 'xfor@pc-wsl' }).label, 'pc-wsl')
+  assert.equal(hostsService.add({ target: 'vps.example.com' }).label, 'vps.example.com')
+})
+
+test('a name someone chose is kept', () => {
+  assert.equal(hostsService.add({ target: 'xfor@pc-wsl', label: 'The PC' }).label, 'The PC')
+})
+
+test('a target that could be read as an option is refused', () => {
+  // `ssh` would take this as a flag. It is spawned without a shell, so this is
+  // belt and braces - but a carrier's safety should not rest on a spawn flag.
+  const option = expectError(() => hostsService.add({ target: '-oProxyCommand=touch /tmp/x' }))
+  assert.equal(option.code, 'INVALID_INPUT')
+
+  const injected = expectError(() => hostsService.add({ target: 'host; rm -rf ~' }))
+  assert.equal(injected.code, 'INVALID_INPUT')
+  assert.ok(injected.fieldErrors?.target)
+})
+
+test('the same target twice is refused with something a form can show', () => {
+  hostsService.add({ target: 'xfor@pc-wsl' })
+
+  const error = expectError(() => hostsService.add({ target: 'xfor@pc-wsl' }))
+  assert.equal(error.code, 'INVALID_INPUT')
+  assert.deepEqual(error.fieldErrors?.target, ['This host is already in the list.'])
+})
+
+test('repointing a host at another machine forgets who it was', () => {
+  const host = hostsService.add({ target: 'xfor@pc-wsl' })
+  getDatabase()
+    .update(hosts)
+    .set({
+      instanceId: '4e0b0adb-1085-43e4-92be-a9ca9bad985c',
+      lastSeenAt: new Date().toISOString()
+    })
+    .run()
+
+  const moved = hostsService.update({ id: host.id, target: 'xfor@other-box' })
+
+  // The new address may be a different machine entirely, and keeping the old
+  // identity would let a repository row follow an address instead of a machine.
+  assert.equal(moved.instanceId, null)
+  assert.equal(moved.lastSeenAt, null)
+})
+
+test('renaming a host keeps everything it had learned', () => {
+  const host = hostsService.add({ target: 'xfor@pc-wsl' })
+  const instanceId = '4e0b0adb-1085-43e4-92be-a9ca9bad985c'
+  getDatabase().update(hosts).set({ instanceId }).run()
+
+  const renamed = hostsService.update({ id: host.id, label: 'Work PC' })
+
+  assert.equal(renamed.label, 'Work PC')
+  assert.equal(renamed.instanceId, instanceId, 'a label is not an identity')
+})
+
+test('two names for one machine cannot both hold its identity', () => {
+  // The database is the backstop, for the race the service check cannot cover.
+  const instanceId = '4e0b0adb-1085-43e4-92be-a9ca9bad985c'
+  const first = hostsService.add({ target: 'xfor@pc-wsl' })
+  const second = hostsService.add({ target: 'xfor@100.78.0.23' })
+
+  getDatabase().update(hosts).set({ instanceId }).where(eq(hosts.id, first.id)).run()
+
+  assert.throws(() => {
+    getDatabase().update(hosts).set({ instanceId }).where(eq(hosts.id, second.id)).run()
+  }, /UNIQUE constraint failed: hosts.instance_id/)
+})
+
+test('but two hosts that have not been met are perfectly distinct', () => {
+  // NULLs in a unique index are all different from one another, which is
+  // exactly what is wanted here: "not met yet" is not an identity to collide.
+  hostsService.add({ target: 'xfor@pc-wsl' })
+  hostsService.add({ target: 'xfor@100.78.0.23' })
+
+  const all = hostsService.list()
+  assert.equal(all.length, 2)
+  assert.ok(all.every((host) => host.instanceId === null))
+})
+
+test('removing a host that is not there says so', () => {
+  assert.equal(expectError(() => hostsService.remove({ id: 999 })).code, 'NOT_FOUND')
+})

--- a/src/core/db/schema.ts
+++ b/src/core/db/schema.ts
@@ -58,6 +58,109 @@ export const principals = sqliteTable(
 export type PrincipalRow = typeof principals.$inferSelect
 export type NewPrincipalRow = typeof principals.$inferInsert
 
+/**
+ * Another machine this install can reach, and how to reach it.
+ *
+ * The table `repositories.host_id` has been pointing at since M0. A row here is
+ * a *route*, not a copy of anything: the host owns its repositories, its SQLite
+ * and its git, and everything this install knows about what is over there it
+ * learned by asking. Nothing here is replicated state, which is why there is no
+ * `synced_at` and never will be.
+ *
+ * ## Why the instance id is nullable
+ *
+ * `instanceId` is the host's own identity (`shared/instance-id.ts`), and it is
+ * what `repositories.host_id` actually stores - so it is tempting to require it
+ * at insert. It cannot be, because of the order the world happens in: a person
+ * types an SSH target into a form and presses Add, and at that moment nobody
+ * knows the instance id, or whether the host answers at all. It is learned on
+ * the first successful connect and written back.
+ *
+ * That also makes NULL the honest record of a host we have never reached: a row
+ * with a target and no instance id is a host that has been *described* but not
+ * yet *met*, and the Hosts screen can say exactly that instead of showing a
+ * fabricated identity next to a machine that may not exist.
+ *
+ * Keeping identity apart from address is what M6 will need: a host's address
+ * changes (DHCP, a renamed tailnet node, a different SSH user) while the
+ * machine holding the repositories does not. When discovery starts proposing
+ * peers, the instance id is what says "you already know this one" - and it is
+ * the only field a `repositories.host_id` may be matched against.
+ *
+ * ## What `kind` will and will not grow into
+ *
+ * `ssh` here, `wsl` at M5, `websocket` at M6. It discriminates over *carriers*,
+ * not over operating systems: what a host runs is discovered by asking it
+ * (`uname -sm`, for M4.2's installer), never declared in a form, because a
+ * person choosing "Linux" from a dropdown is a person who can choose wrong.
+ */
+export const hosts = sqliteTable(
+  'hosts',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    /**
+     * The host's own instance id, learned on the first successful connect and
+     * NULL until then. This is what `repositories.host_id` holds.
+     */
+    instanceId: text('instance_id'),
+    /** What the person calls this machine. Theirs to choose; never matched on. */
+    label: text('label').notNull(),
+    /** Which carrier reaches it. */
+    kind: text('kind', { enum: ['ssh'] })
+      .notNull()
+      .default('ssh'),
+    /**
+     * What the carrier is handed. For `ssh`, a destination `ssh` understands -
+     * and it carries the Unix user, because spike S1 found that a bare MagicDNS
+     * name requests the *client's* username and is refused by the tailnet
+     * policy. `xfor@pc-wsl`, not `pc-wsl`.
+     */
+    target: text('target').notNull(),
+    /**
+     * How an editor on *this* machine names a file over there:
+     * `ssh-remote+<target>` for VS Code, per spike S4. Kept apart from `target`
+     * because the two coincide today and stop coinciding at M5, where the
+     * carrier is `wsl.exe -d Ubuntu` and the editor form is `wsl+Ubuntu`. NULL
+     * means "derive it from the target", which is right until someone's SSH
+     * config aliases differ from their editor's.
+     */
+    editorTarget: text('editor_target'),
+    /**
+     * When this host last answered a request. A fact about the past, so it is
+     * safe to store; whether the host is reachable *now* is not, and is never
+     * written down - the Hosts screen asks the carrier, which knows.
+     */
+    lastSeenAt: text('last_seen_at'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`)
+  },
+  (table) => [
+    /**
+     * One row per target per carrier. Adding `pc-wsl` twice is a mistake worth
+     * catching in the database rather than in the form, since a form is not the
+     * only thing that will insert here once M6 discovers peers.
+     */
+    uniqueIndex('hosts_kind_target_idx').on(table.kind, table.target),
+    /**
+     * And one row per machine. Partial, because NULL is how "not met yet" is
+     * spelled and SQLite treats NULLs in a unique index as all distinct - the
+     * same rule, and the same remedy, as the repositories indexes below.
+     *
+     * This is the index that catches the interesting case: one machine added
+     * twice under two names (`pc-wsl` and `xfor@100.78.0.23`). Neither label
+     * nor target can see that they are the same box; the instance id it reports
+     * on first connect can.
+     */
+    uniqueIndex('hosts_instance_idx')
+      .on(table.instanceId)
+      .where(sql`${table.instanceId} is not null`)
+  ]
+)
+
+export type HostRow = typeof hosts.$inferSelect
+export type NewHostRow = typeof hosts.$inferInsert
+
 export const repositories = sqliteTable(
   'repositories',
   {

--- a/src/core/hosts/__tests__/pool.test.ts
+++ b/src/core/hosts/__tests__/pool.test.ts
@@ -1,0 +1,203 @@
+/**
+ * When there is a connection, and when there is deliberately not one.
+ *
+ * The pool is pure policy - it holds no sockets of its own and spawns nothing -
+ * so it is tested with a fake connection and a clock the test moves by hand.
+ * That is not a shortcut around testing the real thing: `ssh.ts` is what talks
+ * to `ssh`, `stdio-client.ts` is what speaks the protocol, and both are covered
+ * where they live. What is left here is the set of decisions that would
+ * otherwise only ever be exercised by a laptop going to sleep at the wrong
+ * moment.
+ *
+ * The one that matters most is the last test in the file. A `NOT_FOUND` and a
+ * dead network both arrive at this code as a rejected promise, and treating
+ * them alike would mark a perfectly healthy machine unreachable because someone
+ * opened a review that had been deleted.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { createHostPool, BACKOFF_MS, type HostRoute } from '../pool.js'
+import type { SshConnection } from '../ssh.js'
+import { AppError } from '../../../shared/errors.js'
+
+const route: HostRoute = { id: 1, kind: 'ssh', target: 'xfor@pc-wsl' }
+
+interface FakeHost {
+  /** How many times the pool has opened a connection. */
+  connects: number
+  /** What the next request should do. */
+  answer: () => Promise<unknown>
+  closeLast: (error: AppError) => void
+  open: boolean
+}
+
+function fakePool(host: Partial<FakeHost> = {}): {
+  pool: ReturnType<typeof createHostPool>
+  fake: FakeHost
+  advance: (ms: number) => void
+} {
+  let clock = 1_000_000
+  const fake: FakeHost = {
+    connects: 0,
+    answer: () => Promise.resolve([]),
+    closeLast: () => {},
+    open: true,
+    ...host
+  }
+
+  const pool = createHostPool({
+    now: () => clock,
+    connect: (_route, onClose) => {
+      fake.connects += 1
+      fake.open = true
+      fake.closeLast = (error) => {
+        fake.open = false
+        onClose(error)
+      }
+      const connection: SshConnection = {
+        request: () => fake.answer() as Promise<never>,
+        close: () => {
+          fake.open = false
+        },
+        isOpen: () => fake.open,
+        diagnostics: () =>
+          Promise.resolve('ssh: connect to host pc-wsl port 22: Host is down')
+      }
+      return connection
+    }
+  })
+
+  return { pool, fake, advance: (ms: number) => (clock += ms) }
+}
+
+test('nothing connects until something is actually asked', () => {
+  const { pool, fake } = fakePool()
+
+  assert.equal(fake.connects, 0)
+  assert.deepEqual(pool.state(route.id), { connected: false, failures: 0 })
+})
+
+test('one connection serves many requests', async () => {
+  const { pool, fake } = fakePool()
+
+  await pool.request(route, 'repositories.list')
+  await pool.request(route, 'repositories.list')
+  await pool.request(route, 'repositories.list')
+
+  assert.equal(fake.connects, 1)
+  assert.equal(pool.state(route.id).connected, true)
+})
+
+test('a failure puts the host into backoff, and requests inside it fail fast', async () => {
+  const { pool, fake } = fakePool({
+    answer: () => Promise.reject(new AppError('HOST_OFFLINE', 'gone'))
+  })
+
+  await assert.rejects(pool.request(route, 'repositories.list'))
+  const afterFirst = pool.state(route.id)
+  assert.equal(afterFirst.connected, false)
+  assert.equal(afterFirst.failures, 1)
+  // The diagnostics from the connection, not the bare protocol message: this is
+  // what a Hosts screen shows, and "gone" would tell nobody anything.
+  assert.match(afterFirst.lastError ?? '', /Host is down/)
+
+  // The first rung is zero, so a second attempt is allowed immediately and the
+  // second failure is what actually starts the timer.
+  await assert.rejects(pool.request(route, 'repositories.list'))
+  assert.equal(pool.state(route.id).failures, 2)
+  const connectsSoFar = fake.connects
+
+  // Now inside the backoff window. No new connection is attempted at all.
+  await assert.rejects(pool.request(route, 'repositories.list'), /Host is down/)
+  assert.equal(fake.connects, connectsSoFar, 'no ssh was spawned during backoff')
+})
+
+test('backoff expires, and a success clears it completely', async () => {
+  const { pool, fake, advance } = fakePool({
+    answer: () => Promise.reject(new AppError('HOST_OFFLINE', 'gone'))
+  })
+
+  await assert.rejects(pool.request(route, 'repositories.list'))
+  await assert.rejects(pool.request(route, 'repositories.list'))
+  const during = fake.connects
+
+  advance(BACKOFF_MS[BACKOFF_MS.length - 1] ?? 60_000)
+  fake.answer = () => Promise.resolve(['ok'])
+
+  assert.deepEqual(await pool.request(route, 'repositories.list'), ['ok'])
+  assert.ok(fake.connects > during, 'the wait having passed, it tried again')
+
+  // A machine that is back is entirely back - not one rung down the ladder.
+  assert.deepEqual(pool.state(route.id), { connected: true, failures: 0 })
+})
+
+test('a probe reaches past the backoff, because a person pressing a button knows more than a timer', async () => {
+  const { pool, fake } = fakePool({
+    answer: () => Promise.reject(new AppError('HOST_OFFLINE', 'gone'))
+  })
+
+  await assert.rejects(pool.request(route, 'repositories.list'))
+  await assert.rejects(pool.request(route, 'repositories.list'))
+  const during = fake.connects
+
+  fake.answer = () => Promise.resolve([])
+  const state = await pool.probe(route)
+
+  assert.ok(fake.connects > during, 'the probe ignored the wait')
+  assert.equal(state.connected, true)
+})
+
+test('a probe of a host that is down answers rather than throws', async () => {
+  const { pool } = fakePool({
+    answer: () => Promise.reject(new AppError('HOST_OFFLINE', 'gone'))
+  })
+
+  const state = await pool.probe(route)
+
+  assert.equal(state.connected, false)
+  assert.match(state.lastError ?? '', /Host is down/)
+})
+
+test('the connection dying on its own marks the host down', async () => {
+  const { pool, fake } = fakePool()
+
+  await pool.request(route, 'repositories.list')
+  assert.equal(pool.state(route.id).connected, true)
+
+  fake.closeLast(new AppError('HOST_OFFLINE', 'The connection to the host closed.'))
+
+  assert.equal(pool.state(route.id).connected, false)
+  assert.equal(pool.state(route.id).failures, 1)
+})
+
+test('hanging up on purpose is not a failure', async () => {
+  const { pool } = fakePool()
+
+  await pool.request(route, 'repositories.list')
+  pool.disconnect(route.id)
+
+  const state = pool.state(route.id)
+  assert.equal(state.connected, false)
+  // The distinction the idle timer depends on: a connection we closed must not
+  // push the host onto the backoff ladder, or ten quiet minutes would look
+  // exactly like a machine that had gone away.
+  assert.equal(state.failures, 0)
+  assert.equal(state.retryAfter, undefined)
+})
+
+test('an error from the host is the host working, not the host being down', async () => {
+  const { pool } = fakePool({
+    answer: () => Promise.reject(new AppError('NOT_FOUND', 'No review with id 999.'))
+  })
+
+  await assert.rejects(pool.request(route, 'reviews.get'), (error: AppError) => {
+    // Passed through untouched - a caller must not have to unwrap a transport
+    // error to find out that a review does not exist.
+    assert.equal(error.code, 'NOT_FOUND')
+    return true
+  })
+
+  // The round trip succeeded. The machine is fine and stays fine.
+  assert.deepEqual(pool.state(route.id), { connected: true, failures: 0 })
+})

--- a/src/core/hosts/__tests__/ssh.test.ts
+++ b/src/core/hosts/__tests__/ssh.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The argument vector, and the rule about what never leaves the machine.
+ *
+ * Small assertions about a small file, and worth having for two reasons. The
+ * options are load-bearing in a way that is invisible at a glance - drop
+ * `BatchMode` and a missing key turns a spinner into a hang rather than an
+ * error - and the local-only rule is a security-shaped property that would
+ * otherwise be enforced only by a comment.
+ *
+ * Reaching a real host is `docs/across-hosts.md`'s job, under M4's verify
+ * sentence, and was done against `pc-wsl` before this code was written.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { connectOverSsh, isLocalOnly, sshArgs, REMOTE_LAUNCHER, SSH_OPTIONS } from '../ssh.js'
+import { rpcMethodNames } from '../../rpc/dispatcher.js'
+
+test('the command starts the launcher, not a versioned path', () => {
+  const args = sshArgs('xfor@pc-wsl')
+
+  assert.deepEqual(args.slice(-3), [REMOTE_LAUNCHER, 'serve', '--stdio'])
+  // `~` and not an absolute path: only the remote shell knows where home is.
+  assert.match(REMOTE_LAUNCHER, /^~\//)
+  // The target comes immediately before the command, so nothing a person typed
+  // can be read as an option to `ssh`.
+  assert.equal(args[args.length - 4], 'xfor@pc-wsl')
+})
+
+test('a hang is turned into an error before anything else', () => {
+  // Without this, `ssh` waits at a passphrase prompt on a stdin carrying JSON
+  // and no human, and the GUI spins forever.
+  assert.ok(SSH_OPTIONS.includes('BatchMode=yes'))
+})
+
+test('the connection is multiplexed and kept alive', () => {
+  // The first is what makes a reconnect cheap; the second is what makes a dead
+  // connection noticeable at all, rather than a socket nobody gives up on.
+  assert.ok(SSH_OPTIONS.includes('ControlMaster=auto'))
+  assert.ok(SSH_OPTIONS.some((option) => option.startsWith('ServerAliveInterval=')))
+})
+
+test('a host that cannot be resolved says what ssh said, not that a stream ended', async () => {
+  // The bug this test exists for was found against a real machine and is
+  // entirely about ordering: the protocol notices a dead connection when stdout
+  // ends, which for a failing `ssh` is a moment *before* the exit that carries
+  // the status and completes stderr. Reading the reason at the instant the
+  // request failed produced "The connection to the host closed." for a hostname
+  // that does not resolve - true, and no help to anybody.
+  const connection = connectOverSsh({ target: 'gitwarren-no-such-host.invalid' })
+
+  await assert.rejects(connection.request('repositories.list'))
+
+  const reason = await connection.diagnostics()
+  assert.match(reason, /ssh could not connect/i)
+  assert.match(reason, /no-such-host/i)
+  connection.close()
+})
+
+test('host management is answered here and never sent to a host', () => {
+  // A prefix rather than a list, so `hosts.rename` tomorrow cannot quietly
+  // become forwardable by being forgotten.
+  for (const method of rpcMethodNames.filter((name) => name.startsWith('hosts.'))) {
+    assert.equal(isLocalOnly(method), true, `${method} must not leave this machine`)
+  }
+
+  // And everything else must, or a remote host would be unusable.
+  for (const method of rpcMethodNames.filter((name) => !name.startsWith('hosts.'))) {
+    assert.equal(isLocalOnly(method), false, `${method} has to be answerable by a host`)
+  }
+})

--- a/src/core/hosts/pool.ts
+++ b/src/core/hosts/pool.ts
@@ -1,0 +1,310 @@
+/**
+ * One live connection per host, and the policy about when there is one.
+ *
+ * `ssh.ts` knows how to open a pipe to a machine. It has no opinion about
+ * *when*, and that turns out to be most of the difficulty: a connection is
+ * expensive to make, wasteful to keep, and certain to break at the least
+ * convenient moment. The rules are here, on their own, so they can be tested
+ * with a fake connection and no network.
+ *
+ * ## Connect late, hang up quietly
+ *
+ * Nothing connects when a host is added, or when the app starts. The first
+ * request opens the pipe, and ten idle minutes closes it - matching
+ * `ControlPersist`, so the multiplexing master and the daemon expire together
+ * rather than leaving one waiting for the other.
+ *
+ * "Idle" means no request has *finished* recently, not no request has started.
+ * A `reviews.diff` on a large repository can outlast a naive idle timer and be
+ * hung up on halfway through its own answer.
+ *
+ * The cost of connecting late is paid once and is small (spike S1: a warm
+ * `ControlMaster` channel makes it a process spawn). The cost of connecting
+ * eagerly is a laptop that wakes six SSH sessions on every login and a fan that
+ * comes on when nobody asked for anything, which is precisely the impression
+ * "always on, locally" was built to avoid.
+ *
+ * ## Backoff belongs to the host, not to the request
+ *
+ * A failed request fails. It is not retried - see the note in
+ * `core/rpc/stdio-client.ts`, which is the decision this file is built on top
+ * of. What backoff governs is how soon the *next* request is allowed to try
+ * again, so that a screen polling every fifteen seconds against a machine that
+ * is switched off does not spawn four `ssh` processes a minute for an hour.
+ *
+ * While a host is in backoff, requests fail immediately with `HOST_OFFLINE`
+ * rather than waiting for a connection that is not going to succeed. Fast is
+ * kinder than hopeful here: the UI can say "not reachable" now, and M4.5's
+ * banner has something to render.
+ *
+ * One deliberate exception: an explicit probe from the Hosts screen ignores the
+ * backoff, because a person pressing a button has information the timer does
+ * not - they just turned the machine on.
+ */
+import { connectOverSsh, type SshConnection } from './ssh.js'
+import { AppError } from '../../shared/errors.js'
+import type { RpcMethod, RpcParams, RpcResult } from '../../shared/rpc.js'
+
+/** Matches `ControlPersist=10m` in `ssh.ts`. Kept in step deliberately. */
+export const IDLE_TIMEOUT_MS = 10 * 60 * 1000
+
+/**
+ * How long to refuse after a failure, by consecutive failure count.
+ *
+ * Quick twice, because the common failure is a laptop that has not finished
+ * waking; then out of the way, because the second most common one is a machine
+ * that is off for the evening. The last value repeats forever.
+ */
+export const BACKOFF_MS = [0, 1_000, 5_000, 15_000, 60_000] as const
+
+export interface HostRoute {
+  /** The `hosts` row id. Identity within this install, not on the network. */
+  id: number
+  kind: 'ssh'
+  target: string
+}
+
+export interface HostState {
+  connected: boolean
+  /** Consecutive failures; zero once anything succeeds. */
+  failures: number
+  /** Why the last attempt failed, for a screen to show. */
+  lastError?: string
+  /** Epoch ms before which requests fail fast. */
+  retryAfter?: number
+}
+
+export interface HostPoolOptions {
+  /** Swappable for tests; the default opens a real `ssh`. */
+  connect?: (route: HostRoute, onClose: (error: AppError) => void) => SshConnection
+  now?: () => number
+  /** Notified whenever a host's reachability changes. M4.5 renders this. */
+  onStateChange?: (hostId: number, state: HostState) => void
+}
+
+interface Entry {
+  connection: SshConnection | null
+  state: HostState
+  idleTimer: NodeJS.Timeout | null
+  inFlight: number
+}
+
+export interface HostPool {
+  /** Ask a host something, connecting first if needed. */
+  request<M extends RpcMethod>(
+    route: HostRoute,
+    method: M,
+    params?: RpcParams<M>
+  ): Promise<RpcResult<M>>
+  /**
+   * Reach a host on purpose, ignoring backoff, and report what happened.
+   * Never throws: "unreachable, and here is why" is the answer, not a failure.
+   */
+  probe(route: HostRoute): Promise<HostState>
+  state(hostId: number): HostState
+  /** Hang up on one host, or on all of them when the app is quitting. */
+  disconnect(hostId: number): void
+  disconnectAll(): void
+}
+
+const OFFLINE = (message: string): AppError => new AppError('HOST_OFFLINE', message)
+
+export function createHostPool({
+  connect = defaultConnect,
+  now = Date.now,
+  onStateChange
+}: HostPoolOptions = {}): HostPool {
+  const entries = new Map<number, Entry>()
+
+  const entryFor = (hostId: number): Entry => {
+    const existing = entries.get(hostId)
+    if (existing) return existing
+    const created: Entry = {
+      connection: null,
+      state: { connected: false, failures: 0 },
+      idleTimer: null,
+      inFlight: 0
+    }
+    entries.set(hostId, created)
+    return created
+  }
+
+  const publish = (hostId: number, entry: Entry): void => {
+    onStateChange?.(hostId, { ...entry.state })
+  }
+
+  const clearIdle = (entry: Entry): void => {
+    if (entry.idleTimer) {
+      clearTimeout(entry.idleTimer)
+      entry.idleTimer = null
+    }
+  }
+
+  /**
+   * Start the idle clock, if nothing is in flight.
+   *
+   * Called when a request settles rather than when one starts, so a long answer
+   * cannot be hung up on while it is still being computed.
+   */
+  const armIdle = (hostId: number, entry: Entry): void => {
+    clearIdle(entry)
+    if (entry.inFlight > 0 || !entry.connection) return
+    entry.idleTimer = setTimeout(() => {
+      entry.idleTimer = null
+      if (entry.inFlight === 0) closeEntry(hostId, entry)
+    }, IDLE_TIMEOUT_MS)
+    // Node keeps the process alive for a pending timer; an idle host must not
+    // be the reason a CLI refuses to exit.
+    entry.idleTimer.unref?.()
+  }
+
+  const closeEntry = (hostId: number, entry: Entry): void => {
+    clearIdle(entry)
+    const connection = entry.connection
+    entry.connection = null
+    if (entry.state.connected) {
+      entry.state = { ...entry.state, connected: false }
+      publish(hostId, entry)
+    }
+    connection?.close()
+  }
+
+  /** A failure moves the host along the backoff ladder. */
+  const recordFailure = (hostId: number, entry: Entry, message: string): void => {
+    const failures = entry.state.failures + 1
+    // The last rung repeats forever; `?? 0` is unreachable and is there because
+    // a tuple index is not something the compiler can prove is in range.
+    const wait = BACKOFF_MS[Math.min(failures - 1, BACKOFF_MS.length - 1)] ?? 0
+    entry.state = {
+      connected: false,
+      failures,
+      lastError: message,
+      ...(wait > 0 ? { retryAfter: now() + wait } : {})
+    }
+    entry.connection = null
+    clearIdle(entry)
+    publish(hostId, entry)
+  }
+
+  const recordSuccess = (hostId: number, entry: Entry): void => {
+    if (entry.state.connected && entry.state.failures === 0) return
+    entry.state = { connected: true, failures: 0 }
+    publish(hostId, entry)
+  }
+
+  /**
+   * The connection for a host, opening one if there is none.
+   *
+   * `ignoreBackoff` is the probe's escape hatch; every ordinary request
+   * respects the timer.
+   */
+  const connectionFor = (route: HostRoute, ignoreBackoff: boolean): SshConnection => {
+    const entry = entryFor(route.id)
+
+    if (entry.connection && !entry.connection.isOpen()) {
+      entry.connection = null
+    }
+
+    if (!entry.connection) {
+      const { retryAfter } = entry.state
+      if (!ignoreBackoff && retryAfter !== undefined && now() < retryAfter) {
+        throw OFFLINE(entry.state.lastError ?? `${route.target} is not reachable.`)
+      }
+
+      entry.connection = connect(route, (error) => {
+        // The pipe died. Whether that is a failure depends on whether anything
+        // was expecting it: a connection closed by the idle timer has already
+        // been forgotten here, and must not push the host onto the backoff
+        // ladder as though the machine had gone away.
+        const current = entries.get(route.id)
+        if (!current || current.connection === null) return
+        recordFailure(route.id, current, error.message)
+      })
+    }
+
+    return entry.connection
+  }
+
+  const send = async <M extends RpcMethod>(
+    route: HostRoute,
+    method: M,
+    params: RpcParams<M> | undefined,
+    ignoreBackoff: boolean
+  ): Promise<RpcResult<M>> => {
+    const entry = entryFor(route.id)
+    const connection = connectionFor(route, ignoreBackoff)
+
+    entry.inFlight += 1
+    try {
+      const result = await connection.request(method, params)
+      recordSuccess(route.id, entry)
+      return result
+    } catch (error) {
+      const appError = AppError.from(error)
+      // Only a transport failure says anything about the host. A `NOT_FOUND`
+      // travelled the wire perfectly and is the host working correctly, so it
+      // must not mark the machine unreachable or start a backoff.
+      if (appError.code === 'HOST_OFFLINE') {
+        // Awaited, because the useful half of the explanation - the exit status
+        // and what `ssh` printed - lands a moment after the stream ended. See
+        // `diagnostics` in `ssh.ts`.
+        const detail = await connection.diagnostics()
+        recordFailure(route.id, entry, detail || appError.message)
+        throw OFFLINE(detail || appError.message)
+      }
+      recordSuccess(route.id, entry)
+      throw appError
+    } finally {
+      entry.inFlight -= 1
+      armIdle(route.id, entry)
+    }
+  }
+
+  return {
+    request(route, method, params) {
+      return send(route, method, params, false)
+    },
+
+    async probe(route) {
+      try {
+        // `repositories.list` is the cheapest method that proves the whole
+        // stack: `ssh` authenticated, the launcher exists, Node started, SQLite
+        // opened and migrated, and the protocol answered. A dedicated `ping`
+        // would prove strictly less.
+        await send(route, 'repositories.list', undefined, true)
+      } catch {
+        // Swallowed on purpose: the state carries the reason, and a probe that
+        // threw would make "is this host up?" a question with an exception for
+        // an answer.
+      }
+      return this.state(route.id)
+    },
+
+    state(hostId) {
+      return { ...entryFor(hostId).state }
+    },
+
+    disconnect(hostId) {
+      const entry = entries.get(hostId)
+      if (entry) closeEntry(hostId, entry)
+    },
+
+    disconnectAll() {
+      for (const [hostId, entry] of entries) closeEntry(hostId, entry)
+    }
+  }
+}
+
+function defaultConnect(route: HostRoute, onClose: (error: AppError) => void): SshConnection {
+  return connectOverSsh({ target: route.target, onClose })
+}
+
+/**
+ * The pool the application uses.
+ *
+ * A module-level singleton for the same reason the database client is one: a
+ * second pool would mean a second set of `ssh` processes to the same machines,
+ * and nothing above it has any reason to want that. Tests build their own with
+ * `createHostPool`.
+ */
+export const hostPool = createHostPool()

--- a/src/core/hosts/ssh.ts
+++ b/src/core/hosts/ssh.ts
@@ -1,0 +1,287 @@
+/**
+ * `ssh`, as a way of starting a daemon and talking to it.
+ *
+ * The whole of M4's novelty, in one small file, because everything else was
+ * already built to accept it: the protocol is `shared/rpc.ts`, the framing is
+ * `core/rpc/ndjson.ts`, the asking side is `core/rpc/stdio-client.ts`, and what
+ * answers on the far end is the same `gitwarren serve --stdio` the daemon has
+ * run since M2. This module contributes a child process and an argument vector.
+ *
+ * ## The command, and why each part of it is there
+ *
+ *   ssh -o BatchMode=yes -o ControlMaster=auto -o ControlPersist=10m \
+ *       -o ServerAliveInterval=15 -o ServerAliveCountMax=3 \
+ *       <target> ~/.gitwarren/bin/gitwarren serve --stdio
+ *
+ * `BatchMode=yes` is the one that turns a hang into an error. Without it `ssh`
+ * will happily sit at a passphrase or a host-key prompt on a stdin that is
+ * carrying JSON and no human, and the GUI waits forever with a spinner. With
+ * it, an unauthenticated host fails in a second and the Hosts screen can say
+ * what went wrong. Key management is the person's own, through their SSH agent
+ * and config; GitWarren never asks for a password and has nowhere to keep one.
+ *
+ * `ControlMaster=auto` with `ControlPersist=10m` is what makes the *second*
+ * connection cheap. The first pays a TCP handshake and a key exchange; every
+ * one after it multiplexes onto the same channel, so a reconnect after a blip -
+ * or a probe from the Hosts screen while a review is open - costs a process
+ * spawn rather than a round of crypto.
+ *
+ * `ServerAliveInterval` is the half that makes a *dead* connection detectable.
+ * A dropped network with no keepalive leaves `ssh` waiting on a socket the
+ * kernel has no reason to give up on, which is the "content is stale and
+ * nothing says so" failure M4.5 exists to prevent. Three misses at fifteen
+ * seconds means a hung host is known within a minute.
+ *
+ * The remote command is the *launcher path*, not the versioned directory, for
+ * the reason M2 established: agent configs and this carrier both point at
+ * `~/.gitwarren/bin/gitwarren`, so an upgrade replaces what it resolves to and
+ * nothing that referenced it has to be rewritten. `$HOME` is spelled `~` and
+ * expanded by the remote shell, because the local process has no idea what the
+ * remote home directory is.
+ *
+ * ## What this module refuses to do
+ *
+ * It does not install anything (M4.2 does, and until then a host without the
+ * daemon fails with a message saying so), it does not authenticate (`ssh` did
+ * that before we saw a byte), and it does not decide what any method means.
+ *
+ * The one rule it enforces itself is that a `hosts.*` method is never sent. A
+ * host list is a property of the install a person is sitting at: forwarding it
+ * would make host A's list of hosts readable - and writable - from host B, and
+ * turn a hub-and-spoke arrangement into a mesh nobody asked for. The routing
+ * layer in M4.3 is what will decide local-versus-remote in general; this is the
+ * backstop that makes the rule structural rather than a comment, and it lives
+ * here because a carrier is the last thing a request passes before it leaves
+ * the machine.
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { createStdioClient, type StdioClient } from '../rpc/stdio-client.js'
+import { AppError } from '../../shared/errors.js'
+import type { RpcMethod, RpcParams, RpcResult } from '../../shared/rpc.js'
+
+/** The launcher M2 promised would stay put. */
+export const REMOTE_LAUNCHER = '~/.gitwarren/bin/gitwarren'
+
+/**
+ * Options given to `ssh` on every connection.
+ *
+ * A list rather than a template so that a test can assert on it, and so that
+ * the reasoning above has something to point at. Deliberately no `-T`: the
+ * remote command makes this non-interactive already, and no `StrictHostKeyChecking`
+ * override, because silently accepting an unknown host key is a decision that
+ * belongs to the person, in their own SSH config, not to a review tool.
+ */
+export const SSH_OPTIONS = [
+  '-o',
+  'BatchMode=yes',
+  '-o',
+  'ControlMaster=auto',
+  '-o',
+  'ControlPersist=10m',
+  '-o',
+  'ServerAliveInterval=15',
+  '-o',
+  'ServerAliveCountMax=3'
+] as const
+
+export function sshArgs(target: string): string[] {
+  return [...SSH_OPTIONS, target, REMOTE_LAUNCHER, 'serve', '--stdio']
+}
+
+/**
+ * How much of the host's stderr to keep.
+ *
+ * `ssh` says why it failed on stderr and then exits, so by the time anyone can
+ * ask, the only evidence is what was captured while it ran. Bounded because a
+ * daemon in a crash loop can produce a great deal of it, and this is held in
+ * memory for the lifetime of a connection.
+ */
+const MAX_STDERR_BYTES = 8 * 1024
+
+/**
+ * How long to wait for `ssh` to exit before giving up on a better explanation.
+ *
+ * See `diagnostics` below. The wait only ever happens on a connection that has
+ * already failed, and `ssh` exits within milliseconds of closing its streams,
+ * so this is a bound on a pathological case rather than a delay anyone waits
+ * for in practice.
+ */
+const EXIT_GRACE_MS = 500
+
+export interface SshConnection {
+  request<M extends RpcMethod>(method: M, params?: RpcParams<M>): Promise<RpcResult<M>>
+  close(): void
+  isOpen(): boolean
+  /**
+   * The best available explanation of why this connection is no longer working.
+   *
+   * A promise, and that is the whole point of it. The protocol notices a dead
+   * connection when the far end's *stdout* ends, which for a failing `ssh`
+   * happens a moment before the `exit` event that carries the status code and
+   * after which stderr is complete. Reading the reason synchronously at the
+   * instant a request fails therefore gets "the connection closed" - true,
+   * useless, and the message a person would otherwise see for a hostname that
+   * does not resolve.
+   *
+   * So this waits for the exit that is already on its way, briefly, and answers
+   * with what `ssh` actually said.
+   */
+  diagnostics(): Promise<string>
+}
+
+export interface SpawnSshOptions {
+  target: string
+  /** Swappable so the tests can run a fake host without an `ssh` on the box. */
+  spawnProcess?: typeof spawn
+  onClose?: (error: AppError) => void
+}
+
+/**
+ * Start `gitwarren serve --stdio` on `target` and return a way to talk to it.
+ *
+ * Returns as soon as the process is spawned rather than waiting for the far end
+ * to prove itself. There is nothing useful to wait *for*: the daemon announces
+ * itself on stderr, not on the protocol, and a handshake would be one more
+ * round trip before the first real request could go out. If the host is
+ * unreachable the first `request` fails, which is the same thing a caller has
+ * to handle anyway.
+ */
+export function connectOverSsh({
+  target,
+  spawnProcess = spawn,
+  onClose
+}: SpawnSshOptions): SshConnection {
+  let child: ChildProcessWithoutNullStreams
+  try {
+    child = spawnProcess('ssh', sshArgs(target), {
+      // stdin and stdout are the protocol; stderr is diagnostics and must never
+      // be merged into it - that is exactly the mistake `stdio-client.ts`
+      // reports as "the host sent something that is not part of the protocol".
+      stdio: ['pipe', 'pipe', 'pipe'],
+      // No shell. `target` comes from a form, and a shell here would make a
+      // host label an injection point on the local machine.
+      shell: false,
+      windowsHide: true
+    })
+  } catch (error) {
+    throw new AppError(
+      'HOST_OFFLINE',
+      `Could not start ssh: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+
+  let stderr = ''
+  child.stderr.setEncoding('utf8')
+  child.stderr.on('data', (chunk: string) => {
+    // Newest kept, oldest dropped: the last thing said before a failure is the
+    // one that explains it.
+    stderr = (stderr + chunk).slice(-MAX_STDERR_BYTES)
+  })
+
+  let closeError: AppError | null = null
+
+  const client: StdioClient = createStdioClient({
+    input: child.stdout,
+    output: child.stdin,
+    onClose: (error) => {
+      closeError = error
+      onClose?.(error)
+    }
+  })
+
+  // A spawn that fails asynchronously - no `ssh` on this machine at all -
+  // arrives here rather than as a throw above.
+  child.on('error', (error: Error) => {
+    stderr = `${stderr}\n${error.message}`.slice(-MAX_STDERR_BYTES)
+    client.close(`Could not run ssh: ${error.message}`)
+  })
+
+  let exitReason: string | null = null
+  const exited: Promise<void> = new Promise((resolve) => {
+    child.on('exit', (code, signal) => {
+      // The far end going away has already been noticed by the client, through
+      // the end of stdout. What arrives here is the part that says *why*, and
+      // it is what `diagnostics` waits for.
+      exitReason = describeExit(target, code, signal, stderr)
+      client.close(exitReason)
+      resolve()
+    })
+  })
+
+  return {
+    request(method, params) {
+      if (isLocalOnly(method)) {
+        return Promise.reject(
+          new AppError(
+            'INVALID_INPUT',
+            `"${method}" is answered by this machine and is never sent to a host.`
+          )
+        )
+      }
+      return client.request(method, params)
+    },
+    close() {
+      client.close('The connection to the host was closed.')
+      // `ssh` exits when its stdin closes and the remote command ends. The kill
+      // is the backstop for one that does not, and `SIGTERM` rather than
+      // `SIGKILL` so the multiplexing master gets to tidy up its socket.
+      child.stdin.end()
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM')
+    },
+    isOpen() {
+      return client.isOpen()
+    },
+    async diagnostics() {
+      if (exitReason === null && child.exitCode === null && child.signalCode === null) {
+        // Still running, or exiting right now. Wait for the status, but never
+        // hang a screen on a child that refuses to die.
+        await Promise.race([
+          exited,
+          new Promise<void>((resolve) => setTimeout(resolve, EXIT_GRACE_MS).unref?.())
+        ])
+      }
+      // `describeExit` has already folded the last of stderr into its message,
+      // so preferring it avoids saying the same thing twice.
+      return (exitReason ?? closeError?.message ?? stderr).trim()
+    }
+  }
+}
+
+/**
+ * Methods this install answers for itself, whatever host is being looked at.
+ *
+ * See the note at the top of the file. A prefix rather than a list of names, so
+ * that adding `hosts.rename` tomorrow cannot accidentally become forwardable.
+ */
+export function isLocalOnly(method: string): boolean {
+  return method.startsWith('hosts.')
+}
+
+/**
+ * Turn an exit status into something worth putting on a screen.
+ *
+ * `ssh` has one exit code for "everything that went wrong on my side" (255) and
+ * otherwise passes through the remote command's, so 127 really does mean the
+ * launcher is not there - which before M4.2 is the single most likely outcome
+ * of adding a host, and deserves to say what to do about it rather than
+ * "exited with code 127".
+ */
+function describeExit(
+  target: string,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stderr: string
+): string {
+  const tail = stderr.trim().split('\n').slice(-3).join(' ').trim()
+  const detail = tail ? ` ${tail}` : ''
+
+  if (code === 127) {
+    return (
+      `GitWarren is not installed on ${target}: ${REMOTE_LAUNCHER} was not found.` +
+      ' Install the daemon on the host and try again.'
+    )
+  }
+  if (code === 255) return `ssh could not connect to ${target}.${detail}`
+  if (signal) return `The connection to ${target} was terminated (${signal}).${detail}`
+  return `The connection to ${target} ended (exit ${code ?? 'unknown'}).${detail}`
+}

--- a/src/core/rpc/__tests__/dispatcher.test.ts
+++ b/src/core/rpc/__tests__/dispatcher.test.ts
@@ -52,6 +52,7 @@ process.env.GITWARREN_DATA_DIR = dataDir
 
 const { dispatch, handleRequest, isRpcMethod, rpcMethodNames } = await import('../dispatcher.js')
 const { serveStdio } = await import('../stdio.js')
+const { createStdioClient } = await import('../stdio-client.js')
 const { READ_METHODS, resultOf } = await import('../../../shared/rpc.js')
 const { getDatabase, closeDatabase } = await import('../../db/client.js')
 const { comments, commentThreads, repositories, reviewedFiles, reviews } = await import(
@@ -66,7 +67,17 @@ const { AppError } = await import('../../../shared/errors.js')
 interface Carrier {
   name: string
   call<M extends RpcMethod>(method: M, params?: RpcParams<M>): Promise<RpcResult<M>>
-  send(request: RpcRequest): Promise<RpcResponse>
+  /**
+   * The raw message door, for the tests that are about response envelopes
+   * themselves - that an id comes back, that a failure is a message.
+   *
+   * Optional since M4. A carrier built on `rpc/stdio-client.ts` assigns its own
+   * ids and unwraps its own outcomes, so it has no way to ask a question under
+   * a chosen id or to see a response before it becomes a value or a throw. A
+   * `send` faked on top of it would echo back the id the test passed in and
+   * assert nothing at all, which is worse than not running.
+   */
+  send?(request: RpcRequest): Promise<RpcResponse>
 }
 
 const inProcess: Carrier = {
@@ -127,6 +138,35 @@ function stdioCarrier(): Carrier {
         (await send({ id: nextId++, method, params })) as RpcResponse<RpcResult<M>>
       )
     }
+  }
+}
+
+/**
+ * The pair M4 actually ships: `rpc/stdio-client.ts` asking, `rpc/stdio.ts`
+ * answering, with nothing hand-rolled in between.
+ *
+ * The carrier above proves the *protocol* by writing frames itself. This one
+ * proves the *code that will be doing the writing* on every remote host from
+ * M4 onward - and it is the whole reason the client was worth extracting from
+ * the test's private reader: the thing under test is now the thing that ships.
+ *
+ * `ssh` is deliberately not in the picture. What it contributes is a child
+ * process and an argument vector (`core/hosts/ssh.ts`), and the streams it
+ * hands over behave like these two: spike S1 confirmed that against the real
+ * `pc-wsl` node, and the pipe itself was measured byte-exact in S2. Running the
+ * whole contract over a network here would trade forty fast tests for forty
+ * slow ones and one more thing to be flaky.
+ */
+function clientCarrier(): Carrier {
+  const toDaemon = new PassThrough()
+  const fromDaemon = new PassThrough()
+
+  serveStdio({ input: toDaemon, output: fromDaemon })
+  const client = createStdioClient({ input: fromDaemon, output: toDaemon })
+
+  return {
+    name: 'over stdio, through the client',
+    call: (method, params) => client.request(method, params)
   }
 }
 
@@ -280,26 +320,30 @@ function contract(carrier: Carrier): void {
     assert.equal(thread.comments[0]?.author.name, 'Human')
   })
 
-  test(`[${carrier.name}] handleRequest returns the answer under the id it was asked with`, async () => {
-    const response = await carrier.send({ id: 7, method: 'reviews.get', params: { id: reviewId } })
+  // The response envelope itself, which only a carrier holding raw messages can
+  // observe. See the note on `send` above.
+  const envelope = carrier.send?.bind(carrier)
+
+  test(`[${carrier.name}] handleRequest returns the answer under the id it was asked with`, { skip: !envelope }, async () => {
+    const response = await envelope!({ id: 7, method: 'reviews.get', params: { id: reviewId } })
 
     assert.equal(response.id, 7)
     assert.ok('result' in response)
     assert.equal((response.result as { id: number }).id, reviewId)
   })
 
-  test(`[${carrier.name}] handleRequest turns a failure into a message rather than a throw`, async () => {
+  test(`[${carrier.name}] handleRequest turns a failure into a message rather than a throw`, { skip: !envelope }, async () => {
     // A carrier holding a byte stream has nowhere to put an exception, so this
     // has to come back as a response no matter what went wrong.
-    const response = await carrier.send({ id: 8, method: 'reviews.get', params: { id: 999_999 } })
+    const response = await envelope!({ id: 8, method: 'reviews.get', params: { id: 999_999 } })
 
     assert.equal(response.id, 8)
     assert.ok('error' in response)
     assert.equal(response.error.code, 'NOT_FOUND')
   })
 
-  test(`[${carrier.name}] field errors survive the trip, so a form can still put them under an input`, async () => {
-    const response = await carrier.send({
+  test(`[${carrier.name}] field errors survive the trip, so a form can still put them under an input`, { skip: !envelope }, async () => {
+    const response = await envelope!({
       id: 9,
       method: 'reviews.create',
       params: { repositoryId, baseRef: 'main', headRef: 'no-such-branch' }
@@ -312,8 +356,8 @@ function contract(carrier: Carrier): void {
     ])
   })
 
-  test(`[${carrier.name}] an unknown method comes back as a response too`, async () => {
-    const response = await carrier.send({ id: 10, method: 'nope.nope' as RpcMethod })
+  test(`[${carrier.name}] an unknown method comes back as a response too`, { skip: !envelope }, async () => {
+    const response = await envelope!({ id: 10, method: 'nope.nope' as RpcMethod })
 
     assert.ok('error' in response)
     assert.equal(response.error.code, 'INVALID_INPUT')
@@ -413,4 +457,4 @@ function contract(carrier: Carrier): void {
 
 }
 
-for (const carrier of [inProcess, stdioCarrier()]) contract(carrier)
+for (const carrier of [inProcess, stdioCarrier(), clientCarrier()]) contract(carrier)

--- a/src/core/rpc/__tests__/stdio-client.test.ts
+++ b/src/core/rpc/__tests__/stdio-client.test.ts
@@ -1,0 +1,235 @@
+/**
+ * What the client does when the far end misbehaves.
+ *
+ * The happy path is not here. `dispatcher.test.ts` runs the entire protocol
+ * contract through this client against the real `serveStdio`, which is a far
+ * better test of "does it work" than anything in this file - and leaves this
+ * one free to be only about the cases a working daemon never produces.
+ *
+ * Those cases are the reason M4 is harder than M1. A function call cannot
+ * half-answer, and Electron IPC cannot lose a reply; a pipe to another machine
+ * does both, and every one of these behaviours is something a screen will
+ * eventually be showing a person.
+ *
+ * The far end here is a `PassThrough` a test writes to by hand, because that is
+ * the only way to produce a daemon that answers out of order, replies twice,
+ * emits a login banner, or dies mid-request. A real one, correctly, will not.
+ */
+import assert from 'node:assert/strict'
+import { PassThrough } from 'node:stream'
+import { test } from 'node:test'
+
+import { createStdioClient } from '../stdio-client.js'
+import { AppError } from '../../../shared/errors.js'
+import type { RpcRequest } from '../../../shared/rpc.js'
+
+/**
+ * A client wired to two streams a test controls.
+ *
+ * `sent` collects the frames the client wrote, already parsed, so an assertion
+ * can be about the request rather than about a string.
+ */
+function harness(): {
+  client: ReturnType<typeof createStdioClient>
+  sent: RpcRequest[]
+  reply: (line: string) => void
+  endStream: () => void
+  closes: AppError[]
+} {
+  const toHost = new PassThrough()
+  const fromHost = new PassThrough()
+  const sent: RpcRequest[] = []
+  const closes: AppError[] = []
+
+  toHost.setEncoding('utf8')
+  toHost.on('data', (chunk: string) => {
+    for (const line of chunk.split('\n')) {
+      if (line.trim()) sent.push(JSON.parse(line) as RpcRequest)
+    }
+  })
+
+  const client = createStdioClient({
+    input: fromHost,
+    output: toHost,
+    onClose: (error) => closes.push(error)
+  })
+
+  return {
+    client,
+    sent,
+    reply: (line: string) => fromHost.write(`${line}\n`),
+    endStream: () => fromHost.end(),
+    closes
+  }
+}
+
+/** Let the stream's 'data' event run before asserting on what it produced. */
+const settle = (): Promise<void> => new Promise((resolve) => setImmediate(resolve))
+
+test('answers are matched by id, not by the order they arrive in', async () => {
+  const { client, sent, reply } = harness()
+
+  const first = client.request('repositories.list')
+  const second = client.request('reviews.list', {})
+  await settle()
+
+  assert.equal(sent.length, 2)
+  const [a, b] = sent as [RpcRequest, RpcRequest]
+  assert.notEqual(a.id, b.id)
+
+  // Backwards, which is exactly what the daemon does when the second question
+  // is cheaper than the first - and what a FIFO client would deadlock on.
+  reply(JSON.stringify({ id: b.id, result: ['second'] }))
+  reply(JSON.stringify({ id: a.id, result: ['first'] }))
+
+  assert.deepEqual(await first, ['first'])
+  assert.deepEqual(await second, ['second'])
+})
+
+test('an error from the far end arrives as the AppError it was raised as', async () => {
+  const { client, sent, reply } = harness()
+
+  const pending = client.request('reviews.get', { id: 4 })
+  await settle()
+
+  reply(
+    JSON.stringify({
+      id: sent[0]?.id,
+      error: {
+        code: 'INVALID_INPUT',
+        message: 'No such branch.',
+        fieldErrors: { headRef: ['No such branch, tag or commit: nope'] }
+      }
+    })
+  )
+
+  const error = await pending.then(
+    () => null,
+    (thrown: unknown) => thrown as AppError
+  )
+
+  // Code, message and field errors all the way across, so a form on this side
+  // can still put the message under the right input.
+  assert.ok(error instanceof AppError)
+  assert.equal(error.code, 'INVALID_INPUT')
+  assert.deepEqual(error.fieldErrors?.headRef, ['No such branch, tag or commit: nope'])
+})
+
+test('a request in flight when the connection dies fails as HOST_OFFLINE', async () => {
+  const { client, endStream, closes } = harness()
+
+  const pending = client.request('repositories.list')
+  await settle()
+  endStream()
+
+  const error = await pending.then(
+    () => null,
+    (thrown: unknown) => thrown as AppError
+  )
+
+  assert.ok(error instanceof AppError)
+  assert.equal(error.code, 'HOST_OFFLINE')
+  // Reported once, and to the owner, so a pool can decide about reconnecting.
+  assert.equal(closes.length, 1)
+  assert.equal(closes[0]?.code, 'HOST_OFFLINE')
+})
+
+test('a lost request is not resent when the connection returns', async () => {
+  // The decision this whole file exists to protect: a write that died in flight
+  // may or may not have been applied, and re-sending `comments.reply` after an
+  // answer nobody saw is a second comment on someone's review.
+  const { client, sent, endStream } = harness()
+
+  const pending = client.request('comments.reply', { threadId: 1, body: 'Once.' })
+  await settle()
+  assert.equal(sent.length, 1)
+
+  endStream()
+  await pending.catch(() => undefined)
+  await settle()
+
+  assert.equal(sent.length, 1, 'the request was sent exactly once')
+  assert.equal(client.isOpen(), false, 'and the client does not quietly carry on')
+})
+
+test('a request made after the connection died fails immediately', async () => {
+  const { client, endStream } = harness()
+  endStream()
+  await settle()
+
+  const error = await client.request('repositories.list').then(
+    () => null,
+    (thrown: unknown) => thrown as AppError
+  )
+
+  assert.ok(error instanceof AppError)
+  assert.equal(error.code, 'HOST_OFFLINE')
+})
+
+test('a login banner on stdout is reported as what it is', async () => {
+  // The single most likely misconfiguration of a real host: a `.bashrc` that
+  // echoes something on a non-interactive login. The stream is now unusable and
+  // the message has to send someone to their shell profile, not to a bug
+  // report.
+  const { client, reply } = harness()
+
+  const pending = client.request('repositories.list')
+  await settle()
+  reply('Welcome to Ubuntu 24.04 LTS')
+
+  const error = await pending.then(
+    () => null,
+    (thrown: unknown) => thrown as AppError
+  )
+
+  assert.ok(error instanceof AppError)
+  assert.equal(error.code, 'HOST_OFFLINE')
+  assert.match(error.message, /login script/i)
+})
+
+test('an answer to a question nobody asked is ignored rather than fatal', async () => {
+  const { client, sent, reply } = harness()
+
+  const pending = client.request('repositories.list')
+  await settle()
+
+  // A duplicate, or a very late reply. Neither is worth tearing down a
+  // connection that is otherwise working.
+  reply(JSON.stringify({ id: 9999, result: ['nobody asked'] }))
+  reply(JSON.stringify({ id: sent[0]?.id, result: ['the real answer'] }))
+
+  assert.deepEqual(await pending, ['the real answer'])
+  assert.equal(client.isOpen(), true)
+})
+
+test('blank lines between frames are not an error', async () => {
+  // `ssh` is happy to put a stray newline on the stream around a banner.
+  const { client, sent, reply } = harness()
+
+  const pending = client.request('repositories.list')
+  await settle()
+
+  reply('')
+  reply(JSON.stringify({ id: sent[0]?.id, result: [] }))
+
+  assert.deepEqual(await pending, [])
+})
+
+test('close rejects what is in flight and says so once', async () => {
+  const { client, closes } = harness()
+
+  const pending = client.request('repositories.list')
+  await settle()
+
+  client.close('Told to stop.')
+  client.close('Told again.')
+
+  const error = await pending.then(
+    () => null,
+    (thrown: unknown) => thrown as AppError
+  )
+
+  assert.equal(error?.code, 'HOST_OFFLINE')
+  assert.equal(error?.message, 'Told to stop.')
+  assert.equal(closes.length, 1, 'closing twice is not two events')
+})

--- a/src/core/rpc/dispatcher.ts
+++ b/src/core/rpc/dispatcher.ts
@@ -26,16 +26,21 @@
  * different piece of software. Shell capabilities live in `main/ipc.ts` and
  * never enter this map.
  */
+import { getInstanceId } from '../instance.js'
+import { APP_VERSION } from '../version.js'
 import { attachmentsService } from '../services/attachments.js'
 import { commentsService } from '../services/comments.js'
+import { hostsService } from '../services/hosts.js'
 import { repositoriesService } from '../services/repositories.js'
 import { reviewedFilesService } from '../services/reviewed-files.js'
 import { reviewsService } from '../services/reviews.js'
 import { traced } from '../trace.js'
 import { HUMAN_AUTHOR } from '../../shared/actors.js'
 import { AppError } from '../../shared/errors.js'
+import { RPC_PROTOCOL_VERSION } from '../../shared/rpc.js'
 import type {
   AttachmentIngestParams,
+  HostIdentity,
   ReviewOpen,
   RpcMethod,
   RpcParams,
@@ -114,13 +119,46 @@ function toIngestSource(params: unknown): { bytes: Buffer; originalName?: string
 }
 
 /**
+ * This install, as a host sees it.
+ *
+ * Synchronous: the instance id is a cached file read and the version is a
+ * build-time constant.
+ */
+function describeThisInstance(): HostIdentity {
+  return {
+    instanceId: getInstanceId(),
+    protocol: RPC_PROTOCOL_VERSION,
+    version: APP_VERSION
+  }
+}
+
+/**
  * The map. Every entry is a one-line delegation, and that thinness is the
  * point: validation, path resolution and error semantics live in the service,
  * so the GUI, the daemon and the MCP server cannot disagree about what a valid
  * review is. Each service re-parses its own input, so `params` is deliberately
  * `unknown` all the way down to it.
  */
-const handlers: { [M in RpcMethod]: (params: unknown) => Promise<RpcResult<M>> } = {
+const handlers: {
+  // Sync or async. `traced` has always accepted both, and better-sqlite3 is
+  // synchronous, so a service whose work is one indexed read is telling the
+  // truth by not being a promise - `hosts.list` and `app.instance` are the
+  // first two that had no reason to pretend otherwise.
+  [M in RpcMethod]: (params: unknown) => Promise<RpcResult<M>> | RpcResult<M>
+} = {
+  'app.instance': () => describeThisInstance(),
+
+  // Answered by whoever is asked, and never forwarded onward - see the note on
+  // these in `shared/rpc.ts`. They are in the map because a screen reaches the
+  // core through the dispatcher and nowhere else, which is what lets the Hosts
+  // screen work identically in the window and in a browser tab.
+  'hosts.list': () => hostsService.list(),
+  'hosts.get': (params) => hostsService.get(params),
+  'hosts.add': (params) => hostsService.add(params),
+  'hosts.update': (params) => hostsService.update(params),
+  'hosts.remove': (params) => hostsService.remove(params),
+  'hosts.probe': (params) => hostsService.probe(params),
+
   'repositories.list': () => repositoriesService.list(),
   'repositories.get': (params) => repositoriesService.get(params),
   'repositories.add': (params) => repositoriesService.add(params),

--- a/src/core/rpc/ndjson.ts
+++ b/src/core/rpc/ndjson.ts
@@ -1,0 +1,93 @@
+/**
+ * Newline-delimited JSON, as a reader.
+ *
+ * Extracted from `stdio.ts` at M4, when the protocol grew a second side. Until
+ * then only the daemon read frames; now the GUI reads them too - it is the one
+ * asking the questions over `ssh` - and two implementations of "where does a
+ * frame end" is exactly the kind of disagreement that produces a hang rather
+ * than an error. A hang on a pipe is the worst bug shape available: both ends
+ * are healthy, both are waiting, and nothing is logged.
+ *
+ * So the framing lives here, once, and `stdio.ts` (the server) and
+ * `stdio-client.ts` (the client) are both users of it. Neither may parse a
+ * stream itself.
+ *
+ * The rationale for newline-delimited rather than a length prefix is at the top
+ * of `stdio.ts`, where it belongs with the protocol it serves.
+ */
+
+/**
+ * How much of an unterminated line to hold before giving up.
+ *
+ * A frame is a request, and requests are tiny - with one exception. An image on
+ * its way into the attachment store travels as bytes, and 10 MB of them (the
+ * ingest limit) is about 14 MB once base64 has had them, or four times that if
+ * a caller sends the `number[]` form. 64 MB leaves room for the worst of those
+ * and still bounds what a peer that never sends a newline can make this process
+ * allocate.
+ */
+export const MAX_FRAME_BYTES = 64 * 1024 * 1024
+
+export interface FrameReaderOptions {
+  /** One complete frame, already trimmed and never empty. */
+  onFrame: (line: string) => void
+  /**
+   * A peer that sent `MAX_FRAME_BYTES` without a newline. The buffer has been
+   * dropped by the time this is called, so the reader is usable afterwards -
+   * whether it *should* be used again is the caller's decision, and the two
+   * sides answer it differently: a server refuses the frame and reads on, a
+   * client treats it as a broken connection.
+   */
+  onOverflow: (bytes: number) => void
+  /** The stream ended. Any trailing frame has already been delivered. */
+  onEnd?: () => void
+}
+
+/**
+ * Read `input` as frames.
+ *
+ * A chunk boundary falls wherever the OS put it and means nothing: everything
+ * up to the last newline is complete frames, and whatever follows it is the
+ * start of the next one and stays in the buffer.
+ *
+ * Blank lines are skipped rather than reported. A peer that pads its output, or
+ * a log being replayed by hand, should not produce an error - and on the client
+ * side this matters for a reason peculiar to `ssh`, which is happy to put a
+ * bare newline on the stream around a banner.
+ */
+export function readFrames(
+  input: NodeJS.ReadableStream,
+  { onFrame, onOverflow, onEnd }: FrameReaderOptions
+): void {
+  let buffer = ''
+
+  input.setEncoding('utf8')
+
+  input.on('data', (chunk: string) => {
+    buffer += chunk
+
+    if (buffer.length > MAX_FRAME_BYTES && !buffer.includes('\n')) {
+      const bytes = buffer.length
+      buffer = ''
+      onOverflow(bytes)
+      return
+    }
+
+    let newline = buffer.indexOf('\n')
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline).trim()
+      buffer = buffer.slice(newline + 1)
+      if (line) onFrame(line)
+      newline = buffer.indexOf('\n')
+    }
+  })
+
+  input.on('end', () => {
+    // A trailing frame with no newline after it. Honoured, because a peer that
+    // writes a message and closes the pipe has said a perfectly good thing.
+    const line = buffer.trim()
+    buffer = ''
+    if (line) onFrame(line)
+    onEnd?.()
+  })
+}

--- a/src/core/rpc/stdio-client.ts
+++ b/src/core/rpc/stdio-client.ts
@@ -1,0 +1,246 @@
+/**
+ * The protocol from the asking side of a pipe.
+ *
+ * `stdio.ts` has answered requests on a byte stream since M2. This is its
+ * mirror: it *makes* them. Nothing needed it until M4, because until M4 the
+ * process holding the questions and the process holding the answers were always
+ * the same one, or were joined by Electron IPC, which pairs a call with its
+ * answer itself.
+ *
+ * Deliberately ignorant of `ssh`. It is handed two streams and never learns how
+ * they were obtained, which is what lets M5 reuse it unchanged with `wsl.exe`
+ * in front - the difference between those two milestones is a child process and
+ * an argument vector, and none of that belongs in the protocol.
+ *
+ * ## The three things a pipe has that a function call does not
+ *
+ * **Answers come back in any order.** That is the property `id` exists for, and
+ * the server takes advantage of it: a slow `reviews.diff` does not hold up the
+ * cheap reads issued alongside it. So responses are matched through a map, and
+ * a client that assumed FIFO would deadlock the first time a screen opened.
+ *
+ * **The far end can vanish.** A laptop sleeps, a network drops, `ssh` exits.
+ * Every request in flight is rejected with `HOST_OFFLINE` and *none of them is
+ * retried* - see below, it is the most important decision in this file.
+ *
+ * **Nothing is authenticated here.** The stream is trusted because of how it
+ * was obtained: `ssh` authenticated the far end before this module saw a byte.
+ * A carrier that had to check identities would be a different design, and M6's
+ * WebSocket listener is where that question actually gets answered.
+ *
+ * ## Why a lost request is never retried
+ *
+ * When a connection dies mid-flight there are two possibilities and no way to
+ * tell them apart: the daemon never saw the request, or it did the work and the
+ * reply died on the way back. Retrying is safe in the first case and, for
+ * `comments.reply`, posts a second comment in the second.
+ *
+ * A carrier may not make that choice on the caller's behalf, so it makes the
+ * conservative one always: the request fails with `HOST_OFFLINE` and the person
+ * decides. Reconnection is about the *next* request, never about the lost ones.
+ * The web carrier settled this the same way at M3; the note is repeated here
+ * because this is where it would be most tempting to be clever.
+ */
+import { readFrames } from './ndjson.js'
+import { AppError } from '../../shared/errors.js'
+import {
+  isRpcEvent,
+  resultOf,
+  type RpcEvent,
+  type RpcMethod,
+  type RpcOutcome,
+  type RpcParams,
+  type RpcRequest,
+  type RpcResponse,
+  type RpcResult
+} from '../../shared/rpc.js'
+
+export interface StdioClientOptions {
+  /** The far end's stdout: responses and events. */
+  input: NodeJS.ReadableStream
+  /** The far end's stdin: requests. */
+  output: NodeJS.WritableStream
+  /**
+   * A push from the host. Nothing sends one before M6; the hook is here because
+   * a reader that could not tell an event from an answer would have to be
+   * rewritten to accept one, and this way the message simply arrives.
+   */
+  onEvent?: (event: RpcEvent) => void
+  /**
+   * The far end stopped answering, for any reason. Called once, after the
+   * pending requests have been rejected, so a pool can drop this connection and
+   * decide about reconnecting.
+   */
+  onClose?: (error: AppError) => void
+}
+
+export interface StdioClient {
+  /**
+   * Ask, and wait. Rejects with the `AppError` the far end reported, or with
+   * `HOST_OFFLINE` if the connection went away first.
+   */
+  request<M extends RpcMethod>(method: M, params?: RpcParams<M>): Promise<RpcResult<M>>
+  /** Stop, rejecting anything in flight. Idempotent. */
+  close(reason?: string): void
+  /** Whether this client still believes it can carry a request. */
+  isOpen(): boolean
+}
+
+interface Pending {
+  settle: (outcome: RpcOutcome) => void
+}
+
+/**
+ * Speak the protocol over a pair of streams.
+ *
+ * The returned client is single-connection: when the pipe dies it stays dead,
+ * `isOpen()` goes false and every later `request` fails immediately. Deciding
+ * to build another one is a policy question about a *host*, not about a stream,
+ * and it lives one level up in `core/hosts/pool.ts`. Keeping reconnection out
+ * of here is what makes this module testable with two in-memory streams and no
+ * timers at all.
+ */
+export function createStdioClient({
+  input,
+  output,
+  onEvent,
+  onClose
+}: StdioClientOptions): StdioClient {
+  const pending = new Map<number, Pending>()
+  let nextId = 1
+  let closed: AppError | null = null
+
+  /**
+   * Fail everything in flight and refuse everything after.
+   *
+   * Called for a dead stream, a peer that broke framing, and an explicit
+   * `close`, because from a caller's point of view those are the same event:
+   * the answer is not coming. The map is emptied before the callbacks run so
+   * that a `settle` which starts a new request cannot see a stale entry.
+   */
+  const shutdown = (error: AppError): void => {
+    if (closed) return
+    closed = error
+
+    const inFlight = [...pending.values()]
+    pending.clear()
+    for (const { settle } of inFlight) settle({ error: error.toSerialized() })
+
+    onClose?.(error)
+  }
+
+  const receive = (line: string): void => {
+    let message: unknown
+    try {
+      message = JSON.parse(line)
+    } catch {
+      // The far end is not speaking the protocol. Unlike the server, which can
+      // refuse one frame and read on, a client has no way to resynchronise: it
+      // does not know whether the garbage was a whole frame or the first half
+      // of one, so every id it is still waiting for is now in doubt.
+      //
+      // In practice this is the shape a misconfigured host takes - a shell
+      // profile that prints a banner on a non-interactive login, an `ssh`
+      // option that logs to stdout - so the message names that, because the
+      // literal complaint ("could not parse JSON") sends people to look at
+      // GitWarren rather than at their `.bashrc`.
+      shutdown(
+        new AppError(
+          'HOST_OFFLINE',
+          'The host sent something that is not part of the protocol. This is usually a login ' +
+            'script printing to stdout on the host; GitWarren needs that stream to itself.'
+        )
+      )
+      return
+    }
+
+    if (typeof message !== 'object' || message === null) return
+
+    if (isRpcEvent(message as RpcEvent)) {
+      onEvent?.(message as RpcEvent)
+      return
+    }
+
+    const { id, ...outcome } = message as RpcResponse
+    const waiting = pending.get(id)
+    // An answer to a request we are not waiting for. Dropped rather than
+    // treated as a fault: it is what a duplicated id or a very late reply after
+    // a timeout looks like, and neither is worth tearing a connection down for.
+    if (!waiting) return
+    pending.delete(id)
+    waiting.settle(outcome)
+  }
+
+  readFrames(input, {
+    onFrame: receive,
+    onOverflow: (bytes) => {
+      shutdown(
+        new AppError('HOST_OFFLINE', `The host sent ${bytes} bytes without completing a message.`)
+      )
+    },
+    onEnd: () => {
+      shutdown(new AppError('HOST_OFFLINE', 'The connection to the host closed.'))
+    }
+  })
+
+  // A pipe whose reader has gone is an `EPIPE` on the next write, which as an
+  // unhandled 'error' event would take the whole GUI down. It is the same
+  // event as `end` as far as anyone here is concerned.
+  input.on('error', (error: Error) => {
+    shutdown(new AppError('HOST_OFFLINE', `The connection to the host failed: ${error.message}`))
+  })
+  output.on('error', (error: Error) => {
+    shutdown(new AppError('HOST_OFFLINE', `The connection to the host failed: ${error.message}`))
+  })
+
+  return {
+    request<M extends RpcMethod>(method: M, params?: RpcParams<M>): Promise<RpcResult<M>> {
+      if (closed) return Promise.reject(closed)
+
+      const id = nextId++
+      const request: RpcRequest = { id, method, ...(params === undefined ? {} : { params }) }
+
+      return new Promise<RpcResult<M>>((resolve, reject) => {
+        pending.set(id, {
+          settle: (outcome) => {
+            // `resultOf` is the shared unwrapping every carrier uses, so a
+            // `NOT_FOUND` raised on a daemon over `ssh` reaches a React
+            // component as the same `AppError` a local call would have thrown -
+            // code, message and field errors intact.
+            try {
+              resolve(resultOf(outcome) as RpcResult<M>)
+            } catch (error) {
+              // `resultOf` throws the deserialised `AppError`; `AppError.from`
+              // is the guarantee that a rejection is always an `Error`, however
+              // odd the thing on the wire turned out to be.
+              reject(AppError.from(error))
+            }
+          }
+        })
+
+        try {
+          // One `write` per message: Node serialises writes on a stream, so two
+          // requests issued in the same tick cannot interleave halfway through
+          // a line.
+          output.write(`${JSON.stringify(request)}\n`)
+        } catch (error) {
+          pending.delete(id)
+          reject(
+            new AppError(
+              'HOST_OFFLINE',
+              `Could not send to the host: ${error instanceof Error ? error.message : String(error)}`
+            )
+          )
+        }
+      })
+    },
+
+    close(reason = 'The connection to the host was closed.') {
+      shutdown(new AppError('HOST_OFFLINE', reason))
+    },
+
+    isOpen() {
+      return closed === null
+    }
+  }
+}

--- a/src/core/rpc/stdio.ts
+++ b/src/core/rpc/stdio.ts
@@ -35,20 +35,9 @@
  * protocol, which is the failure this whole arrangement exists to prevent.
  */
 import { handleRequest } from './dispatcher.js'
+import { MAX_FRAME_BYTES, readFrames } from './ndjson.js'
 import { AppError } from '../../shared/errors.js'
 import type { RpcRequest, RpcResponse } from '../../shared/rpc.js'
-
-/**
- * How much of an unterminated line to hold before giving up.
- *
- * A frame is a request, and requests are tiny - with one exception. An image on
- * its way into the attachment store travels as bytes, and 10 MB of them (the
- * ingest limit) is about 14 MB once base64 has had them, or four times that if
- * a caller sends the `number[]` form. 64 MB leaves room for the worst of those
- * and still bounds what a peer that never sends a newline can make this process
- * allocate.
- */
-const MAX_FRAME_BYTES = 64 * 1024 * 1024
 
 /**
  * The id used when a frame is so malformed there is no id to answer under.
@@ -85,8 +74,6 @@ function asRequest(value: unknown): RpcRequest | null {
  * cope with out-of-order responses is a caller that is not using the protocol.
  */
 export function serveStdio({ input, output, onEnd }: StdioCarrierOptions): void {
-  let buffer = ''
-
   const write = (message: RpcResponse): void => {
     // One `write` per message rather than a stringify into a shared buffer:
     // Node serialises writes on a stream, so two responses finishing in the
@@ -126,37 +113,17 @@ export function serveStdio({ input, output, onEnd }: StdioCarrierOptions): void 
       })
   }
 
-  input.setEncoding('utf8')
-
-  input.on('data', (chunk: string) => {
-    buffer += chunk
-
-    if (buffer.length > MAX_FRAME_BYTES && !buffer.includes('\n')) {
+  // Framing is `ndjson.ts`, shared with the client half of the protocol so that
+  // the two ends cannot disagree about where a frame ends. What is left here is
+  // only what a *server* does with a frame once it has one.
+  readFrames(input, {
+    onFrame: answer,
+    // Refused rather than fatal, and the connection is kept: a peer that has
+    // mangled one frame is more likely to be a human poking at the pipe than a
+    // broken program, and hanging up would take the diagnosis away with it.
+    onOverflow: () => {
       refuse(NO_ID, `A frame exceeded ${MAX_FRAME_BYTES} bytes without a newline.`)
-      buffer = ''
-      return
-    }
-
-    // Everything up to the last newline is complete frames; whatever follows it
-    // is the start of the next one and stays in the buffer. A chunk boundary
-    // falls wherever the OS put it and means nothing.
-    let newline = buffer.indexOf('\n')
-    while (newline !== -1) {
-      const line = buffer.slice(0, newline).trim()
-      buffer = buffer.slice(newline + 1)
-      // Blank lines are skipped rather than refused: a peer that pads its
-      // output, or a file being replayed by hand, should not get an error back.
-      if (line) answer(line)
-      newline = buffer.indexOf('\n')
-    }
-  })
-
-  input.on('end', () => {
-    // A trailing frame with no newline after it. Honoured, because a peer that
-    // writes a request and closes the pipe has asked a perfectly good question.
-    const line = buffer.trim()
-    buffer = ''
-    if (line) answer(line)
-    onEnd?.()
+    },
+    onEnd: () => onEnd?.()
   })
 }

--- a/src/core/services/hosts.ts
+++ b/src/core/services/hosts.ts
@@ -1,0 +1,239 @@
+/**
+ * The host service: adding, listing and reaching other machines.
+ *
+ * Same contract as every other service - it re-parses its own input, it is the
+ * only implementation, and both surfaces call straight into it. What is
+ * different is that one of its reads is not from SQLite: reachability comes
+ * from the connection pool, live, and is never written down. A host that
+ * answered ten minutes ago is not a fact about now.
+ *
+ * ## Meeting a host
+ *
+ * A row is created from what someone typed, which is a *description* of a
+ * machine. It becomes a *known* machine on the first successful connect, when
+ * the host reports its instance id and that gets written back. Everything that
+ * follows - `repositories.host_id`, M6's discovery, deciding that two entries
+ * are the same box - keys off the instance id and not off the target, because
+ * an address is a way to reach a machine and not the machine.
+ *
+ * The write-back is where the second duplicate check happens, and it is the
+ * interesting one: two rows can be perfectly distinct as *descriptions*
+ * (`pc-wsl` and `xfor@100.78.0.23`) and turn out to name one machine. Nothing
+ * can see that until the machine says so, so the collision is detected on
+ * connect rather than in the form, and it is reported rather than merged -
+ * silently collapsing two rows would take a repository list with it.
+ *
+ * ## Why there is no `hosts.connect`
+ *
+ * Connecting is not something a person does; it is something that happens
+ * because they asked for a repository list. The pool decides when, and the only
+ * deliberate reach is `probe`, which exists so the Hosts screen can offer a
+ * button that says "try now" and mean it.
+ */
+import { asc, eq } from 'drizzle-orm'
+import { getDatabase } from '../db/client.js'
+import { hosts, type HostRow } from '../db/schema.js'
+import { hostPool, type HostRoute } from '../hosts/pool.js'
+import { AppError } from '../../shared/errors.js'
+import { parseWithSchema as parse } from '../../shared/validation.js'
+import {
+  addHostInputSchema,
+  getHostInputSchema,
+  removeHostInputSchema,
+  updateHostInputSchema,
+  type Host,
+  type HostWithState
+} from '../../shared/schemas.js'
+
+function toHost(row: HostRow): Host {
+  return {
+    id: row.id,
+    instanceId: row.instanceId,
+    label: row.label,
+    kind: row.kind,
+    target: row.target,
+    editorTarget: row.editorTarget,
+    lastSeenAt: row.lastSeenAt,
+    createdAt: row.createdAt
+  }
+}
+
+function withState(row: HostRow): HostWithState {
+  return { ...toHost(row), state: hostPool.state(row.id) }
+}
+
+export function routeFor(row: HostRow): HostRoute {
+  return { id: row.id, kind: row.kind, target: row.target }
+}
+
+function requireRow(id: number): HostRow {
+  const row = getDatabase().select().from(hosts).where(eq(hosts.id, id)).get()
+  if (!row) throw new AppError('NOT_FOUND', `No host with id ${id}.`)
+  return row
+}
+
+/**
+ * A sensible name for `xfor@pc-wsl`: "pc-wsl".
+ *
+ * The user part is how to log in, not what the machine is called, and a list of
+ * hosts every one of which begins with the same username is a list that has
+ * stopped distinguishing anything.
+ */
+function defaultLabelFor(target: string): string {
+  const withoutUser = target.includes('@') ? target.slice(target.indexOf('@') + 1) : target
+  return withoutUser || target
+}
+
+function asDuplicateError(error: unknown, target: string): AppError {
+  const code = (error as { code?: string } | null)?.code
+  if (typeof code === 'string' && code.startsWith('SQLITE_CONSTRAINT')) {
+    return new AppError('INVALID_INPUT', `That host is already in the list: ${target}`, {
+      target: ['This host is already in the list.']
+    })
+  }
+  return AppError.from(error)
+}
+
+/**
+ * Record that a host answered, and who it turned out to be.
+ *
+ * Called after a successful request rather than as part of connecting, because
+ * "the pipe opened" and "the daemon answered" are different claims and only the
+ * second one is worth writing down.
+ */
+function recordSeen(row: HostRow, instanceId: string | null): void {
+  const database = getDatabase()
+  const lastSeenAt = new Date().toISOString()
+
+  if (instanceId && instanceId !== row.instanceId) {
+    const other = database.select().from(hosts).where(eq(hosts.instanceId, instanceId)).get()
+    if (other && other.id !== row.id) {
+      throw new AppError(
+        'INVALID_INPUT',
+        `${row.target} is the same machine as "${other.label}" (${other.target}), which is ` +
+          'already in the list. Remove one of them.',
+        { target: ['This machine is already in the list under another name.'] }
+      )
+    }
+    database.update(hosts).set({ instanceId, lastSeenAt }).where(eq(hosts.id, row.id)).run()
+    return
+  }
+
+  database.update(hosts).set({ lastSeenAt }).where(eq(hosts.id, row.id)).run()
+}
+
+export const hostsService = {
+  /** Every host, each with its reachability read from the pool. */
+  list(): HostWithState[] {
+    const rows = getDatabase().select().from(hosts).orderBy(asc(hosts.label)).all()
+    return rows.map(withState)
+  },
+
+  get(input: unknown): HostWithState {
+    const { id } = parse(getHostInputSchema, input)
+    return withState(requireRow(id))
+  },
+
+  add(input: unknown): HostWithState {
+    const { target, label, kind = 'ssh', editorTarget } = parse(addHostInputSchema, input)
+
+    try {
+      const row = getDatabase()
+        .insert(hosts)
+        .values({
+          target,
+          kind,
+          label: label ?? defaultLabelFor(target),
+          // Null rather than a derived default: `ssh-remote+<target>` is what
+          // `shared/editors.ts` builds when this is absent, and storing the
+          // derivation would freeze it at the value it had on the day the host
+          // was added.
+          editorTarget: editorTarget ?? null
+        })
+        .returning()
+        .get()
+      return withState(row)
+    } catch (error) {
+      throw asDuplicateError(error, target)
+    }
+  },
+
+  update(input: unknown): HostWithState {
+    const { id, label, target, editorTarget } = parse(updateHostInputSchema, input)
+    const row = requireRow(id)
+
+    // Repointing at a different machine invalidates the identity we learned:
+    // the new address may be a different box entirely, and keeping the old
+    // instance id would let a repository row follow the address instead of the
+    // machine - which is the one thing the id exists to prevent.
+    const movedElsewhere = target !== undefined && target !== row.target
+
+    try {
+      const updated = getDatabase()
+        .update(hosts)
+        .set({
+          ...(label !== undefined ? { label } : {}),
+          ...(target !== undefined ? { target } : {}),
+          ...(editorTarget !== undefined ? { editorTarget } : {}),
+          ...(movedElsewhere ? { instanceId: null, lastSeenAt: null } : {})
+        })
+        .where(eq(hosts.id, id))
+        .returning()
+        .get()
+
+      if (movedElsewhere) hostPool.disconnect(id)
+      return withState(updated)
+    } catch (error) {
+      throw asDuplicateError(error, target ?? row.target)
+    }
+  },
+
+  /**
+   * Forget a host.
+   *
+   * The connection is dropped first so that an in-flight request cannot write
+   * `last_seen_at` back onto a row that is about to stop existing.
+   *
+   * Repositories on the host are deliberately *not* deleted here. That is M4.3's
+   * decision to make, once there are remote repositories to have an opinion
+   * about; leaving orphaned rows for one slice is better than writing a cascade
+   * now and having to unpick it.
+   */
+  remove(input: unknown): { id: number } {
+    const { id } = parse(removeHostInputSchema, input)
+    requireRow(id)
+    hostPool.disconnect(id)
+    getDatabase().delete(hosts).where(eq(hosts.id, id)).run()
+    return { id }
+  },
+
+  /**
+   * Reach a host on purpose and report what happened.
+   *
+   * Ignores backoff - a person pressing "try now" knows something the timer
+   * does not, usually that they have just switched the machine on. Never
+   * throws: an unreachable host is an answer, and `state.lastError` carries the
+   * reason for the screen to show.
+   */
+  async probe(input: unknown): Promise<HostWithState> {
+    const { id } = parse(getHostInputSchema, input)
+    const row = requireRow(id)
+
+    const state = await hostPool.probe(routeFor(row))
+    if (!state.connected) return { ...toHost(row), state }
+
+    // Reached. Ask who that was, and remember it.
+    let instanceId: string | null = null
+    try {
+      const info = await hostPool.request(routeFor(row), 'app.instance')
+      instanceId = info.instanceId
+    } catch {
+      // A host too old to answer `app.instance` is still a usable host; it just
+      // stays anonymous, and `instance_id` keeps saying "not met" - which is
+      // true in the only sense that matters here.
+    }
+
+    recordSeen(row, instanceId)
+    return withState(requireRow(id))
+  }
+}

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,0 +1,22 @@
+/**
+ * Which release this is, wherever it is running.
+ *
+ * The version is stamped in at build time as `__APP_VERSION__` rather than read
+ * from `package.json`, because by the time any of this is running there may not
+ * *be* a `package.json` next to it: the daemon tarball is a Node binary and two
+ * bundles, and the packaged app keeps its manifest inside an asar.
+ *
+ * `src/cli/router.ts` has done this since M3.3 for `gitwarren --version`. M4
+ * needs the same string one level down - `app.instance` reports it to whoever
+ * connected - and a second guarded `typeof` in a second file is how a constant
+ * quietly acquires two values.
+ *
+ * The guard is not decoration. Each bundle defines the constant separately, and
+ * an undefined identifier in a bundle that forgot to is a `ReferenceError` at
+ * module scope, which takes the whole process down rather than reporting an odd
+ * version. Falling back is the right failure: nothing branches on this string.
+ */
+declare const __APP_VERSION__: string
+
+export const APP_VERSION: string =
+  typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : '0.0.0-dev'

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -82,7 +82,11 @@ export function registerIpcHandlers(): void {
   // Every channel that existed before M1, still answering, now through the
   // dispatcher. The table lives in `shared/api.ts` next to the channel names.
   for (const [channel, method] of Object.entries(CHANNEL_METHODS)) {
-    handle(channel, (payload) => dispatch(method, payload as RpcParams<RpcMethod>))
+    // `RpcParams<typeof method>` rather than `RpcParams<RpcMethod>`: the table
+    // covers only the pre-M1 channels, so the params union here is the smaller
+    // one. Widening it to every method made this stop compiling the moment M4
+    // added a method no legacy channel maps to.
+    handle(channel, (payload) => dispatch(method, payload as RpcParams<typeof method>))
   }
 
   // ---------------------------------------------------------------------------

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -19,6 +19,22 @@ export const APP_ERROR_CODES = [
    */
   'FORBIDDEN',
   'GIT_UNAVAILABLE',
+  /**
+   * The host that owns this data could not be reached, or stopped answering
+   * while we were asking.
+   *
+   * The one code whose right response is usually to wait rather than to change
+   * anything, which is why it is not folded into `INTERNAL`: nothing is broken,
+   * a machine is asleep. It is also the only code a screen is allowed to keep
+   * showing stale content underneath - see the disconnection banner in M4.5 -
+   * because the alternative is blanking a review someone is reading over a
+   * thirty-second network blip.
+   *
+   * A request that fails this way was *not* necessarily un-answered: the daemon
+   * may have done the work and lost the reply on the way back. So a carrier
+   * never retries a write on it. See `core/rpc/stdio-client.ts`.
+   */
+  'HOST_OFFLINE',
   'INTERNAL'
 ] as const
 

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -21,8 +21,13 @@
 import { deserializeAppError, type SerializedAppError } from './errors.js'
 import type { FileContent, FileImage, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
 import type {
+  AddHostInput,
   AddRepositoryInput,
   Attachment,
+  GetHostInput,
+  HostWithState,
+  RemoveHostInput,
+  UpdateHostInput,
   Comment,
   CommentThread,
   CreateReviewInput,
@@ -62,6 +67,27 @@ import type {
  * having to invent one under time pressure.
  */
 export const RPC_PROTOCOL_VERSION = 1
+
+/**
+ * Who just answered.
+ *
+ * `instanceId` is the durable identity of the install (`core/instance.ts`) and
+ * is what `hosts.instance_id` and `repositories.host_id` store. `protocol` is
+ * `RPC_PROTOCOL_VERSION` as the *responder* understands it, which is the point
+ * of exchanging it at all: the two ends of an `ssh` pipe are separately
+ * installed and separately updated, and there is no package manager keeping
+ * them in step.
+ *
+ * `version` is the human-readable release, for a Hosts screen to show and for a
+ * person to compare against their own. Nothing branches on it - a decision made
+ * from a marketing version rather than from a protocol number is a decision
+ * that breaks on a hotfix.
+ */
+export interface HostIdentity {
+  instanceId: string
+  protocol: number
+  version: string
+}
 
 export interface RpcRequest<M extends RpcMethod = RpcMethod> {
   /** Unique per connection. Answers may come back in any order. */
@@ -126,6 +152,44 @@ export function isRpcResponse(message: RpcMessage): message is RpcResponse {
  * diff between two arbitrary strings.
  */
 export interface RpcMethods {
+  /**
+   * Who is answering, and what they speak. The handshake `RPC_PROTOCOL_VERSION`
+   * was reserved for.
+   *
+   * Asked by a GUI on the first successful connection to a host, so the host's
+   * own instance id can be written into the `hosts` row - see
+   * `core/services/hosts.ts`. It is the only method whose answer is about the
+   * responder rather than about a repository, which is exactly why it has to be
+   * a method: nothing else on the wire can say *which machine* just replied.
+   *
+   * Cheap and side-effect-free on purpose. It is also the natural thing for a
+   * future health check to call, and a health check that wrote something would
+   * be a health check nobody could run twice.
+   */
+  'app.instance': { params: void; result: HostIdentity }
+
+  /**
+   * Managing the list of *other* machines this install knows about.
+   *
+   * In the map because both shells need them - the Hosts screen exists in a
+   * browser tab as much as in the window, and M3 settled that a screen reaches
+   * the core through the dispatcher and nowhere else.
+   *
+   * Answered by the install the person is driving, and never forwarded to a
+   * host. A host's list of hosts is its own business, and routing these onward
+   * would turn a hub and its spokes into a mesh, where removing a machine from
+   * one list could remove it from another. `isLocalOnly` in `core/hosts/ssh.ts`
+   * is the backstop that makes that structural; M4.3's router is where the
+   * general local-versus-remote decision will live.
+   */
+  'hosts.list': { params: void; result: HostWithState[] }
+  'hosts.get': { params: GetHostInput; result: HostWithState }
+  'hosts.add': { params: AddHostInput; result: HostWithState }
+  'hosts.update': { params: UpdateHostInput; result: HostWithState }
+  'hosts.remove': { params: RemoveHostInput; result: { id: number } }
+  /** Reach a host now, ignoring backoff. Answers with what happened. */
+  'hosts.probe': { params: GetHostInput; result: HostWithState }
+
   'repositories.list': { params: void; result: RepositoryWithGitState[] }
   'repositories.get': { params: GetRepositoryInput; result: RepositoryWithGitState }
   'repositories.add': { params: AddRepositoryInput; result: Repository }
@@ -231,6 +295,13 @@ export interface AttachmentIngestParams {
  * rather than a guess made from the method name.
  */
 export const READ_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
+  'app.instance',
+  'hosts.list',
+  'hosts.get',
+  // `hosts.probe` is deliberately absent. It reads in the sense that it changes
+  // no host row a caller can see, but it opens a connection and clears a
+  // backoff, and two people pressing "try now" at the same moment should mean
+  // two attempts - which is the whole reason the button exists.
   'repositories.list',
   'repositories.get',
   'repositories.refs',

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -85,6 +85,103 @@ export type GetRepositoryInput = z.input<typeof getRepositoryInputSchema>
 export type RemoveRepositoryInput = z.input<typeof removeRepositoryInputSchema>
 
 /* -------------------------------------------------------------------------- */
+/* Hosts                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const MAX_TARGET_LENGTH = 255
+
+export const hostIdSchema = z.number().int().positive()
+export const hostKindSchema = z.enum(['ssh'])
+
+/**
+ * An SSH destination.
+ *
+ * Validated for shape rather than for reachability - whether a host answers is
+ * something only a connection can say, and a form that tried to guess would
+ * refuse perfectly good `~/.ssh/config` aliases it has no way to resolve.
+ *
+ * What is rejected is what would stop being a destination and start being an
+ * argument: a leading `-` (which `ssh` would read as an option), and whitespace
+ * or a shell metacharacter, neither of which can appear in a real target and
+ * both of which are how a string in a form becomes a command on the local
+ * machine. `ssh` is spawned without a shell, so this is belt-and-braces - but a
+ * carrier's safety should not rest on a spawn flag somebody could change.
+ */
+export const sshTargetSchema = z
+  .string()
+  .trim()
+  .min(1, 'Enter a host to connect to, like user@machine.')
+  .max(MAX_TARGET_LENGTH)
+  .refine((value) => !value.startsWith('-'), {
+    message: 'A host cannot start with "-".'
+  })
+  .refine((value) => !/[\s;&|`$(){}<>'"\\]/.test(value), {
+    message: 'A host can only contain a user name, an @ and a machine name.'
+  })
+
+/** A row as stored, plus how it is doing right now. */
+export const hostSchema = z.object({
+  id: hostIdSchema,
+  /** Null until the host has been reached once. See the schema note. */
+  instanceId: z.string().nullable(),
+  label: z.string(),
+  kind: hostKindSchema,
+  target: z.string(),
+  editorTarget: z.string().nullable(),
+  lastSeenAt: z.iso.datetime().nullable(),
+  createdAt: z.iso.datetime()
+})
+
+/**
+ * Reachability, which is never stored.
+ *
+ * Read from the connection pool at the moment of asking, for the same reason
+ * git state is read live rather than cached: a host that was up ten minutes ago
+ * is not a fact about now, and a screen showing one as though it were is the
+ * bug this whole milestone has to avoid.
+ */
+export const hostStateSchema = z.object({
+  connected: z.boolean(),
+  failures: z.number().int().nonnegative(),
+  lastError: z.string().optional(),
+  retryAfter: z.number().optional()
+})
+
+export const hostWithStateSchema = hostSchema.extend({ state: hostStateSchema })
+
+export const addHostInputSchema = z.object({
+  target: sshTargetSchema,
+  /** Defaults to the target with any `user@` removed. */
+  label: z.string().trim().min(1, 'Name cannot be empty.').max(MAX_NAME_LENGTH).optional(),
+  kind: hostKindSchema.optional(),
+  editorTarget: z.string().trim().max(MAX_TARGET_LENGTH).optional()
+})
+
+export const updateHostInputSchema = z
+  .object({
+    id: hostIdSchema,
+    label: z.string().trim().min(1, 'Name cannot be empty.').max(MAX_NAME_LENGTH).optional(),
+    target: sshTargetSchema.optional(),
+    editorTarget: z.string().trim().max(MAX_TARGET_LENGTH).nullable().optional()
+  })
+  .refine(
+    (value) =>
+      value.label !== undefined || value.target !== undefined || value.editorTarget !== undefined,
+    { message: 'Provide something to change.', path: ['label'] }
+  )
+
+export const getHostInputSchema = z.object({ id: hostIdSchema })
+export const removeHostInputSchema = z.object({ id: hostIdSchema })
+
+export type Host = z.infer<typeof hostSchema>
+export type HostWithState = z.infer<typeof hostWithStateSchema>
+export type HostConnectionState = z.infer<typeof hostStateSchema>
+export type AddHostInput = z.input<typeof addHostInputSchema>
+export type UpdateHostInput = z.input<typeof updateHostInputSchema>
+export type GetHostInput = z.input<typeof getHostInputSchema>
+export type RemoveHostInput = z.input<typeof removeHostInputSchema>
+
+/* -------------------------------------------------------------------------- */
 /* Reviews                                                                    */
 /* -------------------------------------------------------------------------- */
 


### PR DESCRIPTION
The first real remote. A `hosts` row is a route to another machine, and the carrier spawns `gitwarren serve --stdio` over `ssh` and speaks the protocol M2 already shipped.

M4 is going in as five mergeable slices, recorded in `docs/across-hosts.md`:

1. **The hosts table, the carrier and the pool** — this PR.
2. The Hosts screen and the installer over SSH.
3. Repositories on hosts.
4. Attachments, editors and agent access per host.
5. Disconnection.

## What is actually new

Very little, which is the point. `shared/rpc.ts` was already the protocol, `stdio.ts` already answered on a byte stream, and `repositories.host_id` has been waiting since M0. `core/hosts/ssh.ts` contributes a child process and an argument vector.

- **`core/rpc/ndjson.ts`** comes out of `stdio.ts` before anything is added. M4 gives the protocol a client, and two implementations of "where does a frame end" produce a *hang* rather than an error — both ends healthy, both waiting, nothing logged.
- **`core/rpc/stdio-client.ts`** is the asking side. Requests in flight when a connection dies fail with `HOST_OFFLINE` and are **never resent**: a retry of `comments.reply` after an answer nobody saw is a second comment on someone's review. Answers are matched by id because the daemon replies out of order.
- **`core/hosts/pool.ts`** is the policy. Connect on first use; hang up after ten idle minutes to match `ControlPersist`; refuse fast while a host is in backoff, so a fifteen-second poll cannot spawn four `ssh` processes a minute at a machine that is switched off. An explicit probe ignores the backoff — someone pressing "try now" has just turned the box on.
- **`hosts.*` is never forwarded to a host.** A host's list of hosts is its own business; routing these onward would turn a hub and its spokes into a mesh. `isLocalOnly` makes that structural rather than a comment.
- **`app.instance`** is the handshake `RPC_PROTOCOL_VERSION` was reserved for. A host's instance id is learned on first connect and written back, which is what catches one machine added twice under two names (`pc-wsl` and `xfor@100.78.0.23`) — something neither label nor target can see.

## Two things that bit

**The useful half of a failure arrives after the failure.** The protocol notices a dead connection when the far end's stdout ends, which for a failing `ssh` is a moment *before* the `exit` that carries the status code and after which stderr is complete. Reading the reason at rejection time reported `The connection to the host closed.` for a hostname that does not resolve — true, useless, and exactly what a person would have been left with. `diagnostics()` is now a promise that waits for the exit already on its way:

```
ssh could not connect to xfor@no-such-host-here.
ssh: Could not resolve hostname no-such-host-here: nodename nor servname provided, or not known
```

Found by running it against a real machine and reading the output, not by a test passing. There is now a test for it.

**`BatchMode=yes` is what turns a hang into an error.** Without it `ssh` waits at a passphrase or host-key prompt on a stdin carrying JSON and no human, and the GUI spins forever.

## Verification

Proved by hand against the real `pc-wsl` node *before* the code was written: the 44 MB tarball streamed into `~/.gitwarren/daemon/<version>/` over the pipe in 2.5s on a box with nothing but git, and two requests came back **out of order**, which is the property the `id` field exists for.

Then end to end through the shipping code:

| | |
|---|---|
| reachable, cold | 178 ms |
| reachable, warm (multiplexed) | 4 ms |
| instance id learned and written back | ✓ |
| `NOT_FOUND` survives the wire as itself, host stays up | ✓ |
| `hosts.list` refused by the carrier | ✓ |
| deliberate hang-up starts no backoff, reconnects after | ✓ |
| unreachable host fails with what `ssh` said | 18 ms |
| host answering ssh with no GitWarren | exit 127, told by name |

The whole protocol contract in `dispatcher.test.ts` now runs a **third** time — through `stdio-client.ts` against `stdio.ts` — so the thing under test is the thing that ships, and the test's own hand-rolled client is gone. Four assertions about the response *envelope* are skipped for that carrier rather than faked: a client that assigns its own ids cannot ask a question under a chosen id, and a `send` built on top of it would echo back whatever the test passed in and assert nothing.

`npm run lint`, `npm run typecheck`, `npm run build` and `npm test` (449 tests, 445 pass / 4 skipped by the above) all green.

## Not in this PR

No Hosts screen and no installer — M4.2, and they are one slice because the screen's main job is to drive the install. Until then a host is added through the dispatcher and the daemon has to be placed by hand. `hosts.remove` deliberately leaves repository rows alone rather than cascading; that decision belongs to M4.3, once there is a remote repository to have an opinion about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ctnvmLJk5QTtTzVTrPp3Y
