### PR TITLE
M4.2 - The Hosts screen and the installer over SSH

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -1543,7 +1543,7 @@ them verifiable against the real `pc-wsl` node rather than against a mock:
    another machine at all. *(done — see below.)*
 2. **The Hosts screen and the installer over SSH.** `uname -sm`, the tarball
    fetched once and streamed in, the launchers maintained, and the screen that
-   drives it.
+   drives it. *(done — see below.)*
 3. **Repositories on hosts.** `fs.list`, the host segment in routes, reviews
    listed under their host, clones grouped by root commit across hosts.
 4. **Attachments, editors and agent access per host.**
@@ -1648,6 +1648,125 @@ by hand for now. Repositories on hosts are M4.3, so `hosts.remove` deliberately
 leaves any repository rows pointing at that host alone rather than cascading —
 a cascade written now would have to be unpicked once there is a remote
 repository to have an opinion about.
+
+**M4.2, done on the Mac against the WSL node, 10–11 September.** A machine with
+git on it and nothing else is now four commands away from being reviewable,
+and all four go down a connection that was already open:
+
+    uname -sm                                which tarball
+    ~/.gitwarren/bin/gitwarren --version     whether there is anything to do
+    tar xzf -            reading stdin       the bytes
+    …/bin/gitwarren service install          the launchers
+
+`core/hosts/release.ts` decides which file that is and gets it onto *this*
+disk; `core/hosts/install.ts` is the sequence; `hosts.install` on the
+dispatcher is how a screen asks. Nothing was added to `ssh.ts` but
+`runOverSsh`, because "how this app invokes ssh" is one decision and
+`SSH_OPTIONS` is where it was already written down — which is also why `uname`
+on a host with a connection open costs a process spawn and no crypto.
+
+**The host writes its own launchers, and that is the load-bearing choice.** It
+would be a shorter file to `echo` two `sh` scripts into `~/.gitwarren/bin` from
+here. `src/cli/launchers.ts` already knows what a launcher looks like, down to
+the symlink loop and the two absolute paths a login shell cannot work out for
+itself, and a second implementation across an ssh pipe is a copy that drifts.
+The better reason is that running the binary we just unpacked is the only
+*proof* that the architecture was picked correctly: a linux-arm64 tarball on an
+x86-64 box gets as far as a perfectly successful `tar` and then dies at the
+first `exec`, and that is much better discovered during an install someone is
+watching than at the first review they try to open. `--no-login-item` is passed
+because a remote host is not where a login item belongs — the carrier spawns
+`serve --stdio` on demand and hangs up after ten idle minutes, and a daemon
+that also started itself at boot would be a second process on one database
+that nobody asked for. That flag was added in M3.3 for the VPS case, before
+there was one.
+
+Unpacking goes to a scratch directory beside the destination and is moved in
+with one `mv`, because a `tar` interrupted halfway through the destination
+itself leaves a directory that exists, looks installed and cannot run.
+
+**Verification was the point, and it was destructive on purpose.**
+`~/.gitwarren` on `pc-wsl` — which since M4.1 held a hand-built daemon that was
+ahead of the published beta — was deleted, and everything below was done by the
+shipping code onto a machine with nothing on it. From the app: 46.4 MB streamed
+in 3.4 seconds, the launcher and `gitwarren-mcp` written by the host's own
+`service install` with absolute paths into
+`~/.gitwarren/daemon/0.1.7-beta.1/`, `service status` reporting no login item,
+the instance id learned and the row reading *Reachable · GitWarren
+0.1.7-beta.1*. Then the same screen in a Chrome tab against the same core:
+"already up to date, nothing was sent", and Forget. No console errors in
+either, and no horizontal scroll at 390 px.
+
+**Three things bit.**
+
+*One failed press climbed two rungs of the backoff ladder.* A probe of a host
+with no GitWarren on it came back `failures: 2`. A dying connection is noticed
+twice — the close handler sees stdout end, and every request waiting on it
+rejects — and M4.1's pool counted both, so a machine that was switched off went
+from a one-second wait to a fifteen-second one after two attempts instead of
+four. The pool's own tests could not see it: their fake connection rejects a
+request without ever closing, which is a shape a real `ssh` never has. Failures
+are now counted once per connection, by generation. The *message* still takes
+the later of the two, deliberately — the close handler arrives first with "the
+connection closed" because that is all that is known when stdout ends, and the
+request's own failure arrives a moment later having waited for the exit status
+and says "GitWarren is not installed on xfor@pc-wsl". Keeping the first because
+it was first would have undone the thing M4.1 went to some trouble to get
+right. Two tests now assert both halves.
+
+*The remote command is run by the login shell, and on that box it is zsh.* Not
+`sh`, whatever `#!/bin/sh` might suggest — `ssh host '<script>'` hands the
+string to whatever the account's shell is. The unpack script was already free
+of bashisms and of `--strip-components` (busybox `tar` has never had it, so the
+archive's own directory is moved rather than stripped), so it ran unchanged;
+had it not been, this is the sort of thing that fails on someone else's server
+and nowhere else.
+
+*The published tarballs cannot be downloaded yet, and that is not a workflow
+bug.* `release.yml` on `main` builds all four targets, but the tag
+`v0.1.7-beta.1` predates that change — at that tag the daemon job built linux
+only, which is why the draft carries two tarballs and no Homebrew formula. The
+next tag gets macOS. Separately, a *draft* release's assets 404 for everyone,
+so nothing can install from this one until it is published; the 404 says so by
+name rather than reporting a bare status code. `GITWARREN_DAEMON_TARBALL_DIR`
+is what makes a development build installable at all — its version is
+`0.0.0-dev`, which no release has ever heard of — and it is the same answer an
+air-gapped machine with the file on a stick needs, which is why it is a
+directory rather than a flag on a form. Everything above was verified through
+it, with a `linux-x64` tarball built by `scripts/build-daemon-tarball.mjs`.
+
+**The Hosts screen needed no capability flag, and that is the M3.2 design
+working.** Every control on it is one `carrier.request`; in a tab that reaches
+the daemon's core rather than the app's, and what gets managed is *that*
+install's list of hosts — which is correct, because `hosts.*` is answered by
+whoever is asked and never forwarded. `shell.capabilities` exists for controls
+a tab genuinely cannot offer, and installing over ssh is not one of them: the
+install runs wherever the core runs, and that this may be a different machine
+from the browser is the point of the milestone rather than a problem with it.
+`#/hosts` is accordingly the one route in `shared/routes.ts` that is not host
+scoped, and the type says so.
+
+The install is one request with no progress and no timeout, and both are
+deliberate. `shared/rpc.ts` reserves an event channel for M6 and nothing emits
+on it; inventing half of one for a progress bar would put a push-shaped hole in
+a request/response protocol for a wait that is three seconds on a LAN. There is
+also no number of seconds after which abandoning a part-finished install would
+be an improvement. The screen says how big the download is and shows the
+outcome in a dialog rather than a toast, because a person who pressed a button
+and went to make tea should not have to have been watching — least of all for
+the failure, which is `ssh`'s own words and the only thing that says what to
+fix.
+
+**Not done in M4.2, and why.** There is no remote uninstall. `hosts.remove`
+forgets a row on this machine, and the dialog says so in as many words; going
+onto somebody's server to delete a directory is a different act, and
+`rm -rf ~/.gitwarren` is one they can type and read before pressing return. Old
+versions accumulate under `~/.gitwarren/daemon/` and are not pruned, because
+two GitWarrens on two laptops can point one host's launcher at different
+versions and deleting the other's install is not this one's decision to make.
+Nothing on the screen reaches a *repository* on a host yet — that is M4.3, and
+until it lands a host is a machine you can install onto and prove reachable,
+which is exactly what M4.2 set out to be.
 
 ### M5 — WSL from Windows
 

--- a/drizzle/0009_host_daemon_version.sql
+++ b/drizzle/0009_host_daemon_version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `hosts` ADD `daemon_version` text;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,738 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "58a9da50-062b-41ac-b245-72ba030a0292",
+  "prevId": "591c5ede-c25b-4cf8-a00a-d1566c7cd6c4",
+  "tables": {
+    "attachments": {
+      "name": "attachments",
+      "columns": {
+        "sha": {
+          "name": "sha",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "byte_size": {
+          "name": "byte_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comment_threads": {
+      "name": "comment_threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_line": {
+          "name": "start_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_text": {
+          "name": "anchor_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_sha": {
+          "name": "anchor_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "anchor_snapshot": {
+          "name": "anchor_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "comment_threads_review_idx": {
+          "name": "comment_threads_review_idx",
+          "columns": [
+            "review_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "comment_threads_file_idx": {
+          "name": "comment_threads_file_idx",
+          "columns": [
+            "review_id",
+            "file_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comment_threads_review_id_reviews_id_fk": {
+          "name": "comment_threads_review_id_reviews_id_fk",
+          "tableFrom": "comment_threads",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_label": {
+          "name": "author_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_session": {
+          "name": "author_session",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "comments_thread_idx": {
+          "name": "comments_thread_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_thread_id_comment_threads_id_fk": {
+          "name": "comments_thread_id_comment_threads_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comment_threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_author_id_principals_id_fk": {
+          "name": "comments_author_id_principals_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "principals",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hosts": {
+      "name": "hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ssh'"
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "editor_target": {
+          "name": "editor_target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "daemon_version": {
+          "name": "daemon_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "hosts_kind_target_idx": {
+          "name": "hosts_kind_target_idx",
+          "columns": [
+            "kind",
+            "target"
+          ],
+          "isUnique": true
+        },
+        "hosts_instance_idx": {
+          "name": "hosts_instance_idx",
+          "columns": [
+            "instance_id"
+          ],
+          "isUnique": true,
+          "where": "\"hosts\".\"instance_id\" is not null"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "principals": {
+      "name": "principals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "principals_identity_idx": {
+          "name": "principals_identity_idx",
+          "columns": [
+            "kind",
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "repositories_name_idx": {
+          "name": "repositories_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "repositories_host_path_idx": {
+          "name": "repositories_host_path_idx",
+          "columns": [
+            "host_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "repositories_local_path_idx": {
+          "name": "repositories_local_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": true,
+          "where": "\"repositories\".\"host_id\" is null"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviewed_files": {
+      "name": "reviewed_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_digest": {
+          "name": "content_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "reviewed_files_path_idx": {
+          "name": "reviewed_files_path_idx",
+          "columns": [
+            "review_id",
+            "file_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reviewed_files_review_id_reviews_id_fk": {
+          "name": "reviewed_files_review_id_reviews_id_fk",
+          "tableFrom": "reviewed_files",
+          "tableTo": "reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reviews": {
+      "name": "reviews",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref": {
+          "name": "head_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reviews_repository_idx": {
+          "name": "reviews_repository_idx",
+          "columns": [
+            "repository_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reviews_repository_id_repositories_id_fk": {
+          "name": "reviews_repository_id_repositories_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1789074697080,
       "tag": "0008_hosts",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1789076799454,
+      "tag": "0009_host_daemon_version",
+      "breakpoints": true
     }
   ]
 }

--- a/src/core/db/schema.ts
+++ b/src/core/db/schema.ts
@@ -131,6 +131,24 @@ export const hosts = sqliteTable(
      * written down - the Hosts screen asks the carrier, which knows.
      */
     lastSeenAt: text('last_seen_at'),
+    /**
+     * Which GitWarren was on the host the last time it said, and NULL until it
+     * has said anything.
+     *
+     * Stored for the same reason `instance_id` is, and learned in the same
+     * place from the same `app.instance` answer: it is a fact about the install
+     * over there, not about whether it is awake, so it survives the machine
+     * being switched off. That is what lets the Hosts screen say "0.1.6, update
+     * available" for a host it has not connected to since - and the alternative,
+     * asking every host on every list, would connect to all of them to render a
+     * list, which is precisely what the connect-on-use pool exists to avoid.
+     *
+     * It is allowed to be wrong in exactly one way: someone upgrades the daemon
+     * on the host by hand, and this says the old version until the next
+     * connect. That is the same staleness `last_seen_at` has, and the install
+     * button re-reads the truth before it does anything.
+     */
+    daemonVersion: text('daemon_version'),
     createdAt: text('created_at')
       .notNull()
       .default(sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`)

--- a/src/core/hosts/__tests__/install.test.ts
+++ b/src/core/hosts/__tests__/install.test.ts
@@ -1,0 +1,282 @@
+/**
+ * The order of the four commands, and what each answer is allowed to mean.
+ *
+ * `runOverSsh` is swapped for a recorder here, which is worth being honest
+ * about: this tests the *sequence* and the decisions, not that any of it works
+ * against a machine. The second half of that is `docs/across-hosts.md` under
+ * M4.2, where `~/.gitwarren` on `pc-wsl` was wiped and rebuilt from scratch by
+ * this code - which is the only way to find out that a remote `sh` disagrees
+ * with the one on this laptop.
+ *
+ * What a recorder does catch, and catches cheaply, is the class of mistake that
+ * would otherwise be found on somebody else's server: touching the host before
+ * the download has succeeded, believing the launcher without reading it back,
+ * and shipping a script that reaches for a `tar` flag busybox has never had.
+ */
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'node:test'
+import { gzipSync } from 'node:zlib'
+
+import { installOnHost } from '../install.js'
+import { tarballName } from '../release.js'
+import type { SshRunResult } from '../ssh.js'
+import type { HostRoute } from '../pool.js'
+import { AppError } from '../../../shared/errors.js'
+
+const ROUTE: HostRoute = { id: 1, kind: 'ssh', target: 'xfor@pc-wsl' }
+const VERSION = '9.9.9'
+
+const scratch = mkdtempSync(join(tmpdir(), 'gitwarren-install-'))
+const staged = join(scratch, tarballName(VERSION, 'linux-x64'))
+writeFileSync(staged, gzipSync(Buffer.from('a tarball, for the purposes of this test')))
+
+interface Recorded {
+  command: string
+  hadStdin: boolean
+}
+
+/**
+ * A host that answers whatever the test says it answers.
+ *
+ * Keyed by a substring of the command rather than by call index, so a test
+ * reads as "when it asks about the version, say this" and does not have to be
+ * renumbered when a step is added between two others.
+ */
+function fakeHost(answers: Array<[match: string, result: Partial<SshRunResult>]>) {
+  const calls: Recorded[] = []
+
+  const run = ({
+    command,
+    stdin
+  }: {
+    command: string
+    stdin?: unknown
+  }): Promise<SshRunResult> => {
+    calls.push({ command, hadStdin: stdin !== undefined })
+    // Consume the stream so a `createReadStream` in the real code does not sit
+    // open on a file descriptor for the rest of the run.
+    if (stdin && typeof (stdin as { resume?: () => void }).resume === 'function') {
+      ;(stdin as { resume: () => void }).resume()
+    }
+    for (const [match, result] of answers) {
+      if (command.includes(match)) {
+        return Promise.resolve({ code: 0, stdout: '', stderr: '', ...result })
+      }
+    }
+    return Promise.resolve({ code: 0, stdout: '', stderr: '' })
+  }
+
+  return { run: run as never, calls }
+}
+
+/** The four steps, in the order `installOnHost` runs them. */
+function shapeOf(calls: Recorded[]): string[] {
+  return calls.map((call) => {
+    if (call.command.includes('uname')) return 'uname'
+    if (call.command.includes('--version')) return 'version'
+    if (call.command.includes('tar xzf')) return 'unpack'
+    if (call.command.includes('service install')) return 'launchers'
+    return `unknown: ${call.command.slice(0, 40)}`
+  })
+}
+
+test('a host with nothing on it gets asked, then sent, then made to prove itself', async () => {
+  const host = fakeHost([
+    ['uname', { stdout: 'Linux x86_64\n' }],
+    // 127 is what `sh` returns for a launcher that is not there, and is the
+    // ordinary answer on a machine that has never had GitWarren.
+    ['--version', { code: 127 }]
+  ])
+
+  // The version read-back at the end has to succeed, so the second `--version`
+  // answers differently from the first. Order matters in this list.
+  host.calls.length = 0
+  let seenVersion = false
+  const run = (async (options: { command: string; stdin?: unknown }) => {
+    const result = await (host.run as unknown as (o: unknown) => Promise<SshRunResult>)(options)
+    if (options.command.includes('--version')) {
+      if (seenVersion) return { code: 0, stdout: `${VERSION}\n`, stderr: '' }
+      seenVersion = true
+    }
+    return result
+  }) as never
+
+  const report = await installOnHost(ROUTE, {
+    version: VERSION,
+    run,
+    resolve: () => Promise.resolve(staged)
+  })
+
+  assert.deepEqual(shapeOf(host.calls), ['uname', 'version', 'unpack', 'launchers', 'version'])
+  assert.equal(report.action, 'installed')
+  assert.equal(report.previousVersion, null)
+  assert.equal(report.target, 'linux-x64')
+  assert.ok(report.bytes > 0)
+
+  // The bytes travel on stdin of exactly one command, and it is the one that
+  // unpacks them.
+  assert.deepEqual(
+    host.calls.filter((call) => call.hadStdin).map((call) => shapeOf([call])[0]),
+    ['unpack']
+  )
+})
+
+test('a host already on this version is not sent 45 MB again', async () => {
+  const host = fakeHost([
+    ['uname', { stdout: 'Linux x86_64\n' }],
+    ['--version', { stdout: `${VERSION}\n` }]
+  ])
+
+  const report = await installOnHost(ROUTE, {
+    version: VERSION,
+    run: host.run,
+    resolve: () => assert.fail('nothing should be fetched for a host that is already current')
+  })
+
+  assert.equal(report.action, 'already-current')
+  assert.equal(report.bytes, 0)
+  assert.deepEqual(shapeOf(host.calls), ['uname', 'version'])
+})
+
+test('force reinstalls a host that is already current', async () => {
+  const host = fakeHost([
+    ['uname', { stdout: 'Linux x86_64\n' }],
+    ['--version', { stdout: `${VERSION}\n` }]
+  ])
+
+  const report = await installOnHost(ROUTE, {
+    version: VERSION,
+    force: true,
+    run: host.run,
+    resolve: () => Promise.resolve(staged)
+  })
+
+  // `upgraded` rather than `installed`, because something was there - even
+  // though it was the same thing.
+  assert.equal(report.action, 'upgraded')
+  assert.equal(report.previousVersion, VERSION)
+  assert.deepEqual(shapeOf(host.calls), ['uname', 'version', 'unpack', 'launchers', 'version'])
+})
+
+test('an older version is an upgrade, and says what it came from', async () => {
+  let seen = 0
+  const run = (({ command }: { command: string; stdin?: unknown }) => {
+    if (command.includes('uname')) {
+      return Promise.resolve({ code: 0, stdout: 'Darwin arm64\n', stderr: '' })
+    }
+    if (command.includes('--version')) {
+      seen += 1
+      return Promise.resolve({
+        code: 0,
+        stdout: seen === 1 ? '0.1.6\n' : `${VERSION}\n`,
+        stderr: ''
+      })
+    }
+    return Promise.resolve({ code: 0, stdout: '', stderr: '' })
+  }) as never
+
+  const report = await installOnHost(ROUTE, {
+    version: VERSION,
+    run,
+    resolve: (_version, target) => {
+      // The target comes from the host's own `uname`, not from this machine's
+      // platform - which is the whole reason a Mac can install onto Linux.
+      assert.equal(target, 'darwin-arm64')
+      return Promise.resolve(staged)
+    }
+  })
+
+  assert.equal(report.action, 'upgraded')
+  assert.equal(report.previousVersion, '0.1.6')
+  assert.equal(report.target, 'darwin-arm64')
+})
+
+test('nothing is touched on the host when the download fails', async () => {
+  const host = fakeHost([
+    ['uname', { stdout: 'Linux x86_64\n' }],
+    ['--version', { code: 127 }]
+  ])
+
+  await assert.rejects(
+    installOnHost(ROUTE, {
+      version: VERSION,
+      run: host.run,
+      resolve: () => Promise.reject(new AppError('NOT_FOUND', 'no such release'))
+    }),
+    /no such release/
+  )
+
+  // A download that fails must leave the machine exactly as it was, rather than
+  // part-way through an upgrade with the old version already moved aside.
+  assert.deepEqual(shapeOf(host.calls), ['uname', 'version'])
+})
+
+test('a tarball that unpacks but cannot run is reported as the wrong architecture', async () => {
+  const host = fakeHost([
+    ['uname', { stdout: 'Linux x86_64\n' }],
+    ['--version', { code: 127 }],
+    // What a linux-arm64 `node` does on an x86-64 box: `tar` was perfectly
+    // happy, and the first `exec` is where it goes wrong.
+    ['service install', { code: 126, stderr: 'cannot execute binary file: Exec format error' }]
+  ])
+
+  await assert.rejects(
+    installOnHost(ROUTE, { version: VERSION, run: host.run, resolve: () => Promise.resolve(staged) }),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError)
+      assert.match(error.message, /Exec format error/)
+      assert.match(error.message, /wrong one for that machine/)
+      return true
+    }
+  )
+})
+
+test('a launcher that still points somewhere else is not called a success', async () => {
+  // The read-back exists for this: another install on the same machine - a
+  // Homebrew `gitwarren`, a second GUI - maintains the same stable path, and
+  // reporting a version that is not what the carrier will actually spawn is the
+  // kind of wrong that is only discovered much later.
+  const host = fakeHost([
+    ['uname', { stdout: 'Linux x86_64\n' }],
+    ['--version', { stdout: '0.1.6\n' }]
+  ])
+
+  await assert.rejects(
+    installOnHost(ROUTE, { version: VERSION, run: host.run, resolve: () => Promise.resolve(staged) }),
+    /still reports 0\.1\.6 after installing 9\.9\.9/
+  )
+})
+
+test('the remote script uses nothing a minimal sh and tar lack', async () => {
+  const host = fakeHost([
+    ['uname', { stdout: 'Linux x86_64\n' }],
+    ['--version', { code: 127 }]
+  ])
+  let seen = 0
+  const run = (async (options: { command: string; stdin?: unknown }) => {
+    const result = await (host.run as unknown as (o: unknown) => Promise<SshRunResult>)(options)
+    if (options.command.includes('--version') && seen++ > 0) {
+      return { code: 0, stdout: `${VERSION}\n`, stderr: '' }
+    }
+    return result
+  }) as never
+
+  await installOnHost(ROUTE, { version: VERSION, run, resolve: () => Promise.resolve(staged) })
+  const unpack = host.calls.find((call) => call.command.includes('tar xzf'))?.command ?? ''
+
+  // busybox `tar` has neither of these, and a WSL image or a container that
+  // uses it would fail on a flag rather than on anything real. The archive's
+  // own directory is moved instead.
+  assert.doesNotMatch(unpack, /--strip-components/)
+  assert.doesNotMatch(unpack, /--transform/)
+  // No bashisms: `[[`, arrays, `local`. `sh` is what a remote command gets.
+  assert.doesNotMatch(unpack, /\[\[/)
+  // A `tar` that fails must not be followed by a `mv` that installs an empty
+  // directory and calls it done.
+  assert.match(unpack, /^set -e$/m)
+  // And the version is quoted, because it reaches the remote shell as text.
+  assert.match(unpack, /"9\.9\.9"/)
+})

--- a/src/core/hosts/__tests__/pool.test.ts
+++ b/src/core/hosts/__tests__/pool.test.ts
@@ -201,3 +201,73 @@ test('an error from the host is the host working, not the host being down', asyn
   // The round trip succeeded. The machine is fine and stays fine.
   assert.deepEqual(pool.state(route.id), { connected: true, failures: 0 })
 })
+
+test('a pipe that dies under a request is one failure, not two', async () => {
+  // This is the shape a real `ssh` has and the fake above did not: when the far
+  // end goes, the close handler fires *and* every request waiting on it
+  // rejects. Counting both made one press of "Try now" climb two rungs of the
+  // backoff ladder, so a machine that was switched off went from a one-second
+  // wait to a fifteen-second one after two attempts instead of four. Found
+  // against `pc-wsl` while verifying M4.2, by reading a `failures: 2` that
+  // should have said 1.
+  const { pool, fake } = fakePool({
+    answer: () =>
+      new Promise((_resolve, reject) => {
+        fake.closeLast(new AppError('HOST_OFFLINE', 'The connection to the host closed.'))
+        reject(new AppError('HOST_OFFLINE', 'The connection to the host closed.'))
+      })
+  })
+
+  await assert.rejects(pool.request(route, 'repositories.list'))
+
+  const state = pool.state(route.id)
+  assert.equal(state.failures, 1)
+  // And the explanation is the one that waited for `ssh` to exit, not the one
+  // that was all anybody knew at the instant stdout ended. The count takes the
+  // earliest, the message takes the latest.
+  assert.match(state.lastError ?? '', /Host is down/)
+  // First rung, because this was the first failure.
+  assert.equal(state.retryAfter, undefined)
+
+  // And the ladder still climbs on the next one.
+  await assert.rejects(pool.request(route, 'repositories.list'))
+  assert.equal(pool.state(route.id).failures, 2)
+  assert.equal(typeof pool.state(route.id).retryAfter, 'number')
+})
+
+test('a second failure on the same dead connection is still one rung', async () => {
+  // Two requests in flight when the pipe goes is one event, not two, and a
+  // screen that had opened a review and a diff at once must not be punished
+  // twice for one network blip.
+  const { pool, fake } = fakePool({
+    answer: () =>
+      new Promise((_resolve, reject) =>
+        setTimeout(() => reject(new AppError('HOST_OFFLINE', 'gone')), 0)
+      )
+  })
+
+  const first = pool.request(route, 'repositories.list')
+  const second = pool.request(route, 'reviews.list')
+  fake.closeLast(new AppError('HOST_OFFLINE', 'The connection to the host closed.'))
+
+  await assert.rejects(first)
+  await assert.rejects(second)
+
+  assert.equal(pool.state(route.id).failures, 1)
+})
+
+test('a fresh connection that fails is a new rung, not a repeat of the old one', async () => {
+  const { pool, fake, advance } = fakePool({
+    answer: () => Promise.reject(new AppError('HOST_OFFLINE', 'gone'))
+  })
+
+  await assert.rejects(pool.request(route, 'repositories.list'))
+  assert.equal(pool.state(route.id).failures, 1)
+
+  // Past the first rung, so a new connection is opened - and its failure has to
+  // count, or a host that is down would sit at one failure forever.
+  advance(BACKOFF_MS[1] + 1)
+  await assert.rejects(pool.request(route, 'repositories.list'))
+  assert.equal(pool.state(route.id).failures, 2)
+  assert.equal(fake.connects, 2)
+})

--- a/src/core/hosts/__tests__/release.test.ts
+++ b/src/core/hosts/__tests__/release.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Choosing a tarball, and getting it onto this disk.
+ *
+ * The `uname` mapping is the part worth pinning down: it is a table, tables get
+ * edited, and the arm spellings differ between the two operating systems that
+ * are supported - `aarch64` on Linux and `arm64` on macOS, for the same chip.
+ * Getting one of those wrong produces a tarball that unpacks perfectly and
+ * cannot execute, which is a confusing enough failure to be worth four
+ * assertions.
+ *
+ * The download is exercised over a real socket rather than a stubbed `fetch`.
+ * What is being tested is the streaming, the rename and the guard against a
+ * body that is not a tarball, and none of those is really tested by a promise
+ * that resolves with a string.
+ */
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, test } from 'node:test'
+import type { AddressInfo } from 'node:net'
+
+import {
+  DAEMON_TARGETS,
+  resolveTarball,
+  tarballName,
+  tarballUrl,
+  targetFromUname,
+  TARBALL_DIR_ENV_VAR
+} from '../release.js'
+import { AppError } from '../../../shared/errors.js'
+
+const scratch = mkdtempSync(join(tmpdir(), 'gitwarren-release-'))
+const TARBALL = gzipSync(Buffer.from('not really a tar, but it is really gzip'))
+
+test('every uname a supported host can answer maps to a tarball that exists', () => {
+  assert.equal(targetFromUname('Linux x86_64'), 'linux-x64')
+  // The one that is spelled differently on each side, and the reason this is a
+  // function rather than a template string at the call site.
+  assert.equal(targetFromUname('Linux aarch64'), 'linux-arm64')
+  assert.equal(targetFromUname('Darwin arm64'), 'darwin-arm64')
+  assert.equal(targetFromUname('Darwin x86_64'), 'darwin-x64')
+
+  // Trailing newline is what `uname` actually sends back over ssh.
+  assert.equal(targetFromUname('Linux x86_64\n'), 'linux-x64')
+
+  for (const target of [
+    targetFromUname('Linux x86_64'),
+    targetFromUname('Darwin arm64')
+  ] as const) {
+    assert.ok(DAEMON_TARGETS.includes(target))
+  }
+})
+
+test('a machine with no tarball is told so by name, not left to fail at exec', () => {
+  // 32-bit arm and Windows are both real answers from real hosts, and both are
+  // better refused here than three steps later inside `tar`.
+  assert.throws(() => targetFromUname('Linux armv7l'), /no GitWarren daemon/i)
+  assert.throws(() => targetFromUname('MINGW64_NT-10.0 x86_64'), /Linux and macOS/i)
+  assert.throws(() => targetFromUname(''), /that machine/i)
+})
+
+test('the asset name is the one the release workflow writes', () => {
+  // `scripts/build-daemon-tarball.mjs` composes the same string. If these two
+  // ever disagree the installer 404s on every host, so the shape is asserted
+  // rather than left to a comment in each file pointing at the other.
+  assert.equal(
+    tarballName('0.1.7-beta.1', 'linux-x64'),
+    'gitwarren-daemon-0.1.7-beta.1-linux-x64.tar.gz'
+  )
+  // The tag has a `v`; the file name does not.
+  assert.equal(
+    tarballUrl('0.1.7-beta.1', 'linux-arm64'),
+    'https://github.com/klarluft/gitwarren-app/releases/download/v0.1.7-beta.1/' +
+      'gitwarren-daemon-0.1.7-beta.1-linux-arm64.tar.gz'
+  )
+})
+
+test('a staged local file is used, and nothing is downloaded', async () => {
+  const local = mkdtempSync(join(scratch, 'local-'))
+  const cache = mkdtempSync(join(scratch, 'cache-'))
+  const name = tarballName('9.9.9', 'linux-x64')
+  writeFileSync(join(local, name), TARBALL)
+
+  const path = await resolveTarball('9.9.9', 'linux-x64', {
+    localDirectory: local,
+    cacheDirectory: cache,
+    fetchImpl: () => assert.fail('a staged file must not be downloaded again')
+  })
+
+  assert.equal(path, join(local, name))
+  // And it is used in place rather than copied into the cache: a directory
+  // someone staged by hand is theirs, and duplicating 45 MB to reach it is a
+  // cost with nothing on the other side.
+  assert.deepEqual(readdirSync(cache), [])
+})
+
+test('a staged directory that lacks this version refuses rather than downloading', async () => {
+  const local = mkdtempSync(join(scratch, 'empty-'))
+
+  // The alternative - quietly falling through to the network - would install a
+  // *different* build than the one someone deliberately put there, on a machine
+  // where the two can differ. That is the surprise worth an error.
+  await assert.rejects(
+    resolveTarball('9.9.9', 'linux-x64', {
+      localDirectory: local,
+      cacheDirectory: mkdtempSync(join(scratch, 'cache-')),
+      fetchImpl: () => assert.fail('a named directory must not fall through to the network')
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError)
+      assert.equal(error.code, 'NOT_FOUND')
+      assert.match(error.message, new RegExp(TARBALL_DIR_ENV_VAR))
+      return true
+    }
+  )
+})
+
+test('a download is streamed to the cache, and the second call does not repeat it', async () => {
+  let served = 0
+  const server = createServer((request, response) => {
+    served += 1
+    assert.equal(
+      request.url,
+      `/v9.9.9/${tarballName('9.9.9', 'linux-x64')}`,
+      'the URL is composed from the version and the target, and nothing else'
+    )
+    response.writeHead(200, { 'content-type': 'application/gzip' })
+    response.end(TARBALL)
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+  after(() => server.close())
+
+  const cache = mkdtempSync(join(scratch, 'cache-'))
+  const first = await resolveTarball('9.9.9', 'linux-x64', {
+    cacheDirectory: cache,
+    localDirectory: undefined,
+    baseUrl: base
+  })
+
+  assert.deepEqual(readFileSync(first), TARBALL)
+  // Nothing half-written left beside it: the download lands on a `.partial` and
+  // is published by a rename, which is the only operation that can promise a
+  // reader sees all of it or none of it.
+  assert.deepEqual(readdirSync(cache), [tarballName('9.9.9', 'linux-x64')])
+
+  const second = await resolveTarball('9.9.9', 'linux-x64', {
+    cacheDirectory: cache,
+    localDirectory: undefined,
+    baseUrl: base
+  })
+  assert.equal(second, first)
+  assert.equal(served, 1, 'a cached tarball is the whole point of caching it')
+})
+
+test('a draft release 404s, and the message says what to do about it', async () => {
+  const server = createServer((_request, response) => {
+    response.writeHead(404).end('Not Found')
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+  after(() => server.close())
+
+  await assert.rejects(
+    resolveTarball('9.9.9', 'linux-x64', {
+      cacheDirectory: mkdtempSync(join(scratch, 'cache-')),
+      localDirectory: undefined,
+      baseUrl: base
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof AppError)
+      assert.equal(error.code, 'NOT_FOUND')
+      // This is the failure anybody trying M4.2 today actually hits, because
+      // the only release with daemon tarballs on it is still a draft.
+      assert.match(error.message, /may not be published yet/i)
+      assert.match(error.message, new RegExp(TARBALL_DIR_ENV_VAR))
+      return true
+    }
+  )
+})
+
+test('a login page served with a 200 is not cached as a tarball', async () => {
+  const server = createServer((_request, response) => {
+    // The failure worth guarding against: a proxy or an SSO wall that answers
+    // every request with HTML and a success status. `fetch` is perfectly happy
+    // and the file lands on disk under the tarball's name, where it would fail
+    // on every host it was streamed to for as long as the cache kept it.
+    response.writeHead(200, { 'content-type': 'text/html' }).end('<html>Sign in</html>')
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+  after(() => server.close())
+
+  const cache = mkdtempSync(join(scratch, 'cache-'))
+  await assert.rejects(
+    resolveTarball('9.9.9', 'linux-x64', {
+      cacheDirectory: cache,
+      localDirectory: undefined,
+      baseUrl: base
+    }),
+    /not return a GitWarren daemon tarball/i
+  )
+
+  assert.deepEqual(readdirSync(cache), [], 'and nothing is left behind to be believed next time')
+})

--- a/src/core/hosts/install.ts
+++ b/src/core/hosts/install.ts
@@ -1,0 +1,245 @@
+/**
+ * Putting GitWarren on a machine that has never had it, over the connection
+ * that was already open.
+ *
+ * The promise M4 makes is that a host needs nothing installed but git. This is
+ * the file that has to keep it, so the shape of the whole thing follows from
+ * one constraint: the host may have no package manager worth using, no Node, no
+ * route to the internet and no shell but `sh`. What it does have is `ssh`,
+ * `tar` and a home directory. So four commands cross the wire and nothing else:
+ *
+ *   1. `uname -sm`                     - which tarball
+ *   2. `gitwarren --version`           - whether there is anything to do
+ *   3. `tar xzf -` reading stdin       - the bytes
+ *   4. `gitwarren service install`     - the launchers
+ *
+ * ## Why the host writes its own launchers
+ *
+ * Step 4 is the one worth defending. It would be a shorter file to `echo` two
+ * `sh` scripts into `~/.gitwarren/bin` from here, and it would be wrong twice
+ * over. `src/cli/launchers.ts` already knows what a launcher looks like, down
+ * to the symlink loop and the two exported paths that a login shell cannot work
+ * out for itself, and a second implementation across an ssh pipe would be a
+ * copy that drifts. More to the point, running the binary we just unpacked is
+ * the only *proof* that we picked the right architecture: a linux-arm64 tarball
+ * on an x86-64 box gets as far as a working `tar` and then fails at the first
+ * `exec`, and it is much better for that to happen here, during an install
+ * someone is watching, than at the first review they try to open.
+ *
+ * `--no-login-item` is there because a remote host is not where a login item
+ * belongs. The carrier spawns `gitwarren serve --stdio` on demand and hangs up
+ * after ten idle minutes (`core/hosts/pool.ts`); a daemon that also started
+ * itself at boot would be a second process on the same database that nobody
+ * asked for. The flag exists for exactly this - see the note in
+ * `src/cli/service.ts`, which named the VPS case before there was one.
+ *
+ * ## The versioned directory, and what is allowed to be atomic
+ *
+ * The tarball unpacks into `~/.gitwarren/daemon/<version>/` and the stable
+ * `~/.gitwarren/bin/gitwarren` points into it. That indirection is M2's, and it
+ * is what lets an agent config written today survive every upgrade after it:
+ * the launcher path never changes, only what it resolves to.
+ *
+ * Unpacking goes to a scratch directory beside the destination and is moved in
+ * with one `mv`, because a `tar` interrupted halfway through the destination
+ * itself leaves a directory that exists, looks installed and cannot run. On one
+ * filesystem `mv` is `rename`, which either happened or did not.
+ *
+ * ## What this deliberately does not do
+ *
+ * It does not report progress. There is no event channel yet - `shared/rpc.ts`
+ * reserves one for M6 and nothing emits on it - and inventing half of one for a
+ * progress bar would put a push-shaped hole in a request/response protocol for
+ * a wait that is a few seconds on a LAN. The screen says what is happening and
+ * how big the download is; the honest thing to do about the missing bar is to
+ * wait for the channel that other things also need.
+ *
+ * It also does not uninstall. `hosts.remove` forgets a host, which is a
+ * statement about this machine's list; going onto someone's server to delete a
+ * directory is a different act, and `rm -rf ~/.gitwarren` is one the person can
+ * type themselves and read before pressing return.
+ */
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { runOverSsh } from './ssh.js'
+import { resolveTarball, targetFromUname, type DaemonTarget } from './release.js'
+import { shellQuote } from '../shell-quote.js'
+import { APP_VERSION } from '../version.js'
+import { AppError } from '../../shared/errors.js'
+import type { InstallAction } from '../../shared/schemas.js'
+import type { HostRoute } from './pool.js'
+
+/** Where everything lives on the far end. `~` is expanded by the remote shell. */
+const REMOTE_ROOT = '$HOME/.gitwarren'
+
+/**
+ * What happened, minus the host row.
+ *
+ * `already-current` is a first-class outcome rather than a silent no-op: a
+ * person who pressed "Install" and saw nothing move has learned nothing, and
+ * the useful sentence is "0.1.7-beta.1 is already there". The service adds the
+ * row and hands the whole thing to the screen; this layer knows nothing about
+ * SQLite.
+ */
+export interface DaemonInstallReport {
+  action: InstallAction
+  /** What is on the host now. Read back from the launcher, not assumed. */
+  version: string
+  /** What was there before, or null for a host that had no GitWarren. */
+  previousVersion: string | null
+  target: DaemonTarget
+  /** Bytes streamed, or 0 when nothing had to be. For the sentence afterwards. */
+  bytes: number
+}
+
+export interface InstallOptions {
+  /** Reinstall even when the version already matches. */
+  force?: boolean
+  /** The version to put there. The asking machine's, unless a test says otherwise. */
+  version?: string
+  /** Swapped in tests; see `runOverSsh`. */
+  run?: typeof runOverSsh
+  resolve?: typeof resolveTarball
+}
+
+/**
+ * Ask the launcher what it is.
+ *
+ * Null covers both "no launcher" (127) and "a launcher too old to understand
+ * `--version`", which are the same thing as far as the next step is concerned:
+ * whatever is there cannot be identified, so it gets replaced. Nothing branches
+ * on the difference, so nothing here works to tell them apart.
+ */
+async function installedVersion(
+  target: string,
+  run: typeof runOverSsh
+): Promise<string | null> {
+  const { code, stdout } = await run({
+    target,
+    command: `${REMOTE_ROOT}/bin/gitwarren --version 2>/dev/null`
+  })
+  if (code !== 0) return null
+  const version = stdout.trim().split('\n').pop()?.trim()
+  return version || null
+}
+
+/**
+ * The script that receives the bytes.
+ *
+ * `sh`, not `bash`: a BSD host, a minimal container and a busybox WSL image all
+ * have the first and not reliably the second, and there is nothing here that
+ * needs more. No `--strip-components` for the same reason - it is a GNU and
+ * bsdtar spelling and busybox's `tar` has neither, so the archive's own
+ * `gitwarren-daemon/` directory is moved rather than stripped, which every
+ * `tar` in existence agrees about.
+ *
+ * `$$` in the scratch name is the remote shell's pid, so two installs onto one
+ * host cannot collide in the seconds they overlap.
+ */
+function unpackScript(version: string): string {
+  const quoted = shellQuote(version)
+  return [
+    'set -e',
+    `root=${REMOTE_ROOT}`,
+    `dest="$root/daemon"/${quoted}`,
+    `work="$root/daemon/.incoming.$$"`,
+    'mkdir -p "$root/daemon"',
+    'rm -rf "$work"',
+    'mkdir -p "$work"',
+    // The one command that reads the pipe. A failure here has to end the
+    // script, which is what `set -e` is for: continuing would move an empty
+    // directory into place and call it an install.
+    'tar xzf - -C "$work"',
+    '[ -x "$work/gitwarren-daemon/bin/gitwarren" ] || {',
+    '  echo "the tarball did not contain bin/gitwarren" >&2',
+    '  rm -rf "$work"',
+    '  exit 1',
+    '}',
+    // Move the old aside rather than deleting it first, so the window in which
+    // the destination does not exist is one rename wide.
+    'if [ -e "$dest" ]; then mv "$dest" "$work/.previous"; fi',
+    'mv "$work/gitwarren-daemon" "$dest"',
+    'rm -rf "$work"',
+    'echo "$dest"'
+  ].join('\n')
+}
+
+/**
+ * Install, or upgrade, GitWarren on a host.
+ *
+ * Throws `HOST_OFFLINE` when the machine cannot be reached and `INTERNAL` with
+ * the host's own stderr when a step ran and failed - the difference matters to
+ * the person reading it, and neither is a message this function invents.
+ */
+export async function installOnHost(
+  route: HostRoute,
+  { force = false, version = APP_VERSION, run = runOverSsh, resolve = resolveTarball }: InstallOptions = {}
+): Promise<DaemonInstallReport> {
+  const { target: sshTarget } = route
+
+  const uname = await run({ target: sshTarget, command: 'uname -sm' })
+  if (uname.code !== 0) {
+    throw new AppError(
+      'INTERNAL',
+      `\`uname -sm\` failed on ${sshTarget}: ${uname.stderr.trim() || `exit ${uname.code}`}`
+    )
+  }
+  const daemonTarget = targetFromUname(uname.stdout)
+
+  const previousVersion = await installedVersion(sshTarget, run)
+  if (previousVersion === version && !force) {
+    return { action: 'already-current', version, previousVersion, target: daemonTarget, bytes: 0 }
+  }
+
+  // Fetched before anything on the host is touched. A download that fails
+  // should leave the host exactly as it was, not part-way through an upgrade.
+  const tarball = await resolve(version, daemonTarget)
+  const bytes = (await stat(tarball)).size
+
+  const unpack = await run({
+    target: sshTarget,
+    command: unpackScript(version),
+    stdin: createReadStream(tarball)
+  })
+  if (unpack.code !== 0) {
+    throw new AppError(
+      'INTERNAL',
+      `Unpacking GitWarren on ${sshTarget} failed: ${unpack.stderr.trim() || `exit ${unpack.code}`}`
+    )
+  }
+
+  // The host writes its own launchers, and by running proves the tarball's
+  // `node` can execute here. See the note at the top of the file.
+  const launchers = await run({
+    target: sshTarget,
+    command: `${REMOTE_ROOT}/daemon/${shellQuote(version)}/bin/gitwarren service install --no-login-item`
+  })
+  if (launchers.code !== 0) {
+    throw new AppError(
+      'INTERNAL',
+      `GitWarren unpacked on ${sshTarget} but could not start: ` +
+        (launchers.stderr.trim() || `exit ${launchers.code}`) +
+        `. The tarball for ${daemonTarget} may be the wrong one for that machine.`
+    )
+  }
+
+  // Read back rather than assumed. This is the assertion that the launcher the
+  // carrier will spawn - the stable path, not the versioned one - now resolves
+  // to what we just put there.
+  const now = await installedVersion(sshTarget, run)
+  if (now !== version) {
+    throw new AppError(
+      'INTERNAL',
+      `${sshTarget} still reports ${now ?? 'no GitWarren'} after installing ${version}. ` +
+        'Something else on that machine is maintaining ~/.gitwarren/bin/gitwarren.'
+    )
+  }
+
+  return {
+    action: previousVersion === null ? 'installed' : 'upgraded',
+    version,
+    previousVersion,
+    target: daemonTarget,
+    bytes
+  }
+}

--- a/src/core/hosts/pool.ts
+++ b/src/core/hosts/pool.ts
@@ -87,6 +87,21 @@ interface Entry {
   state: HostState
   idleTimer: NodeJS.Timeout | null
   inFlight: number
+  /**
+   * Which connection the state describes. Incremented every time one is opened.
+   *
+   * A dying connection is noticed twice - the close handler sees the pipe end,
+   * and every request that was waiting on it rejects - and both of those are
+   * the *same* event. Counting them separately made one failed press of "Try
+   * now" advance the backoff by two rungs, so a machine that was switched off
+   * went from a one-second wait to a fifteen-second one after two attempts
+   * instead of four. Found against `pc-wsl` in M4.2: the pool's own tests use a
+   * fake connection that rejects a request without ever closing, which is a
+   * shape a real `ssh` never has.
+   */
+  generation: number
+  /** The generation a failure has already been counted for. */
+  failedGeneration: number | null
 }
 
 export interface HostPool {
@@ -123,7 +138,9 @@ export function createHostPool({
       connection: null,
       state: { connected: false, failures: 0 },
       idleTimer: null,
-      inFlight: 0
+      inFlight: 0,
+      generation: 0,
+      failedGeneration: null
     }
     entries.set(hostId, created)
     return created
@@ -169,8 +186,36 @@ export function createHostPool({
     connection?.close()
   }
 
-  /** A failure moves the host along the backoff ladder. */
-  const recordFailure = (hostId: number, entry: Entry, message: string): void => {
+  /**
+   * A failure moves the host along the backoff ladder, once per connection.
+   *
+   * `generation` is what makes it once. See the note on `Entry.generation`: the
+   * end of a pipe and the rejection of what was travelling through it are one
+   * event seen from two places, and only the first of them adds a rung to the
+   * ladder.
+   *
+   * The second still replaces the message, and that is not a detail. The close
+   * handler arrives first with "the connection closed", because that is all
+   * that is known at the instant stdout ends; the request's own failure arrives
+   * a moment later having waited for `ssh` to exit, and says "GitWarren is not
+   * installed on xfor@pc-wsl". Keeping the first message because it was first
+   * would undo the thing M4.1 went to some trouble to get right - so the count
+   * takes the earliest and the explanation takes the latest.
+   */
+  const recordFailure = (
+    hostId: number,
+    entry: Entry,
+    message: string,
+    generation: number
+  ): void => {
+    if (entry.failedGeneration === generation) {
+      if (entry.state.lastError === message) return
+      entry.state = { ...entry.state, lastError: message }
+      publish(hostId, entry)
+      return
+    }
+    entry.failedGeneration = generation
+
     const failures = entry.state.failures + 1
     // The last rung repeats forever; `?? 0` is unreachable and is there because
     // a tuple index is not something the compiler can prove is in range.
@@ -211,6 +256,9 @@ export function createHostPool({
         throw OFFLINE(entry.state.lastError ?? `${route.target} is not reachable.`)
       }
 
+      entry.generation += 1
+      const generation = entry.generation
+
       entry.connection = connect(route, (error) => {
         // The pipe died. Whether that is a failure depends on whether anything
         // was expecting it: a connection closed by the idle timer has already
@@ -218,7 +266,7 @@ export function createHostPool({
         // ladder as though the machine had gone away.
         const current = entries.get(route.id)
         if (!current || current.connection === null) return
-        recordFailure(route.id, current, error.message)
+        recordFailure(route.id, current, error.message, generation)
       })
     }
 
@@ -233,6 +281,9 @@ export function createHostPool({
   ): Promise<RpcResult<M>> => {
     const entry = entryFor(route.id)
     const connection = connectionFor(route, ignoreBackoff)
+    // Read after the connection is in hand, so it names the connection this
+    // request is actually travelling on rather than whatever was there before.
+    const generation = entry.generation
 
     entry.inFlight += 1
     try {
@@ -249,7 +300,7 @@ export function createHostPool({
         // and what `ssh` printed - lands a moment after the stream ended. See
         // `diagnostics` in `ssh.ts`.
         const detail = await connection.diagnostics()
-        recordFailure(route.id, entry, detail || appError.message)
+        recordFailure(route.id, entry, detail || appError.message, generation)
         throw OFFLINE(detail || appError.message)
       }
       recordSuccess(route.id, entry)

--- a/src/core/hosts/release.ts
+++ b/src/core/hosts/release.ts
@@ -1,0 +1,221 @@
+/**
+ * Finding the right daemon tarball, and having it locally before a host is
+ * asked to accept it.
+ *
+ * The whole reason this module is on the *asking* side rather than on the host
+ * is stated in M4: the host needs nothing installed but git. It does not fetch,
+ * it does not resolve a version, and it never talks to GitHub — the machine
+ * with a browser and a person at it does all of that, and what crosses the pipe
+ * is bytes. That is what makes an air-gapped box, a locked-down VPS or a WSL
+ * distro behind a corporate proxy work without a single exception in the code.
+ *
+ * ## The name is the contract
+ *
+ * `scripts/build-daemon-tarball.mjs` says so at the bottom of the file, and
+ * this is the other end of that sentence: `gitwarren-daemon-<version>-<target>.tar.gz`
+ * is composed here from a version and a `uname`, and fetched by URL. One
+ * request, no listing and no search — which matters because a release listing
+ * needs an API call, an API call needs a token when the rate limit bites, and a
+ * review tool has no business asking for one.
+ *
+ * ## Why a local directory can stand in for the release
+ *
+ * `GITWARREN_DAEMON_TARBALL_DIR` is not a test seam bolted on afterwards. There
+ * are two ordinary situations where the release cannot answer: a development
+ * build, whose version is `0.0.0-dev` and which no release has ever heard of,
+ * and a machine that genuinely has no route to github.com but does have the
+ * file on a stick. Both want the same thing — "use this file" — and both are
+ * better served by a directory than by a flag on a form, because the answer is
+ * a property of the *machine* and not of the host being added.
+ *
+ * ## Guarding on the magic bytes rather than on the status code
+ *
+ * A draft release's asset URL 404s, which is caught. The failure worth guarding
+ * against is the other one: a proxy or a login wall that answers 200 with a
+ * page of HTML, which `fetch` reports as a perfectly good response and which
+ * lands on disk as `gitwarren-daemon-….tar.gz`. Cached, it would then fail on
+ * every host it was streamed to, with `tar` complaining somewhere across an ssh
+ * pipe. Two bytes at the front settle it here, where the URL that produced them
+ * is still in scope.
+ */
+import { createWriteStream } from 'node:fs'
+import { mkdir, open, rename, rm, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { pipeline } from 'node:stream/promises'
+import { Readable } from 'node:stream'
+import { getDaemonCacheDirectory } from '../paths.js'
+import { AppError } from '../../shared/errors.js'
+
+/**
+ * The four the release builds. Windows is absent on purpose and not by
+ * omission — see the note in `scripts/build-daemon-tarball.mjs`; a `.tar.gz`
+ * unpacked by hand is not how anything is installed there, and M5 reaches a
+ * Windows machine's WSL with the linux tarball anyway.
+ */
+export const DAEMON_TARGETS = ['linux-x64', 'linux-arm64', 'darwin-x64', 'darwin-arm64'] as const
+export type DaemonTarget = (typeof DAEMON_TARGETS)[number]
+
+/** Set to a directory of `gitwarren-daemon-*.tar.gz` files to use those instead. */
+export const TARBALL_DIR_ENV_VAR = 'GITWARREN_DAEMON_TARBALL_DIR'
+
+const RELEASE_BASE = 'https://github.com/klarluft/gitwarren-app/releases/download'
+
+/** gzip. Checked on the way in; see the note at the top. */
+const GZIP_MAGIC = [0x1f, 0x8b]
+
+/**
+ * `uname -sm`, as a tarball target.
+ *
+ * `uname` is the right question because it is the only one every host can
+ * answer: it predates all of this, it is in the base install of everything with
+ * an `ssh` daemon, and it costs nothing on a connection that is already open.
+ * Asking the host's package manager or reading `/etc/os-release` would be
+ * asking about a *distribution*, which is not what a tarball of a Node binary
+ * and a prebuilt addon cares about.
+ *
+ * The arm spellings are both real: Linux says `aarch64` and macOS says `arm64`
+ * for the same silicon, and a host answering one of them while the file is
+ * named the other is the whole reason this function is not a lookup table
+ * written inline at the call site.
+ */
+export function targetFromUname(output: string): DaemonTarget {
+  const [kernel, machine] = output.trim().split(/\s+/)
+
+  const arch =
+    machine === 'x86_64' || machine === 'amd64'
+      ? 'x64'
+      : machine === 'aarch64' || machine === 'arm64'
+        ? 'arm64'
+        : null
+
+  if (kernel === 'Linux' && arch) return `linux-${arch}` as DaemonTarget
+  if (kernel === 'Darwin' && arch) return `darwin-${arch}` as DaemonTarget
+
+  throw new AppError(
+    'INVALID_INPUT',
+    `There is no GitWarren daemon for ${output.trim() || 'that machine'}. ` +
+      'Linux and macOS on x86-64 or arm64 are what the release builds.'
+  )
+}
+
+export function tarballName(version: string, target: DaemonTarget): string {
+  return `gitwarren-daemon-${version}-${target}.tar.gz`
+}
+
+export function tarballUrl(version: string, target: DaemonTarget): string {
+  return `${RELEASE_BASE}/v${version}/${tarballName(version, target)}`
+}
+
+async function isFile(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Reject anything that is not a gzip stream, naming where it came from.
+ *
+ * Reads the file rather than the response so that a cached file corrupted by a
+ * full disk is caught on the next install too, not only on the download that
+ * wrote it.
+ */
+async function assertGzip(path: string, source: string): Promise<void> {
+  const handle = await open(path, 'r')
+  try {
+    const { buffer, bytesRead } = await handle.read(Buffer.alloc(2), 0, 2, 0)
+    if (bytesRead === 2 && buffer[0] === GZIP_MAGIC[0] && buffer[1] === GZIP_MAGIC[1]) return
+  } finally {
+    await handle.close()
+  }
+  throw new AppError(
+    'INTERNAL',
+    `${source} did not return a GitWarren daemon tarball. It may be a login page or ` +
+      'an error page served with a success status.'
+  )
+}
+
+export interface ResolveTarballOptions {
+  /** Where downloads are kept. Defaults to the app's daemon cache. */
+  cacheDirectory?: string
+  /** Checked before the cache and before the network. Defaults to the env var. */
+  localDirectory?: string | undefined
+  /** Swappable so the tests can serve a real file over a real socket. */
+  baseUrl?: string
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * The path to a local file holding this version's tarball for `target`.
+ *
+ * Three places, in the order of "already answered" to "costs a download": a
+ * directory the machine was told about, the cache, then the release. The
+ * download lands on a `.partial` named after the process so that two installs
+ * racing on two hosts of the same architecture cannot hand each other a half a
+ * file — the rename at the end is what publishes it, and rename is the only
+ * filesystem operation that can promise that.
+ */
+export async function resolveTarball(
+  version: string,
+  target: DaemonTarget,
+  {
+    cacheDirectory = getDaemonCacheDirectory(),
+    localDirectory = process.env[TARBALL_DIR_ENV_VAR]?.trim() || undefined,
+    baseUrl = RELEASE_BASE,
+    fetchImpl = fetch
+  }: ResolveTarballOptions = {}
+): Promise<string> {
+  const name = tarballName(version, target)
+
+  if (localDirectory) {
+    const local = join(localDirectory, name)
+    if (await isFile(local)) {
+      await assertGzip(local, local)
+      return local
+    }
+    // Named and missing is an error rather than a quiet fall-through to the
+    // network: someone who set this variable meant it, and silently downloading
+    // a *different* build than the one they staged is the surprise worth
+    // avoiding on a machine where the two can differ.
+    throw new AppError(
+      'NOT_FOUND',
+      `${TARBALL_DIR_ENV_VAR} is set to ${localDirectory}, which has no ${name}. ` +
+        'Build it with `node scripts/build-daemon-tarball.mjs ' +
+        `${target}\`, or unset the variable to download it.`
+    )
+  }
+
+  const cached = join(cacheDirectory, name)
+  if (await isFile(cached)) {
+    await assertGzip(cached, cached)
+    return cached
+  }
+
+  const url = `${baseUrl}/v${version}/${name}`
+  const response = await fetchImpl(url)
+  if (!response.ok || !response.body) {
+    throw new AppError(
+      response.status === 404 ? 'NOT_FOUND' : 'INTERNAL',
+      `Could not download the GitWarren daemon for ${target} (${response.status} from ${url}). ` +
+        (response.status === 404
+          ? `Version ${version} may not be published yet — a draft release's files cannot be ` +
+            `downloaded. Set ${TARBALL_DIR_ENV_VAR} to a directory holding ${name} to install ` +
+            'from a build you have locally.'
+          : 'Try again in a moment.')
+    )
+  }
+
+  await mkdir(cacheDirectory, { recursive: true })
+  const partial = `${cached}.${process.pid}.partial`
+  try {
+    await pipeline(Readable.fromWeb(response.body), createWriteStream(partial))
+    await assertGzip(partial, url)
+    await rename(partial, cached)
+  } catch (error) {
+    await rm(partial, { force: true })
+    throw AppError.from(error)
+  }
+
+  return cached
+}

--- a/src/core/hosts/ssh.ts
+++ b/src/core/hosts/ssh.ts
@@ -41,9 +41,13 @@
  *
  * ## What this module refuses to do
  *
- * It does not install anything (M4.2 does, and until then a host without the
- * daemon fails with a message saying so), it does not authenticate (`ssh` did
- * that before we saw a byte), and it does not decide what any method means.
+ * It does not authenticate (`ssh` did that before we saw a byte) and it does
+ * not decide what any method means. Since M4.2 it owns one thing besides the
+ * carrier - `runOverSsh`, a single command on a host - because "how this app
+ * invokes ssh" is one decision and `SSH_OPTIONS` is where it is written down.
+ * What that is *used* for is `core/hosts/install.ts`; the multiplexing master
+ * is why `uname -sm` on a host with a connection open costs a process spawn
+ * and nothing else.
  *
  * The one rule it enforces itself is that a `hosts.*` method is never sent. A
  * host list is a property of the install a person is sitting at: forwarding it
@@ -55,6 +59,7 @@
  * the machine.
  */
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import type { Readable } from 'node:stream'
 import { createStdioClient, type StdioClient } from '../rpc/stdio-client.js'
 import { AppError } from '../../shared/errors.js'
 import type { RpcMethod, RpcParams, RpcResult } from '../../shared/rpc.js'
@@ -245,6 +250,106 @@ export function connectOverSsh({
       return (exitReason ?? closeError?.message ?? stderr).trim()
     }
   }
+}
+
+export interface RunOverSshOptions {
+  target: string
+  /** A `sh` script. It crosses as one argument and the login shell runs it. */
+  command: string
+  /** Piped to the remote command's stdin. This is how a tarball gets there. */
+  stdin?: Readable
+  spawnProcess?: typeof spawn
+}
+
+export interface SshRunResult {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * Run one command on a host and wait for it to finish.
+ *
+ * Deliberately resolves on a non-zero exit rather than rejecting. Every caller
+ * asks a question the host is allowed to answer with "no": `uname` on a machine
+ * that answered ssh, `gitwarren --version` on a machine that has never had
+ * GitWarren. Exit 127 *is* the answer to the second, and a throw would make the
+ * ordinary first install arrive as a failure. Not reaching the host at all is
+ * the exception and does reject, because that is not an answer to anything.
+ *
+ * stdout is captured whole, which is safe only because everything run through
+ * here prints a line or two. The tarball travels the other way, on stdin.
+ */
+export function runOverSsh({
+  target,
+  command,
+  stdin,
+  spawnProcess = spawn
+}: RunOverSshOptions): Promise<SshRunResult> {
+  return new Promise((resolve, reject) => {
+    let child: ChildProcessWithoutNullStreams
+    try {
+      child = spawnProcess('ssh', [...SSH_OPTIONS, target, command], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // No shell locally, for the reason `connectOverSsh` gives: `target`
+        // came from a form. The *remote* shell is what runs `command`, which is
+        // why everything interpolated into it is quoted by the caller that
+        // built it - see `core/shell-quote.ts`.
+        shell: false,
+        windowsHide: true
+      })
+    } catch (error) {
+      reject(
+        new AppError(
+          'HOST_OFFLINE',
+          `Could not start ssh: ${error instanceof Error ? error.message : String(error)}`
+        )
+      )
+      return
+    }
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk: string) => {
+      stderr = (stderr + chunk).slice(-MAX_STDERR_BYTES)
+    })
+
+    child.on('error', (error: Error) => {
+      reject(new AppError('HOST_OFFLINE', `Could not run ssh: ${error.message}`))
+    })
+
+    if (stdin) {
+      // A host that dies mid-transfer closes the pipe under us, and an
+      // unhandled EPIPE on a stream nobody awaits takes the whole process down.
+      // The exit status below is the real report; this only has to not be fatal.
+      child.stdin.on('error', () => {})
+      stdin.on('error', (error: Error) => child.stdin.destroy(error))
+      stdin.pipe(child.stdin)
+    } else {
+      child.stdin.end()
+    }
+
+    // `close` rather than `exit`: the streams have to be drained before stdout
+    // is read, and `exit` can arrive with the last chunk still in flight.
+    child.on('close', (code, signal) => {
+      if (signal) {
+        reject(new AppError('HOST_OFFLINE', `ssh to ${target} was terminated (${signal}).`))
+        return
+      }
+      // 255 is ssh's own "I could not do my half of this", and is never the
+      // remote command's status. See `describeExit`.
+      if (code === 255) {
+        reject(new AppError('HOST_OFFLINE', describeExit(target, code, null, stderr)))
+        return
+      }
+      resolve({ code: code ?? 0, stdout, stderr })
+    })
+  })
 }
 
 /**

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -53,3 +53,25 @@ export function ensureDataDirectory(): string {
   mkdirSync(dir, { recursive: true })
   return dir
 }
+
+/**
+ * Where daemon tarballs downloaded for other machines are kept.
+ *
+ * In the data directory rather than beside the install, for the reason M4's
+ * installer exists at all: the file is fetched *once* and then streamed to as
+ * many hosts as share an architecture, so it has to outlive an app update. It
+ * is also the half of the design that makes an air-gapped host work — the
+ * machine with a browser does the downloading, and the host on the other end of
+ * the pipe never talks to GitHub.
+ *
+ * Deliberately not swept on startup. A 45 MB file per architecture per version
+ * is small next to what it saves on a slow link, and deleting one is
+ * `rm -rf` in a directory the user can find; guessing when a version stops
+ * being interesting is the kind of cleverness that deletes the file someone was
+ * about to reinstall from.
+ */
+export const DAEMON_CACHE_DIR_NAME = 'daemon-cache'
+
+export function getDaemonCacheDirectory(): string {
+  return join(getDataDirectory(), DAEMON_CACHE_DIR_NAME)
+}

--- a/src/core/rpc/dispatcher.ts
+++ b/src/core/rpc/dispatcher.ts
@@ -158,6 +158,7 @@ const handlers: {
   'hosts.update': (params) => hostsService.update(params),
   'hosts.remove': (params) => hostsService.remove(params),
   'hosts.probe': (params) => hostsService.probe(params),
+  'hosts.install': (params) => hostsService.install(params),
 
   'repositories.list': () => repositoriesService.list(),
   'repositories.get': (params) => repositoriesService.get(params),

--- a/src/core/services/hosts.ts
+++ b/src/core/services/hosts.ts
@@ -29,20 +29,28 @@
  * because they asked for a repository list. The pool decides when, and the only
  * deliberate reach is `probe`, which exists so the Hosts screen can offer a
  * button that says "try now" and mean it.
+ *
+ * `install` is the second deliberate reach, and the exception that proves the
+ * rule: putting software on somebody's machine is emphatically something a
+ * person does, and it is the one thing here that must never happen because a
+ * screen happened to render.
  */
 import { asc, eq } from 'drizzle-orm'
 import { getDatabase } from '../db/client.js'
 import { hosts, type HostRow } from '../db/schema.js'
 import { hostPool, type HostRoute } from '../hosts/pool.js'
+import { installOnHost } from '../hosts/install.js'
 import { AppError } from '../../shared/errors.js'
 import { parseWithSchema as parse } from '../../shared/validation.js'
 import {
   addHostInputSchema,
   getHostInputSchema,
+  installOnHostInputSchema,
   removeHostInputSchema,
   updateHostInputSchema,
   type Host,
-  type HostWithState
+  type HostWithState,
+  type InstallReport
 } from '../../shared/schemas.js'
 
 function toHost(row: HostRow): Host {
@@ -54,6 +62,7 @@ function toHost(row: HostRow): Host {
     target: row.target,
     editorTarget: row.editorTarget,
     lastSeenAt: row.lastSeenAt,
+    daemonVersion: row.daemonVersion,
     createdAt: row.createdAt
   }
 }
@@ -101,9 +110,13 @@ function asDuplicateError(error: unknown, target: string): AppError {
  * "the pipe opened" and "the daemon answered" are different claims and only the
  * second one is worth writing down.
  */
-function recordSeen(row: HostRow, instanceId: string | null): void {
+function recordSeen(row: HostRow, instanceId: string | null, daemonVersion?: string): void {
   const database = getDatabase()
   const lastSeenAt = new Date().toISOString()
+  // Written on every sighting rather than only on a change, because the host
+  // being upgraded by someone else is exactly the case this column exists to
+  // notice, and it costs the same UPDATE either way.
+  const version = daemonVersion ? { daemonVersion } : {}
 
   if (instanceId && instanceId !== row.instanceId) {
     const other = database.select().from(hosts).where(eq(hosts.instanceId, instanceId)).get()
@@ -115,11 +128,19 @@ function recordSeen(row: HostRow, instanceId: string | null): void {
         { target: ['This machine is already in the list under another name.'] }
       )
     }
-    database.update(hosts).set({ instanceId, lastSeenAt }).where(eq(hosts.id, row.id)).run()
+    database
+      .update(hosts)
+      .set({ instanceId, lastSeenAt, ...version })
+      .where(eq(hosts.id, row.id))
+      .run()
     return
   }
 
-  database.update(hosts).set({ lastSeenAt }).where(eq(hosts.id, row.id)).run()
+  database
+    .update(hosts)
+    .set({ lastSeenAt, ...version })
+    .where(eq(hosts.id, row.id))
+    .run()
 }
 
 export const hostsService = {
@@ -224,16 +245,72 @@ export const hostsService = {
 
     // Reached. Ask who that was, and remember it.
     let instanceId: string | null = null
+    let version: string | undefined
     try {
       const info = await hostPool.request(routeFor(row), 'app.instance')
       instanceId = info.instanceId
+      version = info.version
     } catch {
       // A host too old to answer `app.instance` is still a usable host; it just
       // stays anonymous, and `instance_id` keeps saying "not met" - which is
       // true in the only sense that matters here.
     }
 
-    recordSeen(row, instanceId)
+    recordSeen(row, instanceId, version)
     return withState(requireRow(id))
+  },
+
+  /**
+   * Put GitWarren on a host, and note what it turned out to be running.
+   *
+   * The connection is dropped first, and that is not tidiness. The pool may be
+   * holding a pipe into the daemon that is about to be replaced on disk, and an
+   * `ssh` still attached to the old `lib/gitwarren.cjs` would go on answering
+   * from a directory that has been moved out from under it - the version this
+   * function reads back at the end would then be the new one while the carrier
+   * kept using the old. Hanging up costs a 178 ms reconnect on the multiplexed
+   * channel and removes the whole question.
+   *
+   * The install itself is `core/hosts/install.ts`; what belongs here is what
+   * touches the database - forgetting the connection, writing down the version
+   * that is now over there, and then reaching the machine again.
+   *
+   * That last step is not tidiness either. Without it the row handed back says
+   * `connected: false, failures: 0`, which the screen renders as "not tried
+   * yet" - immediately after somebody watched a progress spinner put GitWarren
+   * onto that machine. The daemon has never been *spoken to*, only installed,
+   * and the honest way to fix the sentence is to speak to it. It costs a
+   * multiplexed reconnect, and it is how the instance id gets learned for a
+   * host that has just met GitWarren for the first time.
+   *
+   * The probe's own failure is swallowed on purpose: an install that worked
+   * followed by a connection that did not is still an install that worked, and
+   * reporting it as a failed install would send someone to fix the wrong thing.
+   * Whatever went wrong is on the row, in `state.lastError`, where the screen
+   * shows it.
+   */
+  async install(input: unknown): Promise<InstallReport> {
+    const { id, force } = parse(installOnHostInputSchema, input)
+    const row = requireRow(id)
+
+    // The pool may be holding a pipe into the daemon that is about to be
+    // replaced on disk. See the note above.
+    hostPool.disconnect(id)
+    const report = await installOnHost(routeFor(row), { force })
+
+    getDatabase()
+      .update(hosts)
+      .set({ daemonVersion: report.version })
+      .where(eq(hosts.id, id))
+      .run()
+
+    try {
+      await hostsService.probe({ id })
+    } catch {
+      // Two machines under one name is the case that lands here, and it is
+      // reported the next time anybody probes rather than as a failed install.
+    }
+
+    return { ...report, host: withState(requireRow(id)) }
   }
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 /**
- * The app shell and its four screens.
+ * The app shell and its five screens.
  *
  * Routing is a hash and a switch (see `lib/router`). The screens are given
  * different amounts of the window - see `reviewWidth` - because a diff needs
@@ -19,6 +19,8 @@ import { AgentAccessCard } from './features/agent/agent-access-card'
 import { AgentAccessPage } from './features/agent/agent-access-page'
 import { CommandCenter } from './features/commands/command-center'
 import { CommandRegistryProvider } from './features/commands/command-registry'
+import { HostsCard } from './features/hosts/hosts-card'
+import { HostsPage } from './features/hosts/hosts-page'
 import { SettingsPanel } from './features/settings/settings-panel'
 import { RepositoryDetail } from './features/repositories/repository-detail'
 import { RepositoryList } from './features/repositories/repository-list'
@@ -74,6 +76,7 @@ export function App() {
 
             {route.name === 'repositories' && <HomeScreen />}
             {route.name === 'agent' && <AgentAccessPage />}
+            {route.name === 'hosts' && <HostsPage />}
             {route.name === 'repository' && <RepositoryDetail repositoryId={route.repositoryId} />}
             {route.name === 'review' && (
               <ReviewDetail reviewId={route.reviewId} tab={route.tab} focus={route.focus} />
@@ -111,6 +114,7 @@ function HomeScreen() {
 
       <div className="flex flex-col gap-6">
         <RepositoryList />
+        <HostsCard />
         <AgentAccessCard />
         <SettingsPanel />
       </div>

--- a/src/renderer/src/features/commands/command-center.tsx
+++ b/src/renderer/src/features/commands/command-center.tsx
@@ -7,7 +7,16 @@
  * declare commands and this binds whatever is currently declared.
  */
 import { useCallback, useMemo, useState, type RefObject } from 'react'
-import { ArrowLeft, ArrowRight, ArrowUpToLine, Home, Keyboard, Plug, Search } from 'lucide-react'
+import {
+  ArrowLeft,
+  ArrowRight,
+  ArrowUpToLine,
+  Home,
+  Keyboard,
+  Plug,
+  Search,
+  Server
+} from 'lucide-react'
 import { formatStep } from '@/lib/keys'
 import { useHotkeys, type Hotkey } from '@/lib/hotkeys'
 import { goBack, navigate } from '@/lib/router'
@@ -94,6 +103,15 @@ export function CommandCenter({ scroller }: { scroller: RefObject<HTMLElement | 
         keywords: 'mcp setup prompt claude codex cursor configure',
         icon: Plug,
         run: () => navigate({ name: 'agent' })
+      },
+      {
+        id: 'nav:hosts',
+        label: 'Go to hosts',
+        group: 'Navigate',
+        keys: 'g s',
+        keywords: 'ssh machines remote server vps wsl install daemon',
+        icon: Server,
+        run: () => navigate({ name: 'hosts' })
       },
       {
         id: 'nav:back',

--- a/src/renderer/src/features/commands/command-registry.tsx
+++ b/src/renderer/src/features/commands/command-registry.tsx
@@ -39,6 +39,10 @@ export const COMMAND_GROUPS = [
   'Navigate',
   'Reviews',
   'Repositories',
+  // Below Repositories because it is contributed by one screen that has to be
+  // gone to, so it is only ever present when it is already what you are
+  // looking at.
+  'Hosts',
   'Application'
 ] as const
 

--- a/src/renderer/src/features/hosts/host-card.tsx
+++ b/src/renderer/src/features/hosts/host-card.tsx
@@ -1,0 +1,142 @@
+/**
+ * One machine, and everything that can be done to it from here.
+ *
+ * Unlike a repository card this one is not a link. A repository leads somewhere
+ * - its reviews - and a host leads nowhere until M4.3 puts repositories under
+ * one; making the whole row clickable now would mean teaching people a gesture
+ * and then changing what it does. The actions are buttons, and the card is a
+ * card.
+ *
+ * ## Why the failure is on the card and not behind a tooltip
+ *
+ * `state.lastError` is the sentence `ssh` produced - "Could not resolve
+ * hostname", "Permission denied (publickey)", "GitWarren is not installed on
+ * xfor@pc-wsl". Every one of those tells the person exactly what to go and fix,
+ * and none of them is discoverable if it lives in a tooltip on a red dot. It
+ * costs two lines on the rows that are failing and nothing at all on the rows
+ * that are not.
+ */
+import { Download, Loader2, Pencil, Plug, RefreshCw, Trash2 } from 'lucide-react'
+import { Breakable } from '@/components/breakable'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Tooltip } from '@/components/ui/tooltip'
+import { DaemonVersionBadge, ReachabilityBadge, needsInstall } from './host-status'
+import type { HostWithState } from '@shared/schemas'
+
+interface HostCardProps {
+  host: HostWithState
+  appVersion: string | undefined
+  /** True while this host is the one being probed or installed onto. */
+  busy: 'probe' | 'install' | null
+  onProbe: (host: HostWithState) => void
+  onInstall: (host: HostWithState) => void
+  onEdit: (host: HostWithState) => void
+  onRemove: (host: HostWithState) => void
+}
+
+export function HostCard({
+  host,
+  appVersion,
+  busy,
+  onProbe,
+  onInstall,
+  onEdit,
+  onRemove
+}: HostCardProps) {
+  const wanted = needsInstall(host, appVersion)
+  const anythingBusy = busy !== null
+
+  return (
+    <Card className="flex flex-col gap-3 p-4">
+      <div className="flex items-start gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="truncate font-medium" title={host.label}>
+              {host.label}
+            </h3>
+            <ReachabilityBadge host={host} />
+            <DaemonVersionBadge host={host} appVersion={appVersion} />
+          </div>
+          {/* Wraps rather than truncates, for the reason the repository card
+              gives about paths: the tail of `xfor@100.78.0.23` is the half that
+              says which machine this is. */}
+          <p data-selectable className="mt-1 break-words font-mono text-xs text-muted-foreground">
+            <Breakable text={host.target} />
+          </p>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          <Tooltip label="Connect to this host now">
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={`Try ${host.label} now`}
+              disabled={anythingBusy}
+              onClick={() => onProbe(host)}
+            >
+              {busy === 'probe' ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+            </Button>
+          </Tooltip>
+          <Tooltip label="Edit this host">
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={`Edit ${host.label}`}
+              disabled={anythingBusy}
+              onClick={() => onEdit(host)}
+            >
+              <Pencil />
+            </Button>
+          </Tooltip>
+          <Tooltip label="Forget this host">
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={`Remove ${host.label}`}
+              className="text-muted-foreground hover:text-destructive"
+              disabled={anythingBusy}
+              onClick={() => onRemove(host)}
+            >
+              <Trash2 />
+            </Button>
+          </Tooltip>
+        </div>
+      </div>
+
+      {host.state.lastError && !host.state.connected && (
+        <p
+          role="status"
+          className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive"
+        >
+          <Breakable text={host.state.lastError} />
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          variant={wanted ? 'default' : 'outline'}
+          disabled={anythingBusy}
+          onClick={() => onInstall(host)}
+        >
+          {busy === 'install' ? <Loader2 className="animate-spin" /> : <Download />}
+          {host.daemonVersion === null
+            ? 'Install GitWarren'
+            : wanted
+              ? 'Update GitWarren'
+              : 'Reinstall'}
+        </Button>
+        {/* Said here rather than only in the install dialog: it is the sentence
+            that explains why a host with nothing on it is a normal starting
+            point rather than a problem to solve before adding it. */}
+        {host.daemonVersion === null && (
+          <p className="text-xs text-muted-foreground">
+            <Plug className="mr-1 inline size-3 align-[-2px]" />
+            The host needs nothing but git — GitWarren is sent over the same connection.
+          </p>
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/src/renderer/src/features/hosts/host-form-dialog.tsx
+++ b/src/renderer/src/features/hosts/host-form-dialog.tsx
@@ -1,0 +1,208 @@
+/**
+ * Add / edit a host.
+ *
+ * One component for both, like `repository-form-dialog.tsx`, and validated with
+ * the same schemas the service re-parses on the other side - so nothing can be
+ * accepted here that the service would reject.
+ *
+ * ## Three fields, and one of them is usually left alone
+ *
+ * The target is the whole of the interaction. It is handed to `ssh` verbatim,
+ * which means every `~/.ssh/config` alias someone already has works, and it
+ * carries the user because spike S1 found that a bare MagicDNS name asks for
+ * the *client's* username and gets refused by the tailnet policy. Hence the
+ * placeholder: `xfor@pc-wsl`, not `pc-wsl`.
+ *
+ * There is no "test connection" button on the form. Adding a host that cannot
+ * be reached is a perfectly ordinary thing to do — the machine is asleep, or
+ * the tailnet is not up yet — and a form that refused would be wrong about a
+ * situation it cannot see. The row lands in the list and says "Not tried yet",
+ * with "Try now" beside it.
+ */
+import { useState, type FormEvent } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field'
+import { Input } from '@/components/ui/input'
+import { errorMessage, firstFieldError } from '@/lib/errors'
+import { useHostMutations } from './use-hosts'
+import { addHostInputSchema, updateHostInputSchema } from '@shared/schemas'
+import { parseWithSchema } from '@shared/validation'
+import type { Host } from '@shared/schemas'
+
+interface HostFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Present when editing; absent when adding. */
+  host?: Host | undefined
+}
+
+export function HostFormDialog({ open, onOpenChange, host }: HostFormDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        {/* Mounted only while open, which is what resets the fields between
+            openings - fresh mount, fresh `useState`, nothing left over. */}
+        {open && (
+          <HostForm key={host?.id ?? 'new'} host={host} onDone={() => onOpenChange(false)} />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function HostForm({ host, onDone }: { host: Host | undefined; onDone: () => void }) {
+  const isEditing = host !== undefined
+  const { addHost, updateHost } = useHostMutations()
+
+  const [target, setTarget] = useState(host?.target ?? '')
+  const [label, setLabel] = useState(host?.label ?? '')
+  const [editorTarget, setEditorTarget] = useState(host?.editorTarget ?? '')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<unknown>(null)
+
+  async function submit(event: FormEvent): Promise<void> {
+    event.preventDefault()
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      if (host) {
+        const input = parseWithSchema(updateHostInputSchema, {
+          id: host.id,
+          label: label.trim(),
+          ...(target.trim() !== host.target ? { target: target.trim() } : {}),
+          // Null rather than omitted when it has been cleared: null is how the
+          // schema spells "go back to deriving it from the target", and
+          // omitting it would leave the old value in place.
+          editorTarget: editorTarget.trim() || null
+        })
+        await updateHost(input)
+      } else {
+        const trimmedLabel = label.trim()
+        const trimmedEditor = editorTarget.trim()
+        const input = parseWithSchema(addHostInputSchema, {
+          target: target.trim(),
+          // Omitted rather than empty, so the service applies its own default -
+          // the target with any `user@` taken off.
+          ...(trimmedLabel ? { label: trimmedLabel } : {}),
+          ...(trimmedEditor ? { editorTarget: trimmedEditor } : {})
+        })
+        await addHost(input)
+      }
+      onDone()
+    } catch (caught) {
+      setError(caught)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const targetError = firstFieldError(error, 'target')
+  const labelError = firstFieldError(error, 'label')
+  const generalError = error && !targetError && !labelError ? errorMessage(error) : null
+
+  return (
+    <form
+      onSubmit={(event) => {
+        void submit(event)
+      }}
+      noValidate
+    >
+      <DialogHeader>
+        <DialogTitle>{isEditing ? 'Edit host' : 'Add host'}</DialogTitle>
+        <DialogDescription>
+          {isEditing
+            ? 'Rename this machine, or point it somewhere else if the address changed.'
+            : 'Anything your own ssh can reach: a config alias, a tailnet name, user@address. ' +
+              'GitWarren never asks for a password — your SSH agent and config do the ' +
+              'authenticating.'}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="flex flex-col gap-4">
+        <Field>
+          <FieldLabel htmlFor="host-target">SSH host</FieldLabel>
+          <Input
+            id="host-target"
+            value={target}
+            onChange={(event) => setTarget(event.target.value)}
+            placeholder="user@machine"
+            className="font-mono text-xs"
+            data-invalid={targetError ? '' : undefined}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <FieldError>{targetError}</FieldError>
+          {!targetError && (
+            <FieldDescription>
+              Include the user name: a bare tailnet name asks for your local one.
+            </FieldDescription>
+          )}
+        </Field>
+
+        <Field>
+          <FieldLabel htmlFor="host-label">Display name</FieldLabel>
+          <Input
+            id="host-label"
+            value={label}
+            onChange={(event) => setLabel(event.target.value)}
+            placeholder={
+              target.includes('@') ? target.slice(target.indexOf('@') + 1) : 'Defaults to the host'
+            }
+            data-invalid={labelError ? '' : undefined}
+            autoComplete="off"
+          />
+          <FieldError>{labelError}</FieldError>
+          {!labelError && !isEditing && (
+            <FieldDescription>Leave blank to use the machine name.</FieldDescription>
+          )}
+        </Field>
+
+        <Field>
+          <FieldLabel htmlFor="host-editor-target">Editor host</FieldLabel>
+          <Input
+            id="host-editor-target"
+            value={editorTarget}
+            onChange={(event) => setEditorTarget(event.target.value)}
+            placeholder={target.trim() || 'Same as the SSH host'}
+            className="font-mono text-xs"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <FieldDescription>
+            Only if your editor knows this machine by a different name. Blank means the SSH host
+            above.
+          </FieldDescription>
+        </Field>
+
+        {generalError && (
+          <p
+            role="alert"
+            className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            {generalError}
+          </p>
+        )}
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="ghost" onClick={onDone}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={submitting}>
+          {submitting && <Loader2 className="animate-spin" />}
+          {isEditing ? 'Save changes' : 'Add host'}
+        </Button>
+      </DialogFooter>
+    </form>
+  )
+}

--- a/src/renderer/src/features/hosts/host-status.tsx
+++ b/src/renderer/src/features/hosts/host-status.tsx
@@ -1,0 +1,99 @@
+/**
+ * The two things a host row has to say before anything else: can we reach it,
+ * and what is installed on it.
+ *
+ * Split out of the card because both are read in more than one place - the card
+ * and the install dialog's "before" line - and because deciding what a state
+ * *means* is the part worth having on its own. A `HostConnectionState` has four
+ * fields and none of them is "up"; the row on screen has to be one word.
+ *
+ * ## Never tried is not the same as down
+ *
+ * `failures: 0, connected: false` is a host nobody has spoken to yet, which is
+ * the state every host is in for the first few seconds of its life. Rendering
+ * that as "unreachable" would mean every host anyone adds is red before it has
+ * been given a chance, which teaches people to ignore the colour. It gets its
+ * own, quieter word and no colour at all.
+ */
+import { CircleCheck, CircleDashed, CircleX, Download } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import type { HostWithState } from '@shared/schemas'
+
+export type Reachability = 'up' | 'down' | 'unknown'
+
+export function reachabilityOf(host: HostWithState): Reachability {
+  if (host.state.connected) return 'up'
+  // A host with a failure behind it is down even while its backoff is running;
+  // a host with none has simply not been asked.
+  return host.state.failures > 0 || host.state.lastError ? 'down' : 'unknown'
+}
+
+export function ReachabilityBadge({ host }: { host: HostWithState }) {
+  switch (reachabilityOf(host)) {
+    case 'up':
+      return (
+        <Badge variant="success">
+          <CircleCheck />
+          Reachable
+        </Badge>
+      )
+    case 'down':
+      return (
+        <Badge variant="destructive">
+          <CircleX />
+          Unreachable
+        </Badge>
+      )
+    case 'unknown':
+      return (
+        <Badge variant="outline">
+          <CircleDashed />
+          Not tried yet
+        </Badge>
+      )
+  }
+}
+
+/**
+ * What is installed over there, compared with what is running here.
+ *
+ * `appVersion` is passed in rather than read here so the comparison is made
+ * against the version that would actually be installed - `app-info` answers for
+ * whichever GitWarren the screen is talking to, which in a browser tab is the
+ * daemon and not the app.
+ */
+export function DaemonVersionBadge({
+  host,
+  appVersion
+}: {
+  host: HostWithState
+  appVersion: string | undefined
+}) {
+  if (host.daemonVersion === null) {
+    return (
+      <Badge variant="outline">
+        <Download />
+        GitWarren not installed
+      </Badge>
+    )
+  }
+
+  // Unknown local version: the badge still names what is over there, because
+  // that is a fact, and says nothing about whether it is current, because that
+  // is not knowable yet.
+  if (appVersion === undefined || host.daemonVersion === appVersion) {
+    return <Badge variant="outline">GitWarren {host.daemonVersion}</Badge>
+  }
+
+  return (
+    <Badge variant="warning">
+      <Download />
+      GitWarren {host.daemonVersion} · {appVersion} available
+    </Badge>
+  )
+}
+
+/** Whether the install button should be the loud one. */
+export function needsInstall(host: HostWithState, appVersion: string | undefined): boolean {
+  return host.daemonVersion === null || (appVersion !== undefined && host.daemonVersion !== appVersion)
+}

--- a/src/renderer/src/features/hosts/hosts-card.tsx
+++ b/src/renderer/src/features/hosts/hosts-card.tsx
@@ -1,0 +1,56 @@
+/**
+ * The way to Hosts from the home screen.
+ *
+ * Same shape as `agent-access-card.tsx`, deliberately: the home screen reads as
+ * one list of places, and a second thing that unfolds in place would break
+ * that.
+ *
+ * It shows a count, and only a count. Reading how many hosts there are is a
+ * local SQLite read; reading whether any of them is *up* is a connection to
+ * every machine in the list, which is not a price the home screen should pay
+ * for a subtitle. The Hosts screen is where reachability is asked for, by
+ * somebody who went there to ask.
+ */
+import { ChevronRight, Server } from 'lucide-react'
+import useSWR from 'swr'
+import { Card } from '@/components/ui/card'
+import { api, CACHE_KEYS } from '@/lib/api'
+import { navigate } from '@/lib/router'
+
+export function HostsCard() {
+  const { data: hosts } = useSWR(CACHE_KEYS.hosts, () => api.hosts.list())
+
+  function open(): void {
+    navigate({ name: 'hosts' })
+  }
+
+  const count = hosts?.length ?? 0
+
+  return (
+    <Card
+      role="button"
+      tabIndex={0}
+      // Picked up by the j/k shortcuts; the browser's own focus does the rest.
+      data-nav-item
+      onClick={open}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          open()
+        }
+      }}
+      className="flex cursor-pointer items-center gap-3 p-4 transition-colors hover:border-foreground/20"
+    >
+      <Server className="size-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium">Hosts</p>
+        <p className="text-xs text-muted-foreground">
+          {count === 0
+            ? 'Review code on another machine over ssh — a PC’s WSL, a VPS, a build box'
+            : `${count} machine${count === 1 ? '' : 's'} reachable over ssh`}
+        </p>
+      </div>
+      <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+    </Card>
+  )
+}

--- a/src/renderer/src/features/hosts/hosts-page.tsx
+++ b/src/renderer/src/features/hosts/hosts-page.tsx
@@ -1,0 +1,265 @@
+/**
+ * The Hosts screen: the other machines, and the button that puts GitWarren on
+ * one.
+ *
+ * Its main job is the install, which is why the installer and this screen went
+ * in as one change. Everything else here — add, forget, rename — is a form over
+ * a table, and none of it is worth a screen on its own; what is worth a screen
+ * is the moment where somebody types `xfor@pc-wsl`, presses Install, and a
+ * machine that had nothing but git on it can be reviewed from this one.
+ *
+ * ## It works in both shells, and nothing here knows which one it is in
+ *
+ * Every button below is one `carrier.request`. In the window that is IPC into
+ * the app's core; in a browser tab it is a WebSocket into the daemon's, and
+ * what gets managed is that daemon's list of hosts — which is right, because
+ * `hosts.*` is answered by whoever is asked and never forwarded (see
+ * `shared/rpc.ts`). So this screen needed no `capabilities` check at all, and
+ * that is the M3.2 design working rather than an omission: the flags exist for
+ * controls a tab genuinely cannot offer, and installing over ssh is not one of
+ * them. The install runs wherever the core runs; that it might be a different
+ * machine from the browser is exactly the point of the milestone.
+ *
+ * ## One thing at a time
+ *
+ * `busy` holds a single host id rather than a set. Two installs at once would
+ * be two 45 MB streams and two `ssh` connections from a screen with one
+ * spinner, and the honest way to say "this is one operation you are waiting on"
+ * is to let it be one.
+ */
+import { useCallback, useMemo, useState } from 'react'
+import useSWR from 'swr'
+import { AlertCircle, ArrowLeft, Plus, RefreshCw, Server } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Tooltip } from '@/components/ui/tooltip'
+import { api, CACHE_KEYS } from '@/lib/api'
+import { errorMessage } from '@/lib/errors'
+import { navigate } from '@/lib/router'
+import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
+import { HostCard } from './host-card'
+import { HostFormDialog } from './host-form-dialog'
+import { InstallResultDialog, type InstallOutcome } from './install-result-dialog'
+import { RemoveHostDialog } from './remove-host-dialog'
+import { useHostMutations, useHosts } from './use-hosts'
+import type { HostWithState } from '@shared/schemas'
+
+export function HostsPage() {
+  const { hosts, error, isLoading, isRefreshing, refresh } = useHosts()
+  const { probeHost, installOnHost } = useHostMutations()
+  const { data: info } = useSWR(CACHE_KEYS.appInfo, () => api.system.appInfo())
+
+  const [formOpen, setFormOpen] = useState(false)
+  const [editing, setEditing] = useState<HostWithState | undefined>(undefined)
+  const [removing, setRemoving] = useState<HostWithState | null>(null)
+  const [busy, setBusy] = useState<{ id: number; what: 'probe' | 'install' } | null>(null)
+  const [outcome, setOutcome] = useState<InstallOutcome | null>(null)
+
+  const openAdd = useCallback((): void => {
+    setEditing(undefined)
+    setFormOpen(true)
+  }, [])
+
+  function openEdit(host: HostWithState): void {
+    setEditing(host)
+    setFormOpen(true)
+  }
+
+  async function probe(host: HostWithState): Promise<void> {
+    setBusy({ id: host.id, what: 'probe' })
+    try {
+      await probeHost(host.id)
+    } catch (caught) {
+      // `hosts.probe` answers rather than throws for an unreachable host, so
+      // anything landing here is the app failing rather than the machine - and
+      // it belongs in front of the person, not in a console.
+      setOutcome({ kind: 'error', label: host.label, message: errorMessage(caught) })
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function install(host: HostWithState): Promise<void> {
+    setBusy({ id: host.id, what: 'install' })
+    try {
+      const report = await installOnHost(host.id)
+      setOutcome({ kind: 'done', label: host.label, report })
+    } catch (caught) {
+      setOutcome({ kind: 'error', label: host.label, message: errorMessage(caught) })
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  useRegisterCommands(
+    useMemo<Command[]>(
+      () => [
+        {
+          id: 'hosts:add',
+          label: 'Add host',
+          group: 'Hosts',
+          keys: 'n',
+          keywords: 'ssh machine remote server vps wsl',
+          icon: Plus,
+          run: openAdd
+        },
+        {
+          id: 'hosts:refresh',
+          label: 'Refresh hosts',
+          group: 'Hosts',
+          keys: 'r',
+          keywords: 'reload reachable status',
+          icon: RefreshCw,
+          run: () => void refresh()
+        }
+      ],
+      [openAdd, refresh]
+    )
+  )
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="-ml-2 mb-2 text-muted-foreground"
+          onClick={() => navigate({ name: 'repositories' })}
+        >
+          <ArrowLeft />
+          Repositories
+        </Button>
+
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <Server className="size-5 shrink-0 text-muted-foreground" />
+              <h1 className="text-xl font-semibold tracking-tight">Hosts</h1>
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {isLoading
+                ? 'Loading…'
+                : `${hosts?.length ?? 0} machine${hosts?.length === 1 ? '' : 's'}${
+                    isRefreshing ? ' · refreshing…' : ''
+                  }`}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Tooltip label="Re-read reachability">
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => void refresh()}
+                disabled={isLoading}
+                aria-label="Refresh"
+              >
+                <RefreshCw className={isRefreshing ? 'animate-spin' : undefined} />
+              </Button>
+            </Tooltip>
+            <Button onClick={openAdd}>
+              <Plus />
+              Add host
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {isLoading && <LoadingState />}
+
+      {!isLoading && error !== undefined && (
+        <ErrorState error={error} onRetry={() => void refresh()} />
+      )}
+
+      {!isLoading && error === undefined && hosts?.length === 0 && <EmptyState onAdd={openAdd} />}
+
+      {!isLoading && error === undefined && hosts && hosts.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {hosts.map((host) => (
+            <li key={host.id}>
+              <HostCard
+                host={host}
+                appVersion={info?.version}
+                busy={busy?.id === host.id ? busy.what : null}
+                onProbe={(target) => void probe(target)}
+                onInstall={(target) => void install(target)}
+                onEdit={openEdit}
+                onRemove={setRemoving}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <HostFormDialog open={formOpen} onOpenChange={setFormOpen} host={editing} />
+      <RemoveHostDialog
+        host={removing}
+        onOpenChange={(open) => {
+          if (!open) setRemoving(null)
+        }}
+      />
+      <InstallResultDialog outcome={outcome} onClose={() => setOutcome(null)} />
+    </section>
+  )
+}
+
+function LoadingState() {
+  return (
+    <ul className="flex flex-col gap-2" aria-busy="true" aria-label="Loading hosts">
+      {[0, 1].map((index) => (
+        <li key={index}>
+          <Card className="flex flex-col gap-3 p-4">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+            <Skeleton className="h-3 w-56" />
+            <Skeleton className="h-8 w-40 rounded-md" />
+          </Card>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <Card className="flex flex-col items-center gap-3 border-dashed px-6 py-14 text-center">
+      <div className="rounded-full bg-muted p-3 text-muted-foreground">
+        <Server className="size-6" />
+      </div>
+      <div>
+        <h3 className="font-medium">No other machines yet</h3>
+        <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+          Add a machine you can already reach over ssh — a PC&rsquo;s WSL, a VPS, a build box — and
+          GitWarren will install itself there over the same connection. The host needs nothing but
+          git.
+        </p>
+      </div>
+      <Button onClick={onAdd} className="mt-1">
+        <Plus />
+        Add your first host
+      </Button>
+    </Card>
+  )
+}
+
+function ErrorState({ error, onRetry }: { error: unknown; onRetry: () => void }) {
+  return (
+    <Card className="flex flex-col items-center gap-3 border-destructive/40 px-6 py-12 text-center">
+      <div className="rounded-full bg-destructive/10 p-3 text-destructive">
+        <AlertCircle className="size-6" />
+      </div>
+      <div>
+        <h3 className="font-medium">Could not load your hosts</h3>
+        <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+          {errorMessage(error)}
+        </p>
+      </div>
+      <Button variant="outline" onClick={onRetry} className="mt-1">
+        <RefreshCw />
+        Try again
+      </Button>
+    </Card>
+  )
+}

--- a/src/renderer/src/features/hosts/install-result-dialog.tsx
+++ b/src/renderer/src/features/hosts/install-result-dialog.tsx
@@ -1,0 +1,113 @@
+/**
+ * What the install did, afterwards.
+ *
+ * A dialog rather than a toast, and that is a decision about how long the thing
+ * takes. An install is tens of seconds on a first run: the person pressed a
+ * button, watched a spinner, and quite possibly went to make tea. A message
+ * that fades after four seconds is a message they will miss, and the one they
+ * will miss most is the failure — which is a paragraph of `ssh`'s own words and
+ * the only thing that says what to fix.
+ *
+ * `already-current` gets the same dialog as the other two on purpose. Pressing
+ * a button and having nothing happen is the outcome people report as a bug; the
+ * useful answer is "0.1.7-beta.1 is already there", and it costs one sentence.
+ */
+import { CheckCircle2, XCircle } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import { Breakable } from '@/components/breakable'
+import { Button } from '@/components/ui/button'
+import type { InstallReport } from '@shared/schemas'
+
+export type InstallOutcome =
+  | { kind: 'done'; label: string; report: InstallReport }
+  | { kind: 'error'; label: string; message: string }
+
+/** `45.2 MB`. Decimal, because that is what a download is measured in. */
+function megabytes(bytes: number): string {
+  return `${(bytes / 1_000_000).toFixed(1)} MB`
+}
+
+function title(outcome: InstallOutcome): string {
+  if (outcome.kind === 'error') return `Could not install on “${outcome.label}”`
+  switch (outcome.report.action) {
+    case 'installed':
+      return `GitWarren is on “${outcome.label}”`
+    case 'upgraded':
+      return `“${outcome.label}” is up to date`
+    case 'already-current':
+      return `“${outcome.label}” was already up to date`
+  }
+}
+
+function body(outcome: InstallOutcome): string {
+  if (outcome.kind === 'error') return outcome.message
+
+  const { action, version, previousVersion, target, bytes } = outcome.report
+  switch (action) {
+    case 'installed':
+      return (
+        `Version ${version} for ${target}, ${megabytes(bytes)} sent over the connection. ` +
+        'The launcher at ~/.gitwarren/bin/gitwarren is what everything points at from now on, ' +
+        'so an agent configured against it will survive every update.'
+      )
+    case 'upgraded':
+      return (
+        `Upgraded from ${previousVersion ?? 'an unknown version'} to ${version} for ${target}, ` +
+        `${megabytes(bytes)} sent. The old version is still in ~/.gitwarren/daemon if you need ` +
+        'to go back to it.'
+      )
+    case 'already-current':
+      return (
+        `${version} is already installed for ${target}, so nothing was sent. Use it anyway if ` +
+        'you think the install there is damaged — the button reinstalls when the version matches.'
+      )
+  }
+}
+
+export function InstallResultDialog({
+  outcome,
+  onClose
+}: {
+  outcome: InstallOutcome | null
+  onClose: () => void
+}) {
+  const failed = outcome?.kind === 'error'
+
+  return (
+    <AlertDialog
+      open={outcome !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            {failed ? (
+              <XCircle className="size-5 shrink-0 text-destructive" />
+            ) : (
+              <CheckCircle2 className="size-5 shrink-0 text-success" />
+            )}
+            {outcome && title(outcome)}
+          </AlertDialogTitle>
+          {/* The failure is `ssh`'s own sentence and can be long and full of
+              paths, so it breaks rather than overflows. */}
+          <AlertDialogDescription className="break-words">
+            {outcome && <Breakable text={body(outcome)} />}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <Button onClick={onClose}>Close</Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/src/features/hosts/remove-host-dialog.tsx
+++ b/src/renderer/src/features/hosts/remove-host-dialog.tsx
@@ -1,0 +1,96 @@
+/**
+ * Removal confirmation.
+ *
+ * The sentence matters more here than it does for a repository. "Remove" on a
+ * machine somebody has just installed software onto reads as "uninstall it",
+ * and it is not: this forgets a row on *this* GitWarren, and everything under
+ * `~/.gitwarren` over there is left exactly where it is. Saying so also happens
+ * to be the honest description of what M4.2 shipped - see the note at the top
+ * of `core/hosts/install.ts` on why there is no remote uninstall.
+ */
+import { useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog'
+import { Breakable } from '@/components/breakable'
+import { Button } from '@/components/ui/button'
+import { errorMessage } from '@/lib/errors'
+import { useHostMutations } from './use-hosts'
+import type { Host } from '@shared/schemas'
+
+interface RemoveHostDialogProps {
+  host: Host | null
+  onOpenChange: (open: boolean) => void
+}
+
+export function RemoveHostDialog({ host, onOpenChange }: RemoveHostDialogProps) {
+  const { removeHost } = useHostMutations()
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<unknown>(null)
+
+  async function confirm(): Promise<void> {
+    if (!host) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      await removeHost(host.id)
+      onOpenChange(false)
+    } catch (caught) {
+      setError(caught)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <AlertDialog
+      open={host !== null}
+      onOpenChange={(open) => {
+        if (!open) setError(null)
+        onOpenChange(open)
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Forget &ldquo;{host?.label}&rdquo;?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This removes the machine from this GitWarren&rsquo;s list. Nothing is uninstalled: the
+            daemon under <code>~/.gitwarren</code> over there stays where it is, and an agent
+            configured against it keeps working.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {host && (
+          <p
+            data-selectable
+            className="mt-3 break-words rounded-md bg-muted px-3 py-2 font-mono text-xs text-muted-foreground"
+          >
+            <Breakable text={host.target} />
+          </p>
+        )}
+
+        {error !== null && (
+          <p role="alert" className="mt-3 text-sm text-destructive">
+            {errorMessage(error)}
+          </p>
+        )}
+
+        <AlertDialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={() => void confirm()} disabled={submitting}>
+            {submitting && <Loader2 className="animate-spin" />}
+            Forget host
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/renderer/src/features/hosts/use-hosts.ts
+++ b/src/renderer/src/features/hosts/use-hosts.ts
@@ -1,0 +1,112 @@
+/**
+ * Data access for the Hosts screen.
+ *
+ * Same bargain as `use-repositories.ts` - SWR owns the cache, every mutation
+ * revalidates one key rather than patching rows by hand - with one difference
+ * that comes from what a host row is. Half of it is stored (label, target, the
+ * instance id once it is known) and half of it is read live from the connection
+ * pool at the moment of asking. Patching a returned row into the list would
+ * freeze that half at the instant the mutation answered, and a list where one
+ * row's "reachable" is four seconds older than its neighbour's is worse than a
+ * list that is uniformly a moment stale.
+ *
+ * There is deliberately no polling here. `repositories` re-reads git state on
+ * an interval because that costs a `git status` on the local disk; a host list
+ * that refreshed itself would be asking the pool, and the pool answering
+ * honestly means connecting - so a screen left open on a second monitor would
+ * hold an ssh connection to every machine in the list for as long as it was
+ * open. Reachability is refreshed when the person asks: "Try now", the refresh
+ * button, or arriving on the screen.
+ */
+import useSWR, { useSWRConfig } from 'swr'
+import { useCallback } from 'react'
+import { api, CACHE_KEYS } from '@/lib/api'
+import type {
+  AddHostInput,
+  HostWithState,
+  InstallReport,
+  UpdateHostInput
+} from '@shared/schemas'
+
+export interface UseHostsResult {
+  hosts: HostWithState[] | undefined
+  error: unknown
+  isLoading: boolean
+  /** True during a background refresh, when stale rows are still on screen. */
+  isRefreshing: boolean
+  refresh: () => Promise<unknown>
+}
+
+export function useHosts(): UseHostsResult {
+  const { data, error, isLoading, isValidating, mutate } = useSWR<HostWithState[], unknown>(
+    CACHE_KEYS.hosts,
+    () => api.hosts.list()
+  )
+
+  return {
+    hosts: data,
+    error,
+    isLoading,
+    isRefreshing: isValidating && !isLoading,
+    refresh: mutate
+  }
+}
+
+export interface HostMutations {
+  addHost: (input: AddHostInput) => Promise<HostWithState>
+  updateHost: (input: UpdateHostInput) => Promise<HostWithState>
+  removeHost: (id: number) => Promise<void>
+  probeHost: (id: number) => Promise<HostWithState>
+  installOnHost: (id: number, force?: boolean) => Promise<InstallReport>
+}
+
+export function useHostMutations(): HostMutations {
+  const { mutate } = useSWRConfig()
+  const revalidate = useCallback(() => mutate(CACHE_KEYS.hosts), [mutate])
+
+  return {
+    addHost: useCallback(
+      async (input) => {
+        const created = await api.hosts.add(input)
+        await revalidate()
+        return created
+      },
+      [revalidate]
+    ),
+    updateHost: useCallback(
+      async (input) => {
+        const updated = await api.hosts.update(input)
+        await revalidate()
+        return updated
+      },
+      [revalidate]
+    ),
+    removeHost: useCallback(
+      async (id) => {
+        await api.hosts.remove({ id })
+        await revalidate()
+      },
+      [revalidate]
+    ),
+    // Probe answers rather than throws for an unreachable host, so the caller
+    // gets the state back *and* the list is refreshed: the probe cleared this
+    // host's backoff, and a neighbour on the same machine may have come back
+    // with it.
+    probeHost: useCallback(
+      async (id) => {
+        const probed = await api.hosts.probe({ id })
+        await revalidate()
+        return probed
+      },
+      [revalidate]
+    ),
+    installOnHost: useCallback(
+      async (id, force) => {
+        const report = await api.hosts.install(force ? { id, force } : { id })
+        await revalidate()
+        return report
+      },
+      [revalidate]
+    )
+  }
+}

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -41,6 +41,15 @@ export const api: GitWarrenApi = {
   // and leaves the button out; see `ShellCapabilities` on why that is better
   // than a button that explains itself when pressed.
   capabilities: shell.capabilities,
+  hosts: {
+    list: () => carrier.request('hosts.list', undefined),
+    get: (input) => carrier.request('hosts.get', input),
+    add: (input) => carrier.request('hosts.add', input),
+    update: (input) => carrier.request('hosts.update', input),
+    remove: (input) => carrier.request('hosts.remove', input),
+    probe: (input) => carrier.request('hosts.probe', input),
+    install: (input) => carrier.request('hosts.install', input)
+  },
   repositories: {
     list: () => carrier.request('repositories.list', undefined),
     get: (input) => carrier.request('repositories.get', input),
@@ -103,6 +112,17 @@ export const api: GitWarrenApi = {
  * built with, which is what you want after creating or closing a review.
  */
 export const CACHE_KEYS = {
+  /**
+   * One key for the whole list, like `repositories`.
+   *
+   * There is no per-host key on purpose. A host row carries live reachability,
+   * so anything that changes one host's state has almost certainly changed the
+   * neighbours' too - a laptop closing its lid takes every host on that tailnet
+   * with it - and re-reading the list is one local SQLite read plus a lookup in
+   * the pool. Splitting it would buy nothing and would let two rows on one
+   * screen disagree about what time it is.
+   */
+  hosts: 'hosts',
   repositories: 'repositories',
   repositoryRefs: (repositoryId: number) => `repository-refs:${repositoryId}`,
   reviews: (repositoryId?: number, status?: string) =>

--- a/src/shared/__tests__/routes.test.ts
+++ b/src/shared/__tests__/routes.test.ts
@@ -155,3 +155,20 @@ test('the Agent Access page is a location, locally and on a host', () => {
 test('a stale link deeper than the agent page still lands on it', () => {
   assert.deepEqual(parseRoute('#/agent/anything'), { name: 'agent' })
 })
+
+test('the Hosts screen is a location, and never one on another install', () => {
+  assert.deepEqual(parseRoute('#/hosts'), { name: 'hosts' })
+  assert.equal(hrefFor({ name: 'hosts' }), '#/hosts')
+  assert.deepEqual(parseRoute(hrefFor({ name: 'hosts' })), { name: 'hosts' })
+
+  // A host list belongs to the install a person is driving: `hosts.*` is
+  // answered locally and never forwarded, so `#/h/<id>/hosts` names a screen
+  // that cannot exist. Rather than falling through to that machine's
+  // repositories - where an unrecognised path lands - the segment is honoured
+  // and the host is dropped, because there is one host list and this is it.
+  assert.deepEqual(parseRoute(`#/h/${HOST}/hosts`), { name: 'hosts' })
+})
+
+test('a stale link deeper than the hosts page still lands on it', () => {
+  assert.deepEqual(parseRoute('#/hosts/4'), { name: 'hosts' })
+})

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -20,8 +20,15 @@
 import type { FileContent, FileImage, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
 import type { AttachmentIngestParams, Carrier, ReviewOpen, RpcMethod } from './rpc.js'
 import type {
+  AddHostInput,
   AddRepositoryInput,
   Attachment,
+  GetHostInput,
+  HostWithState,
+  InstallOnHostInput,
+  InstallReport,
+  RemoveHostInput,
+  UpdateHostInput,
   Comment,
   CommentThread,
   CreateReviewInput,
@@ -271,6 +278,25 @@ export interface GitWarrenApi {
    * offer one that only explains itself when pressed. See `ShellCapabilities`.
    */
   capabilities: ShellCapabilities
+  /**
+   * The other machines this install knows about.
+   *
+   * Every one of these is answered by whoever the carrier reaches and is never
+   * forwarded onward - see the note on `hosts.*` in `shared/rpc.ts`. Which is
+   * why the Hosts screen in a browser tab manages the *daemon's* hosts and the
+   * one in the window manages the app's, without either screen knowing.
+   */
+  hosts: {
+    list(): Promise<HostWithState[]>
+    get(input: GetHostInput): Promise<HostWithState>
+    add(input: AddHostInput): Promise<HostWithState>
+    update(input: UpdateHostInput): Promise<HostWithState>
+    remove(input: RemoveHostInput): Promise<{ id: number }>
+    /** Reach it now, ignoring backoff. Never throws for an unreachable host. */
+    probe(input: GetHostInput): Promise<HostWithState>
+    /** Slow, and the only method here that changes the other machine. */
+    install(input: InstallOnHostInput): Promise<InstallReport>
+  }
   repositories: {
     list(): Promise<RepositoryWithGitState[]>
     get(input: GetRepositoryInput): Promise<RepositoryWithGitState>

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -56,6 +56,25 @@ export interface HostScoped {
 export type Route =
   | ({ name: 'repositories' } & HostScoped)
   | ({ name: 'agent' } & HostScoped)
+  /**
+   * The list of other machines. Deliberately *not* `HostScoped`.
+   *
+   * Every other location here can be on another install, because a repository,
+   * a review and an agent prompt all belong to a machine. A host list does not:
+   * it is the property of the install a person is driving, `hosts.*` is
+   * answered locally and never forwarded, and `isLocalOnly` in
+   * `core/hosts/ssh.ts` enforces that at the carrier. `#/h/<id>/hosts` would be
+   * a URL for a screen that cannot exist, so the type says it cannot be
+   * written.
+   *
+   * `host?: undefined` rather than leaving the property off: everything that
+   * handles a `Route` generically - the deep-link guard, the loopback
+   * translation - asks whether it is on this install, and a member with no such
+   * property at all would make that question a type error at four call sites
+   * that are all perfectly happy with the answer "no host". Declaring it as
+   * always-undefined says the same thing to a reader and to the compiler.
+   */
+  | { name: 'hosts'; host?: undefined }
   | ({ name: 'repository'; repositoryId: number } & HostScoped)
   | ({ name: 'review'; reviewId: number; tab: ReviewTab; focus?: DiffFocus } & HostScoped)
 
@@ -79,6 +98,9 @@ const HOST_SEGMENT = 'h'
  */
 const AGENT_SEGMENT = 'agent'
 
+/** The Hosts screen. Never preceded by a host segment - see `Route`. */
+const HOSTS_SEGMENT = 'hosts'
+
 /**
  * `#/h/<instance>`, or nothing at all for a local route.
  *
@@ -97,6 +119,9 @@ export function hrefFor(route: Route): string {
       return `#/${prefix}`
     case 'agent':
       return `#/${prefix}${AGENT_SEGMENT}`
+    // No prefix, and not because one was forgotten: see `Route`.
+    case 'hosts':
+      return `#/${HOSTS_SEGMENT}`
     case 'repository':
       return `#/${prefix}repositories/${route.repositoryId}`
     case 'review': {
@@ -161,6 +186,12 @@ export function parseRoute(hash: string): Route {
   if (segments.length === 0) return host === undefined ? HOME : { name: 'repositories', host }
 
   if (segments[0] === AGENT_SEGMENT) return { name: 'agent', ...scope }
+
+  // Read *before* the host is honoured rather than after, so that a link
+  // someone assembled by hand as `#/h/<id>/hosts` lands on this machine's host
+  // list instead of silently falling through to another machine's repositories.
+  // There is one host list and it is this one; the segment says so either way.
+  if (segments[0] === HOSTS_SEGMENT) return { name: 'hosts' }
 
   if (segments[0] === 'repositories' && segments[1]) {
     const repositoryId = Number(segments[1])

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -26,6 +26,8 @@ import type {
   Attachment,
   GetHostInput,
   HostWithState,
+  InstallOnHostInput,
+  InstallReport,
   RemoveHostInput,
   UpdateHostInput,
   Comment,
@@ -189,6 +191,16 @@ export interface RpcMethods {
   'hosts.remove': { params: RemoveHostInput; result: { id: number } }
   /** Reach a host now, ignoring backoff. Answers with what happened. */
   'hosts.probe': { params: GetHostInput; result: HostWithState }
+  /**
+   * Put the daemon on a host, or say that it is already there.
+   *
+   * The slowest method in this interface by a wide margin - a download and a
+   * 45 MB stream - and the only one with no timeout on either side, which is
+   * deliberate: there is no number of seconds after which abandoning a
+   * part-finished install would be an improvement. See `core/hosts/install.ts`
+   * on why it reports nothing until it is done.
+   */
+  'hosts.install': { params: InstallOnHostInput; result: InstallReport }
 
   'repositories.list': { params: void; result: RepositoryWithGitState[] }
   'repositories.get': { params: GetRepositoryInput; result: RepositoryWithGitState }

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -129,6 +129,8 @@ export const hostSchema = z.object({
   target: z.string(),
   editorTarget: z.string().nullable(),
   lastSeenAt: z.iso.datetime().nullable(),
+  /** What GitWarren the host was running when it last said. Null until it has. */
+  daemonVersion: z.string().nullable(),
   createdAt: z.iso.datetime()
 })
 
@@ -173,6 +175,35 @@ export const updateHostInputSchema = z
 export const getHostInputSchema = z.object({ id: hostIdSchema })
 export const removeHostInputSchema = z.object({ id: hostIdSchema })
 
+/**
+ * `force` is the difference between "make sure GitWarren is on that machine"
+ * and "put it there again".
+ *
+ * Without it an install of a version that is already there is a no-op with a
+ * sentence, which is what the button does by default - pressing it twice should
+ * not move 45 MB. With it, it reinstalls: the case that needs this is a daemon
+ * directory that is present, reports the right version and is somehow broken,
+ * and a person who has decided that is what happened is right more often than
+ * a version string is.
+ */
+export const installOnHostInputSchema = z.object({
+  id: hostIdSchema,
+  force: z.boolean().optional()
+})
+
+/** What the install did. See `core/hosts/install.ts` for why each is separate. */
+export const installActionSchema = z.enum(['installed', 'upgraded', 'already-current'])
+
+export const installReportSchema = z.object({
+  action: installActionSchema,
+  version: z.string(),
+  previousVersion: z.string().nullable(),
+  target: z.string(),
+  bytes: z.number().int().nonnegative(),
+  /** The host row afterwards, so a screen does not have to re-read it. */
+  host: hostWithStateSchema
+})
+
 export type Host = z.infer<typeof hostSchema>
 export type HostWithState = z.infer<typeof hostWithStateSchema>
 export type HostConnectionState = z.infer<typeof hostStateSchema>
@@ -180,6 +211,9 @@ export type AddHostInput = z.input<typeof addHostInputSchema>
 export type UpdateHostInput = z.input<typeof updateHostInputSchema>
 export type GetHostInput = z.input<typeof getHostInputSchema>
 export type RemoveHostInput = z.input<typeof removeHostInputSchema>
+export type InstallOnHostInput = z.input<typeof installOnHostInputSchema>
+export type InstallAction = z.infer<typeof installActionSchema>
+export type InstallReport = z.infer<typeof installReportSchema>
 
 /* -------------------------------------------------------------------------- */
 /* Reviews                                                                    */


### PR DESCRIPTION
Second of M4's five slices. **Based on `worktree-m4-1-ssh-hosts` (#46), not on `main`** — merge that first, or this diff will read as containing it.

A machine with git on it and nothing else is now four commands away from being reviewable, and all four go down a connection that was already open:

```
uname -sm                                which tarball
~/.gitwarren/bin/gitwarren --version     whether there is anything to do
tar xzf -            reading stdin       the bytes
…/bin/gitwarren service install          the launchers
```

## The installer

`core/hosts/release.ts` decides which tarball that is and gets it onto *this* disk — a staged directory, then the cache, then the release, and never the host. The machine with a browser does the downloading, which is what makes an air-gapped box work without an exception in the code. `core/hosts/install.ts` is the sequence. `ssh.ts` gained only `runOverSsh`, because "how this app invokes ssh" is one decision and `SSH_OPTIONS` is where it was already written down.

**The host writes its own launchers**, by running the binary that was just unpacked. It would be a shorter file to `echo` two `sh` scripts into `~/.gitwarren/bin` from here, and it would be wrong twice: `src/cli/launchers.ts` already knows what a launcher looks like down to the symlink loop, and running the thing is the only *proof* that the architecture was picked right — a linux-arm64 tarball on an x86-64 box gets as far as a perfectly successful `tar` and then dies at the first `exec`. `--no-login-item` because a remote host is not where a login item belongs.

## The screen

`#/hosts` — list, add, edit, forget, "try now", install/update/reinstall. Reached from a home-screen card and from the palette (`g s`).

It is the one route in `shared/routes.ts` that is **not** host-scoped, because a host list belongs to the install a person is driving; `hosts.*` is answered locally and never forwarded, so `#/h/<id>/hosts` names a screen that cannot exist and the type says so.

It also needed **no `shell.capabilities` check at all**, which is the M3.2 design working rather than an omission: the flags exist for controls a tab genuinely cannot offer, and installing over ssh is not one of them — the install runs wherever the core runs.

`hosts.daemon_version` (migration 0009) is learned beside `instance_id` from the same `app.instance` answer, so the list can say "0.1.6, update available" without connecting to every machine to render itself.

## Verified against the real host, destructively

`~/.gitwarren` on `pc-wsl` — which since M4.1 held a hand-built daemon ahead of the published beta — was deleted, and everything below was done by the shipping code onto a machine with nothing on it.

- From the app: 46.4 MB streamed in 3.4 s, both launchers written by the host's own `service install` with absolute paths into `~/.gitwarren/daemon/0.1.7-beta.1/`, `service status` reporting no login item, the instance id learned, the row reading **Reachable · GitWarren 0.1.7-beta.1**.
- The same screen in a Chrome tab against the same core: "already up to date, nothing was sent", and Forget.
- No console errors in either, and no horizontal scroll at 390 px.

## Two things bit

**One failed press climbed two rungs of the backoff ladder.** A probe of a host with no GitWarren came back `failures: 2`. A dying connection is noticed twice — the close handler sees stdout end, and every request waiting on it rejects — and M4.1's pool counted both. Its own tests could not see it: the fake connection rejects a request without ever closing, which is a shape a real `ssh` never has. Failures are now counted once per connection; the *message* still takes the later of the two, deliberately, because that is the one that waited for `ssh`'s exit status and says "GitWarren is not installed on xfor@pc-wsl" rather than "the connection closed".

**The remote command is run by the login shell, and on that box it is zsh.** Not `sh`. The unpack script was already free of bashisms and of `--strip-components` (busybox `tar` has never had it), so it ran unchanged — but this is the sort of thing that otherwise fails on someone else's server and nowhere else.

## On the release assets

Not a workflow bug. `release.yml` on `main` builds all four targets; the tag `v0.1.7-beta.1` predates that change, so at that tag the daemon job built linux only — which is why the draft carries two tarballs and no Homebrew formula. The next tag gets macOS. Separately, a **draft** release's assets 404 for everyone, so nothing can install from this one until it is published; the 404 says so by name. `GITWARREN_DAEMON_TARBALL_DIR` is what makes a development build installable at all, and is the same answer an air-gapped machine with the file on a stick needs.

## Gate

`npm run lint`, `npm run typecheck`, `npm run build` clean. 471 tests, 467 passing, the same 4 skips M4.1 documented. New: 8 for the installer sequence, 8 for tarball resolution (over a real socket), 3 for the pool's failure counting, 2 for the route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nui3Ud66nmefqnycANfNmm
