### PR TITLE
M4.3 - Repositories on hosts

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -1546,6 +1546,7 @@ them verifiable against the real `pc-wsl` node rather than against a mock:
    drives it. *(done — see below.)*
 3. **Repositories on hosts.** `fs.list`, the host segment in routes, reviews
    listed under their host, clones grouped by root commit across hosts.
+   *(done — see below.)*
 4. **Attachments, editors and agent access per host.**
 5. **Disconnection.** The stale banner and the silent refetch.
 
@@ -1767,6 +1768,215 @@ versions and deleting the other's install is not this one's decision to make.
 Nothing on the screen reaches a *repository* on a host yet — that is M4.3, and
 until it lands a host is a machine you can install onto and prove reachable,
 which is exactly what M4.2 set out to be.
+
+**M4.3, done on the Mac against the WSL node, 11 September.** A host stops
+being a machine you can install onto and becomes a machine you can review. The
+slice is one method, one router and a segment in the URL, and the reason it is
+not more than that is that M4.1 and M4.2 had already built the hard half:
+
+    fs.list                     browse a filesystem you cannot see
+    core/hosts/router.ts        answered here, or answered over there
+    #/h/<instance>/…            which machine a link is about
+
+**A host is a place you go, not rows in this database.** The design question
+this slice actually had to settle was where a remote repository *lives*, and
+`repositories.host_id` — a column M0 added and nothing had ever written — made
+one answer look obvious: keep a row here per repository over there, so a list
+can be drawn without touching the network. It was the wrong answer, and rules 1
+and 2 say so plainly. A host owns its repositories: the row for
+`~/github.com/klarluft/gitwarren-app` on `pc-wsl` is in *that machine's* SQLite,
+its reviews hang off it there, and the agent inside WSL reads them over its own
+local MCP. Nothing syncs. A second row over here would be a copy of a name and a
+path only that machine can keep true, and it would give one repository two ids —
+while `#/h/<instance>/repositories/<id>` has always meant "that id, as that host
+knows it".
+
+So `#/h/<instance>/` is a host's repository list, fetched from the host, when
+somebody asks for it. The Hosts screen is where you ask; M4.2's host card said
+in a comment that it led nowhere "until M4.3", and now it has a button. The
+button appears only once the machine has said who it is, because a route needs
+an instance id and a host that has been described but never met has none — the
+same honesty `instance_id` being nullable buys everywhere else, arriving at the
+UI, and "Try now" is what makes the button appear.
+
+That also settles the question M4.1 left open. **`hosts.remove` has nothing to
+cascade to.** No row in this database names a host, so forgetting one forgets a
+way of reaching a computer and leaves every repository, review and comment over
+there exactly where it was; adding the host again reaches all of it again. The
+column stays, because dropping it is a migration that buys nothing and "this row
+is local" is still a claim worth making in SQL, and its comment now says what
+would have to become true for anything to write it.
+
+**Not fanning out is a feature, and it is the same argument as connect-on-use.**
+A home screen listing every host's repositories would open an `ssh` connection
+to every machine on the list in order to render — which is precisely what
+`core/hosts/pool.ts` exists to avoid, and what M4.2 already refused to do for a
+version number. One host, one visit, one connection.
+
+**The host rides on the envelope.** `RpcRequest.host` is an instance id, and it
+is deliberately not a `hostId` field on every input schema. *Where* a request
+goes is not part of what a method means — `reviews.diff` has one meaning and it
+is the same on every machine — so threading a host through the service, the MCP
+tool and the zod schema would teach three layers about a thing none of them has
+any business knowing. It also has to be *strippable*: the router removes it
+before forwarding, which is what makes a chain of hosts impossible to build by
+accident. What arrives at the far end has no host on it, so the far end answers
+it. A hub cannot be talked into becoming a spoke.
+
+Three ways a request stays here: no host at all, which is nearly every request
+and is byte-for-byte the request it was in M0; *our own* instance id, which is
+what another GitWarren writes when it links to this one and is rule 4 in a
+single comparison; and `hosts.*`, checked before the host is even resolved,
+because a host's list of hosts is its own business. `isLocalOnly` in `ssh.ts` is
+still there as a backstop, and the belt-and-braces is on purpose — a routing bug
+should not be able to put one on a wire.
+
+Carriers now come through `handleRoutedRequest` rather than `handleRequest`, so
+the decision is made once instead of in each of them. The Electron window, the
+daemon over a pipe and a browser tab all get remote hosts from the same change,
+and the tab case is the one that shows the shape is right: a tab reaches the
+core, and the core is the hub whether or not it happens to have a window.
+
+**`fs.list` exists because of a capability, not a domain.** It is the only
+method here that is not about reviews, and the comment
+`repository-form-dialog.tsx` has carried since M3 is why: a browser tab has no
+folder picker, and on a remote host the picker the shell *does* have would
+browse the wrong machine and produce a path `pc-wsl` has never heard of. So the
+gesture splits — opening a window stays in the shell, "what is inside this
+folder" becomes a method — and the native dialog is now used in exactly one
+case, a local form in the Electron window.
+
+A listing carries more than names, because the asking side has to draw a picker
+for a filesystem it has never seen: the parent (null at the root, which is how
+the screen knows to stop offering "Up"), where home is, the separator, and
+whether each folder holds a `.git`. That last one is what makes it beat a text
+field — it answers "is this the folder I want" without descending into it. One
+column rather than a tree, because every expanded node in a tree is a round
+trip over an `ssh` pipe and the thing being looked for is one folder, not a
+structure worth understanding. The path stays editable throughout, since for
+someone who knows where they are going, typing beats any number of clicks.
+
+Hidden folders are listed and flagged rather than filtered, and the decision is
+the screen's: dotfile repositories are a real thing people review, and a listing
+that silently dropped rows would be one you could not trust when what you wanted
+was not in it. A leading `~` is expanded by whoever answers, because that is the
+only machine that knows what it stands for — someone adding a repository on
+`pc-wsl` knows it is under `~/github.com` and has no reason to know that is
+`/home/xfor` over there.
+
+There is no sandbox, and that is a decision rather than an oversight.
+`repositories.add` already takes any absolute path on the host and reads git
+there, so a caller who can reach the dispatcher can already name any directory
+on the machine; a traversal check on this one method would be theatre next to an
+open door. The real boundary is who may reach the dispatcher — `core/web/token.ts`
+for a tab, the person's own SSH keys for a host.
+
+**Clones are grouped by the commit their history starts at.** Two checkouts of
+one project on two machines share a root commit and nothing else — not their
+path, and usually not their name — so `rootCommit` joins `RepositoryGitState`
+and a row on a host's list that matches one here becomes a link to the local
+clone. `--first-parent` is what makes it a single answer rather than a set: a
+history that has ever absorbed another project by merge has two roots, and a set
+is not a key, while the root of the first-parent chain is. It is cached per path
+for the run, because it is the one thing in that module that cannot change while
+the app is open and `rev-list` walks to the beginning of time to find it.
+
+The comparison runs from the host towards this computer and not the other way,
+and the reason is what each list costs. This machine's repositories are one
+local SQLite read, free from anywhere; another machine's are a connection. The
+grouping is made where it is free.
+
+**What a remote screen deliberately does not offer.** Three controls disappear
+rather than doing something plausible: revealing a path, which would open a
+Finder window on this Mac at a path only WSL has; opening a file in an editor,
+which would join the two halves M1 kept apart across a network and hand a Mac
+editor a path from a different filesystem; and attaching an image, because an
+attachment is a file in the owning host's store and the *displaying* half of
+that is M4.4 — ingesting now would put a real image on `pc-wsl` and render it
+here as a broken one, in a comment nobody could fix except by editing markdown
+by hand. Absent rather than disabled, which is the rule M3 set for a browser
+tab: a disabled control is a promise the shell cannot keep.
+
+**Three things bit.**
+
+*Emptying the editor list did not remove the button.* The open-in-editor control
+in `diff-view.tsx` is drawn when it is given a *callback*, not when there is an
+editor to name — so a remote review lost its editor picker and kept its buttons,
+and pressing one asked *this* install for `reviews.filePath` of a review id that
+means something else over there. On a machine with no review of that number it
+is a `NOT_FOUND`; on one that has a review of that number it opens an unrelated
+local file, which is the single failure shape this slice set out to prevent.
+Found by pressing it against `pc-wsl` and reading what happened, not by a test.
+The callback is now undefined on a host, so the button has nothing to be drawn
+from.
+
+*Two lists, one cache key.* A read-coalescing key and an SWR key that ignore the
+host make "the repositories on `pc-wsl`" and "the repositories on this Mac" the
+same question, and hand the second asker the first one's answer. Every id in
+this app is a per-host autoincrement integer — the point `shared/routes.ts`
+makes about links is just as true of a cache — so the host is part of the key in
+both carriers and in `CACHE_KEYS`. It goes on the *end*, after the prefix, so
+that the family-wide `startsWith` invalidation still works.
+
+*The host was running a daemon older than the method.* The first run against
+`pc-wsl` answered `fs.list` with `Unknown method "fs.list"` in twelve
+milliseconds, and reported no `rootCommit` — because the daemon over there was
+the published 0.1.7-beta.1 and both are new here. That is version skew behaving
+exactly as `RPC_PROTOCOL_VERSION` was reserved for: an unknown method comes back
+as an error a caller can read rather than as a hang, and an absent field is
+absent rather than wrong. It is also the case a person will hit, so it is worth
+saying plainly: **a host has to be reinstalled from the GUI before M4.3's
+screens work against it**, which is one button on the Hosts screen and four
+seconds.
+
+**Verified end to end against `pc-wsl` through the shipping code.** The daemon
+reinstalled from this build (46.4 MB in 4.5 s), then: `fs.list` on the host in
+129 ms cold and 6 ms warm on the multiplexed channel, answering `/home/xfor`
+with `/` as its separator and `/home` as its parent; `~/github.com/klarluft`
+expanded over there into five folders, every one of them marked as a repository;
+the same method with no host answering `/Users/michalwrzosek`, which is the
+whole point of it being a method. A folder that is not there came back as
+`PATH_NOT_FOUND` with its own sentence intact after the round trip. Two
+repositories added on the host and listed from the Mac with their WSL paths; the
+clone marker on exactly one of the two rows, naming this machine's checkout of
+the same project, and clicking it landing on `#/repositories/1` — a local route,
+no host segment. `hosts.list` with a host on the envelope answered here. A stale
+link to a machine nobody knows failing as a lookup rather than a network wait,
+with the id in the message. A review created on the host from the Mac, opened at
+`#/h/<instance>/reviews/2/files`, commented into `pc-wsl`'s database and read
+back — while review 2 *here* was a different review entirely, which is the
+clearest possible demonstration of why the segment had to exist. No console
+errors, and no horizontal scroll at 390 px.
+
+**What M4.3 found and left alone.** Electron's `contextBridge` strips everything
+but `message` off a rejected promise, so `AppError.code` and `fieldErrors` do
+not survive the preload: in the packaged window `errorCode(error)` is always
+null and `firstFieldError` always undefined. This predates the milestone —
+adding an already-tracked repository has been showing its duplicate-path message
+in the form's general slot rather than under the field since M1 — and it is not
+specific to hosts; the shell channels lose their codes the same way. A browser
+tab is unaffected, because its carrier throws in the same world it is caught in.
+The fix is to stop throwing across the bridge: the preload's carrier should hand
+back the `RpcOutcome` it already has and let the renderer call `resultOf`, which
+is what `shared/rpc.ts` says that function is for. It is its own change, with
+its own reasoning about where the M1 boundary sits, so it was not folded into
+this one — the cost meanwhile is that the "this host is not answering" state
+renders in a tab and not in the window, where the same sentence arrives under a
+more generic heading.
+
+**Not done in M4.3, and why.** Attachments, editors and per-host agent access
+are M4.4, and the three controls above are switched off rather than half-built
+in the meantime. `attachments.ingest` would route to a host correctly today, but
+the renderer sends an `ArrayBuffer` and `stdio-client.ts` still serialises with
+plain `JSON.stringify` — the web carrier solved this in `web/wire.ts` and that
+encoder wants to move somewhere both can use it, which is M4.4's first job.
+Deep links still carry no host: an agent's `gitwarren://` link written on
+`pc-wsl` is a local link, and opening it on the Mac shows the Mac's review of
+that number. That is rule 4 needing the loopback fragment to grow a host
+segment, and it belongs with M6's live links rather than here. There is no
+disconnection banner and no silent refetch — a host that goes away mid-review
+still empties the screen — which is M4.5, and the reason its error state already
+has a shape to grow into.
 
 ### M5 — WSL from Windows
 

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -1897,7 +1897,7 @@ here as a broken one, in a comment nobody could fix except by editing markdown
 by hand. Absent rather than disabled, which is the rule M3 set for a browser
 tab: a disabled control is a promise the shell cannot keep.
 
-**Three things bit.**
+**Four things bit.**
 
 *Emptying the editor list did not remove the button.* The open-in-editor control
 in `diff-view.tsx` is drawn when it is given a *callback*, not when there is an
@@ -1909,6 +1909,15 @@ local file, which is the single failure shape this slice set out to prevent.
 Found by pressing it against `pc-wsl` and reading what happened, not by a test.
 The callback is now undefined on a host, so the button has nothing to be drawn
 from.
+
+*The banner accused a perfectly good host of not existing.* For the first frames
+of a cold load the host list has not arrived, and `hosts?.find(...)` answers
+undefined — which the banner rendered as "a host this GitWarren no longer
+knows". It is the same mistake `host-status.tsx` already has a paragraph about
+in the other direction: an unanswered question is not the alarming answer, and
+"not loaded yet" is not "not known". Caught by watching a reload rather than by
+reading the code, and the fix is to tell the two apart rather than to make the
+sentence quieter.
 
 *Two lists, one cache key.* A read-coalescing key and an SWR key that ignore the
 host make "the repositories on `pc-wsl`" and "the repositories on this Mac" the

--- a/src/core/__tests__/root-commit.test.ts
+++ b/src/core/__tests__/root-commit.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The key two clones of one project are grouped by.
+ *
+ * M4.3 needs a way to say "the thing under `~/github.com` on `pc-wsl` and the
+ * thing under `~/github.com` on this Mac are the same repository". Neither the
+ * path nor the name can say it - two clones are usually in different places and
+ * are often called something different - so the answer is the commit the
+ * history starts at, which is the same forty characters everywhere.
+ *
+ * Against a real `git`, because every property being claimed here is `git`'s
+ * and not this app's. The interesting one is the last test: a history that has
+ * absorbed another project by merge has *two* roots, so the naive
+ * `rev-list --max-parents=0` answers with a set - and a set is not a key. The
+ * first-parent root is, and that is what makes a clone identifiable at all.
+ */
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, test } from 'node:test'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-root-data-'))
+const workDir = mkdtempSync(join(tmpdir(), 'gitwarren-root-work-'))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+const { readGitState } = await import('../git.js')
+
+function run(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}
+
+function makeRepo(name: string): string {
+  const root = join(workDir, name)
+  mkdirSync(root, { recursive: true })
+  run(root, 'init', '-b', 'main')
+  run(root, 'config', 'user.email', 'test@example.com')
+  run(root, 'config', 'user.name', 'Test')
+  return root
+}
+
+function commit(root: string, message: string): void {
+  writeFileSync(join(root, `${message}.txt`), `${message}\n`)
+  run(root, 'add', '.')
+  run(root, 'commit', '-m', message)
+}
+
+let origin: string
+
+before(() => {
+  origin = makeRepo('origin')
+  commit(origin, 'first')
+  commit(origin, 'second')
+})
+
+after(() => {
+  rmSync(dataDir, { recursive: true, force: true })
+  rmSync(workDir, { recursive: true, force: true })
+})
+
+test('the root commit is the first commit, in full', async () => {
+  const state = await readGitState(origin)
+  const expected = run(origin, 'rev-list', '--max-parents=0', 'HEAD')
+
+  assert.equal(state.rootCommit, expected)
+  assert.match(state.rootCommit ?? '', /^[0-9a-f]{40}$/)
+})
+
+test('a clone in another place reports the same root', async () => {
+  // What a repository on another machine actually is: a different path, a
+  // different name, the same history. The grouping has to see through both.
+  const clone = join(workDir, 'somewhere-else')
+  execFileSync('git', ['clone', '--quiet', origin, clone], { cwd: workDir })
+
+  const here = await readGitState(origin)
+  const there = await readGitState(clone)
+
+  assert.notEqual(origin, clone)
+  assert.equal(there.rootCommit, here.rootCommit)
+})
+
+test('a repository with no commits has no root, and that is not a group', async () => {
+  const empty = makeRepo('empty')
+  const state = await readGitState(empty)
+
+  assert.equal(state.isEmpty, true)
+  // Null rather than a placeholder: two empty repositories are two empty
+  // repositories, and a shared falsy key would collapse them into one.
+  assert.equal(state.rootCommit, null)
+})
+
+test('a history that swallowed another project still has one root', async () => {
+  const merged = makeRepo('merged')
+  commit(merged, 'ours')
+  const ourRoot = run(merged, 'rev-list', '--max-parents=0', 'HEAD')
+
+  // A second, entirely unrelated history, merged in - a vendored project, or
+  // two repositories joined years ago. `git` is perfectly happy with it.
+  run(merged, 'remote', 'add', 'other', origin)
+  run(merged, 'fetch', '--quiet', 'other')
+  run(merged, 'merge', '--quiet', '--allow-unrelated-histories', '--no-edit', 'other/main')
+
+  const allRoots = run(merged, 'rev-list', '--max-parents=0', 'HEAD').split('\n')
+  assert.equal(allRoots.length, 2, 'the fixture should genuinely have two roots')
+
+  const state = await readGitState(merged)
+  // The first-parent root: where *this* project began, not where something it
+  // later absorbed did. It is the half of the pair that is stable enough to be
+  // a key.
+  assert.equal(state.rootCommit, ourRoot)
+})

--- a/src/core/db/schema.ts
+++ b/src/core/db/schema.ts
@@ -187,10 +187,36 @@ export const repositories = sqliteTable(
      * The install that owns this repository, or NULL for this one.
      *
      * A host owns its repositories: SQLite, git and the MCP server for a repo
-     * all live on the machine the repo is on, and a row here for a repository
-     * on another host is a *reference* to it, never a copy. NULL rather than
-     * this install's own instance id, so that nothing has to be rewritten when
-     * a data directory is moved or restored onto a machine that mints a new id.
+     * all live on the machine the repo is on. NULL rather than this install's
+     * own instance id, so that nothing has to be rewritten when a data
+     * directory is moved or restored onto a machine that mints a new id.
+     *
+     * ## Nothing writes it, and M4.3 decided that on purpose
+     *
+     * It was added in M0 for a design where this database would hold a row per
+     * remote repository - a bookmark saying "there is one of these on `pc-wsl`"
+     * - so that a repository list could be drawn without touching the network.
+     * M4.3 built the other thing, because rules 1 and 2 of the plan say so
+     * plainly: a host owns its repositories, and nothing syncs. A repository on
+     * `pc-wsl` is a row in *that machine's* SQLite with its own id, its reviews
+     * hang off it there, and the agent inside WSL reads them over its own local
+     * MCP. A second row over here would be a copy of a name and a path that
+     * only that machine can keep true, and it would give one repository two
+     * ids - while `#/h/<instance>/repositories/<id>` has always meant "that id,
+     * as that host knows it".
+     *
+     * So a host is a *place you go*: `#/h/<instance>/` is its repository list,
+     * fetched from it, when somebody asks for it. That is also what makes
+     * connect-on-use hold - a home screen that listed every host's repositories
+     * would open an `ssh` connection to every machine on the list in order to
+     * render, which is exactly what `core/hosts/pool.ts` exists to avoid.
+     *
+     * The column stays because dropping it is a migration that buys nothing,
+     * and because "this row is local" is a claim worth being able to make in
+     * SQL - `localRepositoryAt` in the service makes it. It would start being
+     * written the day GitWarren wanted to remember something about a machine
+     * that is switched off, which is a decision about caching and would want
+     * arguing on its own.
      */
     hostId: text('host_id'),
     /**

--- a/src/core/git.ts
+++ b/src/core/git.ts
@@ -52,7 +52,56 @@ const UNREADABLE: RepositoryGitState = {
   branch: null,
   detachedAt: null,
   isEmpty: false,
+  rootCommit: null,
   error: null
+}
+
+/**
+ * Root commits already read, by repository path.
+ *
+ * The only thing in this module that is remembered between calls, and it is
+ * remembered because it is the only thing here that is not *live*. Every other
+ * field is read fresh precisely because it changes while the app is open;
+ * where a history begins does not. What makes the cache worth having is the
+ * cost: `rev-list` walks the first-parent chain to the beginning of time, which
+ * for a repository with a hundred thousand commits is not something to do on
+ * every render of a list.
+ *
+ * It is allowed to be wrong in exactly one way - somebody rewrites the root
+ * commit of a repository while GitWarren is running, and the grouping is stale
+ * until the next launch. That is a rebase of the first commit of a project,
+ * which is rarer than the app being restarted.
+ *
+ * Keyed by path rather than by repository id because the answer belongs to the
+ * checkout, and two rows pointing at one path have the same one.
+ */
+const rootCommits = new Map<string, string | null>()
+
+/**
+ * The commit a history starts at, or null when there is not one yet.
+ *
+ * `--first-parent` is what makes this a single answer. An ordinary
+ * `rev-list --max-parents=0` reports *every* root, and a repository that has
+ * ever absorbed another one by merge has more than one - so the set is not a
+ * key, while the root of the first-parent chain is: it is where the project
+ * itself began, and it is the same commit in every clone of it.
+ */
+async function readRootCommit(repositoryPath: string): Promise<string | null> {
+  const cached = rootCommits.get(repositoryPath)
+  if (cached !== undefined) return cached
+
+  const result = await runGit(
+    ['rev-list', '--max-parents=0', '--first-parent', 'HEAD'],
+    repositoryPath
+  )
+  // The last line, not the first: `rev-list` answers newest first, so on the
+  // rare history where the filter still leaves two, the oldest is the root.
+  const root =
+    result.code === 0 && result.stdout ? (result.stdout.split('\n').at(-1)?.trim() ?? null) : null
+
+  const value = root && root.length > 0 ? root : null
+  rootCommits.set(repositoryPath, value)
+  return value
 }
 
 /**
@@ -77,6 +126,10 @@ export async function readGitState(repositoryPath: string): Promise<RepositoryGi
   const symbolic = await runGit(['symbolic-ref', '--quiet', '--short', 'HEAD'], repositoryPath)
   const hasCommits = (await runGit(['rev-parse', '--verify', '--quiet', 'HEAD'], repositoryPath)).code === 0
 
+  // Skipped entirely on a repository with no commits: there is no root to find,
+  // and `rev-list HEAD` on an unborn branch is an error rather than an answer.
+  const rootCommit = hasCommits ? await readRootCommit(repositoryPath) : null
+
   if (symbolic.code === 0 && symbolic.stdout) {
     return {
       exists: true,
@@ -84,6 +137,7 @@ export async function readGitState(repositoryPath: string): Promise<RepositoryGi
       branch: symbolic.stdout,
       detachedAt: null,
       isEmpty: !hasCommits,
+      rootCommit,
       error: null
     }
   }
@@ -95,6 +149,7 @@ export async function readGitState(repositoryPath: string): Promise<RepositoryGi
     branch: null,
     detachedAt: head.code === 0 && head.stdout ? head.stdout : null,
     isEmpty: !hasCommits,
+    rootCommit,
     error: head.code === 0 ? null : 'Could not read HEAD.'
   }
 }

--- a/src/core/hosts/__tests__/router.test.ts
+++ b/src/core/hosts/__tests__/router.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Whether a request stays here.
+ *
+ * The router is the one place that decides, and getting it wrong is quiet in
+ * both directions: a request that should have been forwarded is answered with
+ * *this* machine's data under another machine's heading, and one that should
+ * have stayed here goes out over a wire it had no business being on. Neither
+ * looks like a failure from the screen.
+ *
+ * So what is pinned here is the decision, not the delivery. Actually reaching a
+ * host is `ssh.ts`, `stdio-client.ts` and the pool, each covered where it
+ * lives, and the whole of it verified end to end against the real `pc-wsl` node
+ * - which is where M4.1, M4.2 and M4.3 each found the bug the tests could not
+ * have. What a test *can* hold still is the three ways a request is answered
+ * locally and the one way it is not.
+ */
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, before, test } from 'node:test'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-router-'))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+const { isAnsweredLocally, route, handleRoutedRequest } = await import('../router.js')
+const { getInstanceId } = await import('../../instance.js')
+const { getDatabase, closeDatabase } = await import('../../db/client.js')
+const { hosts } = await import('../../db/schema.js')
+const { AppError } = await import('../../../shared/errors.js')
+
+/** A host this install has met but which is not this install. */
+const OTHER = 'c0ffee00-0000-4000-8000-000000000001'
+/** A host nobody has ever heard of - what a stale link carries. */
+const STRANGER = 'c0ffee00-0000-4000-8000-0000000000ff'
+
+before(() => {
+  getDatabase()
+    .insert(hosts)
+    .values({ label: 'pc-wsl', kind: 'ssh', target: 'xfor@pc-wsl', instanceId: OTHER })
+    .run()
+})
+
+after(() => {
+  closeDatabase()
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+test('no host on the envelope is this machine, as it always was', () => {
+  assert.equal(isAnsweredLocally(undefined, 'repositories.list'), true)
+})
+
+test('our own instance id is this machine', () => {
+  // Not a curiosity: it is what another GitWarren writes when it links *to*
+  // this one, and rule 4 says a link resolves where it is clicked. Answering it
+  // here rather than looking for a `hosts` row pointing at ourselves is that
+  // rule in one comparison.
+  assert.equal(isAnsweredLocally(getInstanceId(), 'reviews.open'), true)
+})
+
+test('a host list is answered by whoever is asked, even when a host is named', () => {
+  // The mesh rule. Forwarding `hosts.*` would make host A's list readable - and
+  // removable - from host B. The carrier refuses to send them as a backstop;
+  // this is the layer that means the carrier never sees one.
+  assert.equal(isAnsweredLocally(OTHER, 'hosts.list'), true)
+  assert.equal(isAnsweredLocally(OTHER, 'hosts.remove'), true)
+  assert.equal(isAnsweredLocally(OTHER, 'hosts.install'), true)
+})
+
+test('a repository on a host this install knows is not answered here', () => {
+  assert.equal(isAnsweredLocally(OTHER, 'repositories.list'), false)
+})
+
+test('a host id nobody knows is NOT_FOUND, and the message names it', async () => {
+  // What a link to a machine that has since been forgotten produces. Naming the
+  // id is the whole of the message's value: it is the only thing the reader can
+  // compare against their Hosts screen.
+  try {
+    await route(STRANGER, 'repositories.list')
+    throw new Error('expected the route to reject')
+  } catch (error) {
+    assert.ok(error instanceof AppError)
+    assert.equal(error.code, 'NOT_FOUND')
+    assert.ok(error.message.includes(STRANGER), `message should name the host: ${error.message}`)
+  }
+})
+
+test('an unknown host is refused before anything is sent', async () => {
+  // A `hosts` row is what turns an id into a way of connecting, so an id with
+  // no row cannot produce a connection attempt at all - there is nothing to
+  // connect to. The assertion is that it fails as a lookup rather than as a
+  // timeout.
+  const started = Date.now()
+  await assert.rejects(() => route(STRANGER, 'repositories.list'))
+  assert.ok(Date.now() - started < 1_000, 'a missing row is a lookup, not a network wait')
+})
+
+test('a local request goes through the dispatcher and comes back as a response', async () => {
+  const response = await handleRoutedRequest({ id: 7, method: 'repositories.list' })
+
+  assert.equal(response.id, 7)
+  assert.ok('result' in response)
+  assert.deepEqual(response.result, [])
+})
+
+test('a routed failure arrives as a message, never as a throw', async () => {
+  // The carrier's contract: there is nowhere on a byte stream to put an
+  // exception, so every outcome has to be a frame.
+  const response = await handleRoutedRequest({
+    id: 8,
+    method: 'repositories.list',
+    host: STRANGER
+  })
+
+  assert.equal(response.id, 8)
+  assert.ok('error' in response)
+  assert.equal(response.error.code, 'NOT_FOUND')
+})
+
+test('a host on the envelope does not reach the far end', async () => {
+  // The strip is what stops a chain of hosts forming: what a host receives has
+  // no host on it, so it answers rather than forwarding. Asserted here through
+  // the one case that can be checked without a network - our own id, which is
+  // routed locally and must not leave a `host` anywhere it could be read.
+  const response = await handleRoutedRequest({
+    id: 9,
+    method: 'repositories.list',
+    host: getInstanceId()
+  })
+
+  assert.ok('result' in response)
+  assert.deepEqual(response.result, [])
+  assert.ok(!('host' in response), 'a response is an answer, not an envelope going back out')
+})

--- a/src/core/hosts/router.ts
+++ b/src/core/hosts/router.ts
@@ -1,0 +1,131 @@
+/**
+ * Whether a request is answered here or somewhere else.
+ *
+ * M4.1 left a note saying this file was coming, and `isLocalOnly` in `ssh.ts`
+ * has been standing in for it since: a backstop that refuses to forward
+ * `hosts.*` and has no opinion about anything else, because until M4.3 nothing
+ * was forwarded at all. This is the general decision, and it is one function.
+ *
+ * ## The host is on the envelope, not in the params
+ *
+ * `RpcRequest.host` carries an instance id. It is deliberately not a `hostId`
+ * field on every input schema, and the difference is not cosmetic:
+ *
+ * - *Where* a request goes is not something the method means. `reviews.diff`
+ *   has exactly one meaning, and it is the same meaning on every machine. A
+ *   host field in its params would have to be threaded through the service, the
+ *   MCP tool and the zod schema, none of which have any business knowing that
+ *   more than one machine exists.
+ * - It has to be *strippable*. The router removes it before forwarding, which
+ *   is what makes a chain of hosts impossible to build by accident: what
+ *   arrives at the far end is a request with no host on it, so the far end
+ *   answers it itself. A hub cannot be talked into becoming a spoke.
+ * - An older daemon ignores it. Unknown fields are ignored by every peer in
+ *   this protocol (see `RPC_PROTOCOL_VERSION`), so a GUI that has learned about
+ *   hosts can still talk to one that has not.
+ *
+ * ## Three ways a request stays here
+ *
+ * **No host.** The overwhelming majority. A link written before hosts existed,
+ * or written today for a local review, is a request with no host on it, and it
+ * behaves exactly as it did in M0.
+ *
+ * **Our own instance id.** `#/h/<this machine>/reviews/4` is a perfectly
+ * ordinary thing to be handed - it is what a *different* GitWarren produces
+ * when it links to this one, and rule 4 says a link resolves where it is
+ * clicked. Answering it locally rather than looking for a `hosts` row pointing
+ * at ourselves is the whole of that rule in one comparison.
+ *
+ * **`hosts.*`.** A host's list of hosts is its own business. Forwarding these
+ * would make host A's list readable, and removable, from host B, and turn a hub
+ * and its spokes into a mesh nobody asked for. Note that this is checked
+ * *before* the host is resolved, so `hosts.list` with a host on it is answered
+ * here rather than refused: the screen asking is the Hosts screen of this
+ * install, and there is only one of those. The carrier still refuses to send
+ * them, and that belt-and-braces is on purpose - a routing bug should not be
+ * able to put one on a wire.
+ *
+ * ## What a host id resolves against
+ *
+ * The `hosts` table, by `instance_id` and never by target or label. An address
+ * is a way to reach a machine and not the machine; the instance id is the one
+ * name that survives a rename, a new IP and a different carrier, which is
+ * exactly why routes carry it. A host that has been described but never met has
+ * no instance id yet, so nothing can link to it - and that is the honest
+ * answer, not a gap: until the machine has said who it is, this install cannot
+ * tell it apart from any other.
+ */
+import { eq } from 'drizzle-orm'
+import { getDatabase } from '../db/client.js'
+import { hosts } from '../db/schema.js'
+import { getInstanceId } from '../instance.js'
+import { hostPool } from './pool.js'
+import { routeFor } from '../services/hosts.js'
+import { isLocalOnly } from './ssh.js'
+import { dispatch } from '../rpc/dispatcher.js'
+import { AppError } from '../../shared/errors.js'
+import type {
+  RpcMethod,
+  RpcParams,
+  RpcRequest,
+  RpcResponse,
+  RpcResult
+} from '../../shared/rpc.js'
+
+/** Answered by this install, whatever the request said. */
+export function isAnsweredLocally(host: string | undefined, method: string): boolean {
+  return host === undefined || host === getInstanceId() || isLocalOnly(method)
+}
+
+/**
+ * Send a method wherever it belongs, and answer as if it had been local.
+ *
+ * A failure from a host arrives as the `AppError` it was raised as - a
+ * `NOT_FOUND` from a daemon over `ssh` reaches a React component as the same
+ * `NOT_FOUND` a local call would have thrown, which is what lets one set of
+ * error handling serve both. The one code that is *added* out here is
+ * `HOST_OFFLINE`, and it is added by the pool, which is the only layer that
+ * knows the difference between "the answer is no" and "there was no answer".
+ */
+export async function route<M extends RpcMethod>(
+  host: string | undefined,
+  method: M,
+  params?: RpcParams<M>
+): Promise<RpcResult<M>> {
+  if (isAnsweredLocally(host, method)) return dispatch(method, params)
+
+  const row = getDatabase().select().from(hosts).where(eq(hosts.instanceId, host as string)).get()
+  if (!row) {
+    // Names the id rather than saying "unknown host", because the id is what
+    // the link contained and is the only thing the person can compare against
+    // their Hosts screen. This is what a link to a machine that has since been
+    // forgotten produces, and it should read like one.
+    throw new AppError(
+      'NOT_FOUND',
+      `This GitWarren does not know a host with id ${host as string}. ` +
+        'It may have been removed, or the link may have come from somewhere else.'
+    )
+  }
+
+  return hostPool.request(routeFor(row), method, params)
+}
+
+/**
+ * The door every carrier holding a message off a wire comes through.
+ *
+ * `handleRequest` in the dispatcher answers a request *here*; this one answers
+ * it wherever it belongs. Carriers use this one, which is why the routing
+ * decision is made once rather than in each of them - and why a browser tab
+ * gets remote hosts for free: the tab reaches the core, and the core is the hub
+ * whether or not it happens to have a window.
+ *
+ * Never throws, for the same reason `handleRequest` never does: a carrier
+ * holding a byte stream has nowhere to put an exception.
+ */
+export async function handleRoutedRequest(request: RpcRequest): Promise<RpcResponse> {
+  try {
+    return { id: request.id, result: await route(request.host, request.method, request.params) }
+  } catch (error) {
+    return { id: request.id, error: AppError.from(error).toSerialized() }
+  }
+}

--- a/src/core/rpc/dispatcher.ts
+++ b/src/core/rpc/dispatcher.ts
@@ -30,6 +30,7 @@ import { getInstanceId } from '../instance.js'
 import { APP_VERSION } from '../version.js'
 import { attachmentsService } from '../services/attachments.js'
 import { commentsService } from '../services/comments.js'
+import { fsService } from '../services/fs.js'
 import { hostsService } from '../services/hosts.js'
 import { repositoriesService } from '../services/repositories.js'
 import { reviewedFilesService } from '../services/reviewed-files.js'
@@ -160,6 +161,10 @@ const handlers: {
   'hosts.probe': (params) => hostsService.probe(params),
   'hosts.install': (params) => hostsService.install(params),
 
+  // Answered by whoever owns the folder, which is the whole point of it being
+  // a method - see the note in `shared/rpc.ts`.
+  'fs.list': (params) => fsService.list(params),
+
   'repositories.list': () => repositoriesService.list(),
   'repositories.get': (params) => repositoriesService.get(params),
   'repositories.add': (params) => repositoriesService.add(params),
@@ -238,12 +243,18 @@ export async function dispatch<M extends RpcMethod>(
 }
 
 /**
- * The carrier's entry point: a request in, a response out, never a throw.
+ * A request in, a response out, never a throw - answered *here*.
  *
  * A carrier holding a byte stream has no way to report an exception - there is
  * only the wire - so every failure has to come back as a message. Errors keep
  * their `AppError` code and their field errors, which is what lets a form on
  * the other side of an `ssh` pipe still put a message under the right input.
+ *
+ * Carriers do not use this one. Since M4.3 they come through
+ * `handleRoutedRequest` in `core/hosts/router.ts`, which honours the host on
+ * the envelope and then arrives back here for everything that stays local. The
+ * split is what keeps this file's promise true: the dispatcher decides what the
+ * core can *do*, and has never had an opinion about which machine does it.
  */
 export async function handleRequest(request: RpcRequest): Promise<RpcResponse> {
   try {

--- a/src/core/rpc/stdio.ts
+++ b/src/core/rpc/stdio.ts
@@ -27,14 +27,14 @@
  * Deliver bytes, and nothing else. It does not know what a method means, it
  * does not validate `params`, and it does not decide who a comment belongs to -
  * see the note at the top of `dispatcher.ts`. Every request goes through
- * `handleRequest`, which is the same door `main/ipc.ts` uses, so a review
+ * `handleRoutedRequest`, which is the same door `main/ipc.ts` uses, so a review
  * opened over a pipe is the review the window would have shown.
  *
  * Its tests are `rpc/__tests__/dispatcher.test.ts`. That is deliberate: a
  * carrier with its own test suite would be asserting its own opinions about the
  * protocol, which is the failure this whole arrangement exists to prevent.
  */
-import { handleRequest } from './dispatcher.js'
+import { handleRoutedRequest } from '../hosts/router.js'
 import { MAX_FRAME_BYTES, readFrames } from './ndjson.js'
 import { AppError } from '../../shared/errors.js'
 import type { RpcRequest, RpcResponse } from '../../shared/rpc.js'
@@ -103,10 +103,10 @@ export function serveStdio({ input, output, onEnd }: StdioCarrierOptions): void 
       return
     }
 
-    // `handleRequest` never throws - that is its contract, and it is what makes
+    // `handleRoutedRequest` never throws - that is its contract, and it is what makes
     // it usable here at all, since there is nowhere on a pipe to put an
     // exception. The catch is for the write.
-    void handleRequest(request)
+    void handleRoutedRequest(request)
       .then(write)
       .catch((error: unknown) => {
         console.error('[stdio] could not answer a request', error)

--- a/src/core/rpc/websocket.ts
+++ b/src/core/rpc/websocket.ts
@@ -23,15 +23,19 @@
  *
  * ## What it does not do
  *
- * Decide anything. Every request goes through `handleRequest`, the same door
- * `main/ipc.ts` and `stdio.ts` use, and this file may not add a method, skip
- * validation or name an author - see the note at the top of `dispatcher.ts`.
+ * Decide anything. Every request goes through `handleRoutedRequest`, the same
+ * door `main/ipc.ts` and `stdio.ts` use, and this file may not add a method,
+ * skip validation or name an author - see the note at the top of
+ * `dispatcher.ts`. That includes deciding *where* a request goes: a tab may ask
+ * for a review on another host, and what this file does about it is pass the
+ * host along untouched.
+ *
  * Authentication happened before the upgrade was accepted (`web/server.ts`); a
  * socket that reaches here is one the user's browser was told the secret for,
  * and this file is not the place to second-guess that.
  */
 import type { WebSocket } from 'ws'
-import { handleRequest } from './dispatcher.js'
+import { handleRoutedRequest } from '../hosts/router.js'
 import { AppError } from '../../shared/errors.js'
 import type { RpcRequest, RpcResponse } from '../../shared/rpc.js'
 
@@ -98,9 +102,9 @@ export function serveWebSocket(socket: WebSocket): void {
       return
     }
 
-    // `handleRequest` never throws - that is its contract. The catch is for the
+    // `handleRoutedRequest` never throws - that is its contract. The catch is for the
     // write, which can fail on a socket that closed between the two.
-    void handleRequest(request)
+    void handleRoutedRequest(request)
       .then(write)
       .catch((error: unknown) => {
         console.error('[web] could not answer a request', error)

--- a/src/core/services/__tests__/fs.test.ts
+++ b/src/core/services/__tests__/fs.test.ts
@@ -1,0 +1,166 @@
+/**
+ * What a machine says about its own folders.
+ *
+ * Against a real filesystem, because every claim here is one about the
+ * filesystem: that a symlink to a file is not a folder, that `~` means the
+ * answering machine's home, that a missing path and an empty one are different
+ * answers. A fake would let all four pass while the real thing did something
+ * else on the one platform nobody tested.
+ *
+ * The property that matters most is at the end. The whole point of `fs.list` is
+ * that the machine holding the files answers, and a person on a Mac browsing a
+ * Linux host has no way to check what they were told - so a listing that
+ * quietly dropped rows would be indistinguishable from a folder that did not
+ * contain what they were looking for.
+ */
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import { after, before, test } from 'node:test'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-fs-data-'))
+process.env.GITWARREN_DATA_DIR = dataDir
+
+const { fsService, MAX_ENTRIES } = await import('../fs.js')
+const { AppError } = await import('../../../shared/errors.js')
+
+const root = mkdtempSync(join(tmpdir(), 'gitwarren-fs-'))
+
+before(() => {
+  mkdirSync(join(root, 'plain'))
+  mkdirSync(join(root, '.hidden'))
+  mkdirSync(join(root, 'a-repository', '.git'), { recursive: true })
+  // A worktree or a submodule spells `.git` as a file, and is just as much a
+  // repository. Both shapes have to be recognised or half of the badges are
+  // missing on exactly the machines where checking by hand is hardest.
+  mkdirSync(join(root, 'a-worktree'))
+  writeFileSync(join(root, 'a-worktree', '.git'), 'gitdir: /elsewhere\n')
+  writeFileSync(join(root, 'a-file.txt'), 'not a folder\n')
+  symlinkSync(join(root, 'a-file.txt'), join(root, 'link-to-file'))
+  symlinkSync(join(root, 'plain'), join(root, 'link-to-folder'))
+})
+
+after(() => {
+  rmSync(root, { recursive: true, force: true })
+  rmSync(dataDir, { recursive: true, force: true })
+})
+
+async function names(path?: string): Promise<string[]> {
+  const listing = await fsService.list(path === undefined ? {} : { path })
+  return listing.entries.map((entry) => entry.name)
+}
+
+async function expectError(code: string, fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn()
+  } catch (error) {
+    assert.ok(error instanceof AppError, `expected AppError, got ${String(error)}`)
+    assert.equal(error.code, code)
+    return
+  }
+  throw new Error(`expected the call to reject with ${code}`)
+}
+
+test('folders are listed and files are not', async () => {
+  const listed = await names(root)
+
+  assert.ok(listed.includes('plain'))
+  assert.ok(listed.includes('a-repository'))
+  assert.ok(!listed.includes('a-file.txt'), 'a file is never the answer to "which repository"')
+})
+
+test('a symlink counts as what it points at', async () => {
+  const listed = await names(root)
+
+  assert.ok(listed.includes('link-to-folder'), 'a link to a folder is a way into that folder')
+  assert.ok(!listed.includes('link-to-file'), 'a link to a file is still a file')
+})
+
+test('both spellings of a repository are marked', async () => {
+  const listing = await fsService.list({ path: root })
+  const marked = listing.entries.filter((entry) => entry.isRepository).map((entry) => entry.name)
+
+  assert.deepEqual(marked.sort(), ['a-repository', 'a-worktree'])
+})
+
+test('hidden folders are listed and flagged, never filtered out', async () => {
+  const listing = await fsService.list({ path: root })
+  const hidden = listing.entries.find((entry) => entry.name === '.hidden')
+
+  // Dotfile repositories are a real thing people review, so the decision about
+  // whether to show these belongs to the screen. A listing that dropped rows
+  // would be one you could not trust when what you wanted was not in it.
+  assert.ok(hidden, '.hidden should be in the listing')
+  assert.equal(hidden.isHidden, true)
+  assert.equal(listing.entries.find((entry) => entry.name === 'plain')?.isHidden, false)
+})
+
+test('entries carry the absolute path, which is what gets stored', async () => {
+  const listing = await fsService.list({ path: root })
+  const plain = listing.entries.find((entry) => entry.name === 'plain')
+
+  assert.equal(plain?.path, join(root, 'plain'))
+})
+
+test('no path at all means home, and the separator says whose filesystem this is', async () => {
+  const listing = await fsService.list({})
+
+  assert.equal(listing.path, homedir())
+  assert.equal(listing.home, homedir())
+  // The one field a Mac driving a Linux host cannot work out for itself.
+  assert.equal(listing.separator, sep)
+})
+
+test('a leading ~ is expanded by whoever answers', async () => {
+  // Which is the point of it: someone adding a repository on `pc-wsl` knows it
+  // is under `~/github.com` and has no reason to know that `~` is `/home/xfor`
+  // over there.
+  const listing = await fsService.list({ path: '~' })
+
+  assert.equal(listing.path, homedir())
+})
+
+test('a ~ in the middle is part of a folder name, not a home directory', async () => {
+  await expectError('PATH_NOT_FOUND', () => fsService.list({ path: join(root, 'no~such') }))
+})
+
+test('the way up, and the fact that there is not one at the root', async () => {
+  const inside = await fsService.list({ path: join(root, 'plain') })
+  assert.equal(inside.parent, root)
+
+  const top = await fsService.list({ path: sep })
+  assert.equal(top.parent, null, 'null is how the screen knows to stop offering "Up"')
+})
+
+test('a missing folder and an empty one are different answers', async () => {
+  const empty = await fsService.list({ path: join(root, 'plain') })
+  assert.deepEqual(empty.entries, [])
+  assert.equal(empty.truncated, false)
+
+  await expectError('PATH_NOT_FOUND', () => fsService.list({ path: join(root, 'nope') }))
+})
+
+test('a file is refused as a folder, and says which it is', async () => {
+  await expectError('INVALID_INPUT', () => fsService.list({ path: join(root, 'a-file.txt') }))
+})
+
+test('a relative path is refused rather than resolved against the daemon cwd', async () => {
+  // The cwd of a daemon spawned over `ssh` is whatever the login shell left it
+  // as, which is not something a caller on another machine can reason about.
+  await expectError('INVALID_INPUT', () => fsService.list({ path: 'relative/path' }))
+})
+
+test('a very large folder is cut short, and says so', async () => {
+  const many = join(root, 'many')
+  mkdirSync(many)
+  for (let index = 0; index < MAX_ENTRIES + 5; index += 1) {
+    mkdirSync(join(many, `folder-${String(index).padStart(4, '0')}`))
+  }
+
+  const listing = await fsService.list({ path: many })
+  assert.equal(listing.entries.length, MAX_ENTRIES)
+  // The flag is what lets the screen keep the text field honest: the folder
+  // someone wants may be one of the ones not shown.
+  assert.equal(listing.truncated, true)
+})

--- a/src/core/services/fs.ts
+++ b/src/core/services/fs.ts
@@ -1,0 +1,204 @@
+/**
+ * Reading a directory, so that a machine without a window can still be browsed.
+ *
+ * This is the one piece of the core that exists because of a *capability*
+ * rather than because of a domain. `capabilities.pickDirectory` is false in a
+ * browser tab, and it is meaningless on a remote host - a native picker there
+ * would browse the wrong machine, which is the comment
+ * `repository-form-dialog.tsx` has been carrying since M3. So the picker's job
+ * is split in two: opening a window stays in the shell where it always was, and
+ * "what is inside this folder" becomes a method, answered by whoever owns the
+ * folder.
+ *
+ * That is also why this is not `dialog.showOpenDialog` behind an interface. A
+ * dialog returns a path and nothing else; a method has to return enough for the
+ * *asking* machine to draw a picker for a filesystem it cannot see - which
+ * means the separator, where home is, and which of these folders is a
+ * repository.
+ *
+ * ## Directories only
+ *
+ * A file is never the answer to "which repository is this?", and a source tree
+ * has a hundred files per folder. Listing them would make every response an
+ * order of magnitude bigger, over a connection that in M4 is an `ssh` pipe, for
+ * rows a person cannot click.
+ *
+ * Hidden entries *are* listed, and the decision about whether to show them is
+ * left to the screen. Dotfile repositories are a real thing people review, so
+ * this cannot filter them out; and a listing that silently omitted rows would
+ * be a listing you could not trust when the folder you wanted was not in it.
+ *
+ * ## What it will not do
+ *
+ * There is no root to escape from and no traversal check, and that is
+ * deliberate rather than an oversight. `repositories.add` already takes any
+ * absolute path on the host and reads git there; a caller who can reach the
+ * dispatcher can already name any directory on the machine. Pretending this one
+ * method has a sandbox would be security theatre over a door that is open next
+ * to it - the real boundary is who may reach the dispatcher at all, which is
+ * `core/web/token.ts` for a tab and the person's own SSH keys for a host.
+ */
+import { readdir, stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { isAbsolute, join, resolve, sep } from 'node:path'
+import { AppError } from '../../shared/errors.js'
+import { parseWithSchema as parse } from '../../shared/validation.js'
+import { listDirectoryInputSchema, type DirectoryListing } from '../../shared/schemas.js'
+
+/**
+ * How many subdirectories to send back.
+ *
+ * `node_modules` is the case this exists for: a folder with two thousand
+ * entries in it is not a folder anybody is going to find a repository in by
+ * scrolling, and the whole listing has to cross an `ssh` pipe first. The screen
+ * says the list was cut short, so the remaining half of the interaction - the
+ * text field - is still there for someone who knows the path.
+ */
+export const MAX_ENTRIES = 500
+
+/**
+ * Expand a leading `~`, and only a leading one.
+ *
+ * The remote case is why this is here at all: a person adding a repository on
+ * `pc-wsl` from a Mac knows it is under `~/github.com`, and has no particular
+ * reason to know that `~` is `/home/xfor` over there. Expanded by whoever
+ * answers, because that is the only machine that knows.
+ *
+ * `~user` is deliberately not expanded. It would mean reading the password
+ * database to answer, and a path that begins `~someone` is very much more
+ * likely to be a directory that is literally called that.
+ */
+function expandHome(path: string): string {
+  if (path === '~') return homedir()
+  if (path.startsWith('~/') || path.startsWith('~\\')) return join(homedir(), path.slice(2))
+  return path
+}
+
+/**
+ * Is this directory a git repository root?
+ *
+ * A `.git` entry, of either shape: a directory in an ordinary clone, a file in
+ * a linked worktree or a submodule. Deliberately not `git rev-parse` - that
+ * would be a process per row, and this answer only decides whether to draw a
+ * badge next to a folder name.
+ */
+async function looksLikeRepository(path: string): Promise<boolean> {
+  try {
+    await stat(join(path, '.git'))
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** The parent of a path, or null once there is nothing above it. */
+function parentOf(path: string): string | null {
+  const parent = resolve(path, '..')
+  return parent === path ? null : parent
+}
+
+/**
+ * List the directories inside one directory.
+ *
+ * A missing or unreadable path is an `AppError` rather than an empty listing,
+ * because the two are different answers to the person typing: one means "that
+ * folder is not there" and the other means "it is there and it is empty".
+ */
+async function listDirectory(input: unknown): Promise<DirectoryListing> {
+  const { path } = parse(listDirectoryInputSchema, input)
+
+  const requested = path === undefined || path.trim() === '' ? homedir() : expandHome(path.trim())
+  if (!isAbsolute(requested)) {
+    throw new AppError('INVALID_INPUT', `Not an absolute path: ${requested}`, {
+      path: ['Enter a path that starts at the root of the filesystem.']
+    })
+  }
+
+  // Resolved rather than used as typed, so that `..` in a hand-typed path and
+  // the parent link below both produce the same string for the same folder -
+  // which is what lets the screen tell whether it has moved.
+  const directory = resolve(requested)
+
+  let names: string[]
+  try {
+    const found = await readdir(directory, { withFileTypes: true })
+    names = found
+      .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
+      .map((entry) => entry.name)
+      .sort((a, b) => a.localeCompare(b))
+  } catch (error) {
+    throw asBrowseError(error, directory)
+  }
+
+  const truncated = names.length > MAX_ENTRIES
+  const shown = truncated ? names.slice(0, MAX_ENTRIES) : names
+
+  const entries = await Promise.all(
+    shown.map(async (name) => {
+      const full = join(directory, name)
+      return {
+        name,
+        path: full,
+        // A symlink that points at a file, or at nothing, is filtered out here
+        // rather than above: `readdir` reports the link, and only a `stat`
+        // knows what is on the other end of it.
+        isDirectory: await isDirectory(full),
+        isRepository: await looksLikeRepository(full),
+        isHidden: name.startsWith('.')
+      }
+    })
+  )
+
+  return {
+    path: directory,
+    parent: parentOf(directory),
+    home: homedir(),
+    separator: sep,
+    entries: entries.filter((entry) => entry.isDirectory).map(({ isDirectory: _, ...rest }) => rest),
+    truncated
+  }
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Turn a filesystem errno into something worth showing.
+ *
+ * The two that actually happen are worth separating: a path that is not there
+ * is usually a typo, and a path that is there and refused is usually somebody
+ * else's home directory. Everything else keeps its own message, which for a
+ * filesystem error is generally more use than any sentence written here.
+ */
+function asBrowseError(error: unknown, path: string): AppError {
+  const code = (error as { code?: string } | null)?.code
+  if (code === 'ENOENT') {
+    return new AppError('PATH_NOT_FOUND', `No such folder: ${path}`, {
+      path: ['That folder does not exist.']
+    })
+  }
+  if (code === 'ENOTDIR') {
+    return new AppError('INVALID_INPUT', `Not a folder: ${path}`, {
+      path: ['That is a file, not a folder.']
+    })
+  }
+  if (code === 'EACCES' || code === 'EPERM') {
+    return new AppError('FORBIDDEN', `Not allowed to read ${path}.`, {
+      path: ['GitWarren is not allowed to read that folder.']
+    })
+  }
+  return AppError.from(error)
+}
+
+/**
+ * The service, so that the dispatcher's map stays a table of one-line
+ * delegations and every method reads the same way.
+ */
+export const fsService = {
+  list: listDirectory
+}

--- a/src/core/services/hosts.ts
+++ b/src/core/services/hosts.ts
@@ -215,10 +215,17 @@ export const hostsService = {
    * The connection is dropped first so that an in-flight request cannot write
    * `last_seen_at` back onto a row that is about to stop existing.
    *
-   * Repositories on the host are deliberately *not* deleted here. That is M4.3's
-   * decision to make, once there are remote repositories to have an opinion
-   * about; leaving orphaned rows for one slice is better than writing a cascade
-   * now and having to unpick it.
+   * There is no cascade to repositories, and M4.3 - which was left the decision
+   * - found it had nothing to decide. No row in this database ever names a
+   * host: a repository on `pc-wsl` is a row in that machine's SQLite, and this
+   * install holds only the route to the machine. So forgetting a host forgets a
+   * way of reaching a computer, and every repository, review and comment over
+   * there is exactly where it was. Adding the host again reaches all of it
+   * again. See the note on `repositories.host_id` in the schema.
+   *
+   * What is *not* removed is anything on the host itself - see "Not done in
+   * M4.2": going onto somebody's server to delete a directory is a different
+   * act, and the dialog says as much.
    */
   remove(input: unknown): { id: number } {
     const { id } = parse(removeHostInputSchema, input)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -24,6 +24,7 @@
  */
 import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
 import { dispatch } from '../core/rpc/dispatcher.js'
+import { route } from '../core/hosts/router.js'
 import { traced } from '../core/trace.js'
 import { attachmentsService } from '../core/services/attachments.js'
 import { AppError } from '../shared/errors.js'
@@ -75,12 +76,23 @@ export function registerIpcHandlers(): void {
     if (typeof payload !== 'object' || payload === null || !('method' in payload)) {
       throw new AppError('INVALID_INPUT', 'A request needs a method.')
     }
-    const { method, params } = payload as { method: RpcMethod; params?: unknown }
-    return dispatch(method, params as RpcParams<RpcMethod>)
+    const { method, params, host } = payload as {
+      method: RpcMethod
+      params?: unknown
+      host?: string
+    }
+    // `route` rather than `dispatch`: since M4.3 the renderer may be looking at
+    // a screen that belongs to another machine, and which machine that is
+    // arrives on the envelope. Everything with no host on it - which is nearly
+    // everything - reaches the same dispatcher it always did.
+    return route(host, method, params as RpcParams<RpcMethod>)
   })
 
   // Every channel that existed before M1, still answering, now through the
   // dispatcher. The table lives in `shared/api.ts` next to the channel names.
+  // Deliberately not routed: these are the pre-M1 shape, one channel per
+  // method with the params as the whole payload, and there is nowhere in that
+  // shape to put a host. They mean what they have always meant - this machine.
   for (const [channel, method] of Object.entries(CHANNEL_METHODS)) {
     // `RpcParams<typeof method>` rather than `RpcParams<RpcMethod>`: the table
     // covers only the pre-M1 channels, so the params union here is the smaller

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -50,13 +50,21 @@ async function invoke<T>(channel: string, payload?: unknown): Promise<T> {
 const inFlight = new Map<string, Promise<unknown>>()
 
 const carrier: Carrier = {
-  request<M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> {
+  request<M extends RpcMethod>(
+    method: M,
+    params: RpcParams<M>,
+    host?: string
+  ): Promise<RpcResult<M>> {
     const send = (): Promise<RpcResult<M>> =>
-      invoke<RpcResult<M>>(IPC_CHANNELS.rpcRequest, { method, params })
+      invoke<RpcResult<M>>(IPC_CHANNELS.rpcRequest, { method, params, host })
 
     if (!isReadMethod(method)) return send()
 
-    const key = `${method}:${JSON.stringify(params ?? null)}`
+    // The host is part of the key, not a detail of it. Without it the
+    // repository list of `pc-wsl` and the repository list of this Mac are the
+    // same question asked twice, and the second component to ask would be
+    // handed the first one's answer.
+    const key = `${host ?? ''}:${method}:${JSON.stringify(params ?? null)}`
     const existing = inFlight.get(key) as Promise<RpcResult<M>> | undefined
     if (existing) return existing
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,13 @@
  * Routing is a hash and a switch (see `lib/router`). The screens are given
  * different amounts of the window - see `reviewWidth` - because a diff needs
  * the room and the rest of the app reads better narrow.
+ *
+ * Since M4.3 the route may also name a *machine*, and this is the only place
+ * that reads it. `HostScopeProvider` puts it where every screen below can get
+ * at the api bound to it (`lib/host-scope`), so nothing in `features/` takes a
+ * host as a prop and nothing has to remember to pass one on. A route with no
+ * host - which is every route this app produced before M4 - provides the local
+ * api, and the tree below is byte-for-byte the tree it was.
  */
 import { useRef } from 'react'
 // `?inline` rather than a bundled file URL: the packaged renderer is loaded
@@ -19,12 +26,14 @@ import { AgentAccessCard } from './features/agent/agent-access-card'
 import { AgentAccessPage } from './features/agent/agent-access-page'
 import { CommandCenter } from './features/commands/command-center'
 import { CommandRegistryProvider } from './features/commands/command-registry'
+import { HostBanner } from './features/hosts/host-banner'
 import { HostsCard } from './features/hosts/hosts-card'
 import { HostsPage } from './features/hosts/hosts-page'
 import { SettingsPanel } from './features/settings/settings-panel'
 import { RepositoryDetail } from './features/repositories/repository-detail'
 import { RepositoryList } from './features/repositories/repository-list'
 import { ReviewDetail } from './features/reviews/review-detail'
+import { HostScopeProvider } from './lib/host-scope'
 import { useRoute, type ReviewTab } from './lib/router'
 import { cn } from './lib/utils'
 
@@ -53,40 +62,58 @@ export function App() {
     // the first one waits and moving along a row of icon buttons then shows
     // each immediately - which is the behaviour that makes a toolbar readable.
     <TooltipProvider>
-      {/* Wraps the screens, because a screen contributes its own commands while
-          it is mounted and the palette has to outlive any one of them. */}
-      <CommandRegistryProvider>
-        <div className="flex h-full flex-col">
-          {/* Draggable strip so the frameless macOS title bar still moves the window. */}
-          <div className="titlebar-drag h-11 shrink-0" />
+      {/* The machine every screen below is about. Read here and nowhere else:
+          the route is the only thing that knows, and one reader means no
+          component can disagree with another about which host it is showing. */}
+      <HostScopeProvider host={route.host}>
+        {/* Wraps the screens, because a screen contributes its own commands
+            while it is mounted and the palette has to outlive any one of them. */}
+        <CommandRegistryProvider>
+          <div className="flex h-full flex-col">
+            {/* Draggable strip so the frameless macOS title bar still moves the window. */}
+            <div className="titlebar-drag h-11 shrink-0" />
 
-          <main
-            ref={scroller}
-            // Focusable only under program control, so returning to the top can
-            // put the keyboard back there too without adding a tab stop.
-            tabIndex={-1}
-            className={cn(
-              'mx-auto w-full flex-1 overflow-y-auto px-6 pb-10 outline-none',
-              route.name === 'review' ? reviewWidth(route.tab) : 'max-w-3xl'
-            )}
-          >
-            <div className="mb-6">
-              <UpdateBanner />
-            </div>
+            <main
+              ref={scroller}
+              // Focusable only under program control, so returning to the top can
+              // put the keyboard back there too without adding a tab stop.
+              tabIndex={-1}
+              className={cn(
+                'mx-auto w-full flex-1 overflow-y-auto px-6 pb-10 outline-none',
+                route.name === 'review' ? reviewWidth(route.tab) : 'max-w-3xl'
+              )}
+            >
+              <div className="mb-6">
+                <UpdateBanner />
+              </div>
 
-            {route.name === 'repositories' && <HomeScreen />}
-            {route.name === 'agent' && <AgentAccessPage />}
-            {route.name === 'hosts' && <HostsPage />}
-            {route.name === 'repository' && <RepositoryDetail repositoryId={route.repositoryId} />}
-            {route.name === 'review' && (
-              <ReviewDetail reviewId={route.reviewId} tab={route.tab} focus={route.focus} />
-            )}
-          </main>
+              {/* Above every screen rather than on each of them: whichever one
+                  you are looking at, the first thing worth knowing is whose
+                  machine it belongs to. Renders nothing when the answer is
+                  "this one". */}
+              <HostBanner />
 
-          <ScrollToTop target={scroller} />
-          <CommandCenter scroller={scroller} />
-        </div>
-      </CommandRegistryProvider>
+              {/* The home screen is this machine's, and only this machine's -
+                  the logo, the agent prompt and the settings are all about the
+                  install you are sitting at. A host's home is its repositories
+                  and nothing else, which is what `#/h/<instance>/` means. */}
+              {route.name === 'repositories' &&
+                (route.host === undefined ? <HomeScreen /> : <RepositoryList />)}
+              {route.name === 'agent' && <AgentAccessPage />}
+              {route.name === 'hosts' && <HostsPage />}
+              {route.name === 'repository' && (
+                <RepositoryDetail repositoryId={route.repositoryId} />
+              )}
+              {route.name === 'review' && (
+                <ReviewDetail reviewId={route.reviewId} tab={route.tab} focus={route.focus} />
+              )}
+            </main>
+
+            <ScrollToTop target={scroller} />
+            <CommandCenter scroller={scroller} />
+          </div>
+        </CommandRegistryProvider>
+      </HostScopeProvider>
     </TooltipProvider>
   )
 }

--- a/src/renderer/src/features/comments/comment-composer.tsx
+++ b/src/renderer/src/features/comments/comment-composer.tsx
@@ -21,6 +21,17 @@
  *
  * The transformations behind the toolbar and the Enter key live in
  * `markdown-editing.ts`, as pure functions over the text and the selection.
+ *
+ * ## Images, on a review that belongs to another machine
+ *
+ * Attaching is off on a host, and that is a decision rather than an oversight.
+ * An attachment is a file in the store of whoever owns the review, and the
+ * comment body names it by a token that only that store can resolve; the
+ * *displaying* half of that - `main/attachment-protocol.ts` resolving
+ * `(host, id)` - is M4.4. Ingesting now would put a real image on `pc-wsl` and
+ * render it here as a broken one, in a comment that cannot be fixed by
+ * anything but editing markdown by hand. Refusing is the kinder failure, and
+ * the text comment underneath it still works perfectly.
  */
 import {
   useCallback,
@@ -50,6 +61,7 @@ import { Tabs, TabsList, TabsPanel, TabsTab } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import { Tooltip } from '@/components/ui/tooltip'
 import { api } from '@/lib/api'
+import { useHost } from '@/lib/host-scope'
 import { errorMessage } from '@/lib/errors'
 import { useKeepAboveKeyboard } from '@/lib/keyboard-inset'
 import { cn } from '@/lib/utils'
@@ -89,6 +101,7 @@ export function CommentComposer({
   onCancel,
   className
 }: CommentComposerProps) {
+  const host = useHost()
   const [value, setValue] = useState(initialValue)
   const [tab, setTab] = useState<'write' | 'preview'>('write')
   const [dragging, setDragging] = useState(false)
@@ -235,6 +248,11 @@ export function CommentComposer({
       const images = files.filter((file) => file.type.startsWith('image/'))
       if (images.length === 0) return
 
+      if (host !== undefined) {
+        setError(new Error(REMOTE_IMAGES_UNSUPPORTED))
+        return
+      }
+
       const state = readState()
       if (!state) return
 
@@ -266,7 +284,7 @@ export function CommentComposer({
         setBusy(false)
       }
     },
-    [applyEdit, readState]
+    [applyEdit, host, readState]
   )
 
   /**
@@ -361,7 +379,11 @@ export function CommentComposer({
               dragging && 'border-primary bg-primary/5'
             )}
           >
-            <Toolbar disabled={disabled} transform={transform} onAttach={() => void pickFile()} />
+            <Toolbar
+              disabled={disabled}
+              transform={transform}
+              onAttach={host === undefined ? () => void pickFile() : undefined}
+            />
             <Textarea
               ref={textareaRef}
               value={value}
@@ -436,7 +458,8 @@ function Toolbar({
 }: {
   disabled: boolean
   transform: (fn: (state: EditorState) => EditorState) => void
-  onAttach: () => void
+  /** Absent when there is nowhere to put an image. See the note at the top. */
+  onAttach: (() => void) | undefined
 }) {
   const actions = [
     { icon: Bold, title: 'Bold (⌘B)', run: (s: EditorState) => wrapInline(s, '**') },
@@ -490,29 +513,45 @@ function Toolbar({
         </Tooltip>
       ))}
 
-      <span className="mx-1 h-4 w-px bg-border" />
+      {/* Absent rather than disabled when there is nowhere to put the image -
+          the same rule the reveal button follows. See the note at the top. */}
+      {onAttach && (
+        <>
+          <span className="mx-1 h-4 w-px bg-border" />
 
-      <Tooltip label="Attach an image">
-        <button
-          type="button"
-          aria-label="Attach an image"
-          disabled={disabled}
-          onMouseDown={(event) => {
-            event.preventDefault()
-            onAttach()
-          }}
-          className={cn(
-            'rounded p-1.5 text-muted-foreground transition-colors',
-            'hover:bg-muted hover:text-foreground',
-            'disabled:pointer-events-none disabled:opacity-50'
-          )}
-        >
-          <ImageIcon className="size-4" />
-        </button>
-      </Tooltip>
+          <Tooltip label="Attach an image">
+            <button
+              type="button"
+              aria-label="Attach an image"
+              disabled={disabled}
+              onMouseDown={(event) => {
+                event.preventDefault()
+                onAttach()
+              }}
+              className={cn(
+                'rounded p-1.5 text-muted-foreground transition-colors',
+                'hover:bg-muted hover:text-foreground',
+                'disabled:pointer-events-none disabled:opacity-50'
+              )}
+            >
+              <ImageIcon className="size-4" />
+            </button>
+          </Tooltip>
+        </>
+      )}
     </div>
   )
 }
+
+/**
+ * Said when someone drops a screenshot onto a review that lives elsewhere.
+ *
+ * Written as a fact about where the file would have to go rather than as
+ * "unsupported", because that is the part a person can do something about:
+ * the same picture pasted into a review on this computer works.
+ */
+const REMOTE_IMAGES_UNSUPPORTED =
+  'Images cannot be attached to a review on another machine yet. The comment text works as usual.'
 
 /**
  * A default alt text, used only when nothing better is available.

--- a/src/renderer/src/features/comments/use-comments.ts
+++ b/src/renderer/src/features/comments/use-comments.ts
@@ -16,7 +16,8 @@
  */
 import { useSWRConfig } from 'swr'
 import { useCallback } from 'react'
-import { api, CACHE_PREFIXES } from '@/lib/api'
+import { CACHE_PREFIXES } from '@/lib/api'
+import { useApi } from '@/lib/host-scope'
 import { useReviewThreads } from '@/features/reviews/use-reviews'
 import type {
   Comment,
@@ -48,6 +49,7 @@ export interface CommentMutations {
 }
 
 export function useCommentMutations(): CommentMutations {
+  const api = useApi()
   const { mutate } = useSWRConfig()
 
   // A comment also bumps its review's `updatedAt`, which reorders every review
@@ -70,7 +72,7 @@ export function useCommentMutations(): CommentMutations {
         await revalidate()
         return thread
       },
-      [revalidate]
+      [api, revalidate]
     ),
     reply: useCallback(
       async (input) => {
@@ -78,7 +80,7 @@ export function useCommentMutations(): CommentMutations {
         await revalidate()
         return comment
       },
-      [revalidate]
+      [api, revalidate]
     ),
     edit: useCallback(
       async (id, body) => {
@@ -86,21 +88,21 @@ export function useCommentMutations(): CommentMutations {
         await revalidate()
         return comment
       },
-      [revalidate]
+      [api, revalidate]
     ),
     remove: useCallback(
       async (id) => {
         await api.comments.remove({ id })
         await revalidate()
       },
-      [revalidate]
+      [api, revalidate]
     ),
     setResolved: useCallback(
       async (threadId, resolved) => {
         await api.comments.setResolved({ threadId, resolved })
         await revalidate()
       },
-      [revalidate]
+      [api, revalidate]
     )
   }
 }

--- a/src/renderer/src/features/hosts/host-banner.tsx
+++ b/src/renderer/src/features/hosts/host-banner.tsx
@@ -1,0 +1,68 @@
+/**
+ * "You are looking at another machine", and the way back.
+ *
+ * The one piece of chrome M4.3 adds, and it is deliberately a strip above every
+ * screen rather than a badge on each of them. Once a repository list, a review
+ * and a diff can all belong to a different computer, *which* computer is the
+ * thing a person has to be able to check without thinking - and a component
+ * that has to be remembered on each screen is a component that will be missing
+ * from the one that mattered.
+ *
+ * It renders nothing at all on a local route, which is nearly every route this
+ * app has ever produced. That asymmetry is the same one the routes have: a
+ * local location looks exactly as it always did, and the machinery only shows
+ * itself when there is something to say.
+ *
+ * The host's *label* is what is shown, not the instance id in the URL. The id
+ * is how machines refer to each other and a UUID is not a name; the label is
+ * what the person typed. A host that has been forgotten since the link was
+ * written has no label to show, and saying so here is better than a screen full
+ * of `NOT_FOUND` with no explanation of which machine failed to be found.
+ */
+import { Server } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useHost } from '@/lib/host-scope'
+import { navigate } from '@/lib/router'
+import { useHosts } from './use-hosts'
+import { ReachabilityBadge } from './host-status'
+
+export function HostBanner() {
+  const host = useHost()
+  // Unconditional: a hook cannot be skipped, and the host list is one local
+  // SQLite read that the home screen has already made and SWR has already
+  // cached. The early return is below.
+  const { hosts } = useHosts()
+
+  if (host === undefined) return null
+
+  const row = hosts?.find((candidate) => candidate.instanceId === host)
+
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-md border border-dashed px-3 py-2">
+      <Server className="size-4 shrink-0 text-muted-foreground" />
+      <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+        <p className="text-sm font-medium">
+          {row ? row.label : 'A host this GitWarren no longer knows'}
+        </p>
+        {row ? (
+          <ReachabilityBadge host={row} />
+        ) : (
+          // The id, in this one case, because it is all there is - and because
+          // it is what the person can compare against the Hosts screen to work
+          // out which machine the link was written on.
+          <span data-selectable className="font-mono text-xs text-muted-foreground">
+            {host}
+          </span>
+        )}
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="shrink-0 text-muted-foreground"
+        onClick={() => navigate({ name: 'repositories' })}
+      >
+        Back to this computer
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/src/features/hosts/host-banner.tsx
+++ b/src/renderer/src/features/hosts/host-banner.tsx
@@ -18,6 +18,18 @@
  * what the person typed. A host that has been forgotten since the link was
  * written has no label to show, and saying so here is better than a screen full
  * of `NOT_FOUND` with no explanation of which machine failed to be found.
+ *
+ * ## Not loaded yet is not the same as not known
+ *
+ * The host list is a read like any other, and for the first frames of a cold
+ * load there is no list - which is not the same claim as "this machine is not
+ * in it". Conflating them made a perfectly ordinary host announce itself as "a
+ * host this GitWarren no longer knows" for half a second on every reload, which
+ * is exactly the lesson `host-status.tsx` already records about a host nobody
+ * has spoken to yet: the honest rendering of an unanswered question is not the
+ * alarming answer. So the sentence is only reached once the list has actually
+ * arrived, and until then the banner says what it does know - that this is
+ * somewhere else - and shows the id.
  */
 import { Server } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -35,21 +47,27 @@ export function HostBanner() {
 
   if (host === undefined) return null
 
-  const row = hosts?.find((candidate) => candidate.instanceId === host)
+  // Undefined while the list is still on its way; null once it has arrived and
+  // this host is genuinely not in it. See the note above.
+  const row = hosts === undefined ? undefined : (hosts.find((c) => c.instanceId === host) ?? null)
 
   return (
     <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-md border border-dashed px-3 py-2">
       <Server className="size-4 shrink-0 text-muted-foreground" />
       <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
         <p className="text-sm font-medium">
-          {row ? row.label : 'A host this GitWarren no longer knows'}
+          {row
+            ? row.label
+            : row === null
+              ? 'A host this GitWarren no longer knows'
+              : 'Another machine'}
         </p>
         {row ? (
           <ReachabilityBadge host={row} />
         ) : (
-          // The id, in this one case, because it is all there is - and because
-          // it is what the person can compare against the Hosts screen to work
-          // out which machine the link was written on.
+          // The id, while there is no label to show - and because it is what
+          // the person can compare against the Hosts screen to work out which
+          // machine the link was written on.
           <span data-selectable className="font-mono text-xs text-muted-foreground">
             {host}
           </span>

--- a/src/renderer/src/features/hosts/host-card.tsx
+++ b/src/renderer/src/features/hosts/host-card.tsx
@@ -1,11 +1,19 @@
 /**
  * One machine, and everything that can be done to it from here.
  *
- * Unlike a repository card this one is not a link. A repository leads somewhere
- * - its reviews - and a host leads nowhere until M4.3 puts repositories under
- * one; making the whole row clickable now would mean teaching people a gesture
- * and then changing what it does. The actions are buttons, and the card is a
- * card.
+ * Since M4.3 a host does lead somewhere - `#/h/<instance>/` is its repository
+ * list - so there is a button that goes there. The card is still a card rather
+ * than one big link, because the other five things on it are actions and a row
+ * where clicking anywhere navigates is a row where "Forget" is one slip away.
+ *
+ * ## The way in appears only once the machine has said who it is
+ *
+ * `#/h/<instance>/` needs an instance id, and a host that has been described
+ * but never reached has none - it is a target somebody typed, and this install
+ * cannot yet tell it from any other machine. So the button is absent until the
+ * first successful connect writes the id back, and "Try now" is what makes it
+ * appear. That is not a limitation worked around; it is the same honesty
+ * `instance_id` being nullable buys everywhere else, arriving at the UI.
  *
  * ## Why the failure is on the card and not behind a tooltip
  *
@@ -16,11 +24,12 @@
  * costs two lines on the rows that are failing and nothing at all on the rows
  * that are not.
  */
-import { Download, Loader2, Pencil, Plug, RefreshCw, Trash2 } from 'lucide-react'
+import { ChevronRight, Download, Loader2, Pencil, Plug, RefreshCw, Trash2 } from 'lucide-react'
 import { Breakable } from '@/components/breakable'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Tooltip } from '@/components/ui/tooltip'
+import { navigate } from '@/lib/router'
 import { DaemonVersionBadge, ReachabilityBadge, needsInstall } from './host-status'
 import type { HostWithState } from '@shared/schemas'
 
@@ -127,6 +136,19 @@ export function HostCard({
               ? 'Update GitWarren'
               : 'Reinstall'}
         </Button>
+        {/* The way in. Present only once there is an instance id to route on -
+            see the note at the top of the file. */}
+        {host.instanceId !== null && (
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={anythingBusy}
+            onClick={() => navigate({ name: 'repositories', host: host.instanceId as string })}
+          >
+            Repositories
+            <ChevronRight />
+          </Button>
+        )}
         {/* Said here rather than only in the install dialog: it is the sentence
             that explains why a host with nothing on it is a normal starting
             point rather than a problem to solve before adding it. */}

--- a/src/renderer/src/features/repositories/directory-browser-dialog.tsx
+++ b/src/renderer/src/features/repositories/directory-browser-dialog.tsx
@@ -1,0 +1,269 @@
+/**
+ * A folder picker for a filesystem this window cannot see.
+ *
+ * `repository-form-dialog.tsx` has carried a comment since M3 saying that a
+ * browser tab has no `pickDirectory` and that a native picker on a remote host
+ * would browse the wrong machine. This is that comment made real, and the shape
+ * follows from the two cases rather than from wanting a nicer picker:
+ *
+ * - In a **browser tab** there is no shell dialog to open at all. The core is
+ *   on the same machine as the files, so a listing is one method call.
+ * - On a **remote host** there is a shell dialog, and using it would be worse
+ *   than not having one: it would show this Mac's folders and produce a path
+ *   `pc-wsl` has never heard of. The native picker is *withheld* here even
+ *   though the shell has one, which is the case that proves this cannot just be
+ *   a capability fallback.
+ *
+ * ## One column, not a tree
+ *
+ * A tree is the obvious shape and the wrong one over a connection. Every
+ * expanded node is a round trip, an open tree is a screenful of them, and the
+ * thing being looked for is one folder rather than a structure worth
+ * understanding. So: one folder at a time, its parent above it, and the path
+ * always visible and always editable - because for someone who knows where they
+ * are going, typing it is faster than any number of clicks, and on a machine
+ * with a hundred repositories under `~/github.com` it is the only reasonable
+ * way in.
+ *
+ * The `.git` badge is the whole reason this beats a text field. It answers "is
+ * this the folder I want" without descending into it, and it is why a listing
+ * carries `isRepository` rather than the screen guessing from a name.
+ */
+import { useState, type FormEvent } from 'react'
+import useSWR from 'swr'
+import { AlertCircle, ChevronRight, CornerLeftUp, Folder, House, Loader2 } from 'lucide-react'
+import { Breakable } from '@/components/breakable'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+import { CACHE_KEYS } from '@/lib/api'
+import { errorMessage } from '@/lib/errors'
+import { useApi, useHost } from '@/lib/host-scope'
+import type { DirectoryListing } from '@shared/schemas'
+
+interface DirectoryBrowserDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Where to start. Absent starts at the answering machine's home directory. */
+  initialPath?: string | undefined
+  /** Called with an absolute path on the machine being browsed. */
+  onChoose: (path: string) => void
+}
+
+export function DirectoryBrowserDialog({
+  open,
+  onOpenChange,
+  initialPath,
+  onChoose
+}: DirectoryBrowserDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        {/* Mounted only while open, so each opening starts from wherever the
+            form's path field points now rather than from wherever the last
+            visit wandered to. Same trick the repository form uses. */}
+        {open && (
+          <Browser
+            initialPath={initialPath}
+            onChoose={(path) => {
+              onChoose(path)
+              onOpenChange(false)
+            }}
+            onCancel={() => onOpenChange(false)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Browser({
+  initialPath,
+  onChoose,
+  onCancel
+}: {
+  initialPath: string | undefined
+  onChoose: (path: string) => void
+  onCancel: () => void
+}) {
+  const api = useApi()
+  const host = useHost()
+
+  // `undefined` means "wherever you start", which the answering machine
+  // decides. Kept distinct from the empty string so that clearing the field
+  // does not silently mean "home" while the field says otherwise.
+  const [path, setPath] = useState<string | undefined>(initialPath)
+  const [typed, setTyped] = useState(initialPath ?? '')
+  const [showHidden, setShowHidden] = useState(false)
+
+  const { data, error, isLoading } = useSWR<DirectoryListing, unknown>(
+    CACHE_KEYS.directory(path, host),
+    () => api.fs.list(path === undefined ? {} : { path }),
+    // The filesystem is not something to poll. A person who has just made a
+    // folder in another window presses Go, which re-reads.
+    { revalidateOnFocus: false, shouldRetryOnError: false, keepPreviousData: true }
+  )
+
+  function go(next: string): void {
+    setPath(next)
+    setTyped(next)
+  }
+
+  function submitTyped(event: FormEvent): void {
+    event.preventDefault()
+    const trimmed = typed.trim()
+    // An empty field means home, which is where an empty `path` starts. Saying
+    // so is better than refusing an empty box.
+    setPath(trimmed === '' ? undefined : trimmed)
+  }
+
+  const entries = (data?.entries ?? []).filter((entry) => showHidden || !entry.isHidden)
+  const hiddenCount = (data?.entries ?? []).length - entries.length
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Choose a folder</DialogTitle>
+        <DialogDescription>
+          {host === undefined
+            ? 'Folders on this computer. A repository is marked; a subfolder of one works too.'
+            : // Named rather than "on the host": the sentence is the reminder
+              // that these are not this machine's folders.
+              'Folders on the machine this list belongs to. A repository is marked.'}
+        </DialogDescription>
+      </DialogHeader>
+
+      <div className="flex min-h-0 flex-col gap-3">
+        <form onSubmit={submitTyped} className="flex gap-2" noValidate>
+          <Input
+            value={typed}
+            onChange={(event) => setTyped(event.target.value)}
+            placeholder={data?.home ?? '/path/to/folder'}
+            className="font-mono text-xs"
+            aria-label="Folder to list"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <Button type="submit" variant="outline" className="shrink-0">
+            Go
+          </Button>
+        </form>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground"
+            onClick={() => {
+              setPath(undefined)
+              setTyped('')
+            }}
+          >
+            <House />
+            Home
+          </Button>
+          {/* Absent at the root of the filesystem, where there is nothing
+              above: `parent` being null is the listing saying so. */}
+          {data?.parent && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground"
+              onClick={() => go(data.parent as string)}
+            >
+              <CornerLeftUp />
+              Up
+            </Button>
+          )}
+          <span className="flex-1" />
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Switch checked={showHidden} onCheckedChange={setShowHidden} />
+            Hidden
+            {hiddenCount > 0 && !showHidden && <span>({hiddenCount})</span>}
+          </label>
+        </div>
+
+        {error !== undefined && (
+          <p
+            role="alert"
+            className="flex items-start gap-2 rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+          >
+            <AlertCircle className="mt-0.5 size-4 shrink-0" />
+            <Breakable text={errorMessage(error)} />
+          </p>
+        )}
+
+        {/* A fixed height rather than one that grows with the folder: a dialog
+            that is three rows tall in one directory and fills the screen in the
+            next makes the buttons under it move while someone is clicking. */}
+        <ul className="h-64 overflow-y-auto rounded-md border">
+          {isLoading && (
+            <li className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Reading…
+            </li>
+          )}
+          {!isLoading && entries.length === 0 && error === undefined && (
+            <li className="px-3 py-2 text-sm text-muted-foreground">
+              {hiddenCount > 0 ? 'Only hidden folders in here.' : 'No folders in here.'}
+            </li>
+          )}
+          {entries.map((entry) => (
+            <li key={entry.path}>
+              <button
+                type="button"
+                onClick={() => go(entry.path)}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-muted"
+              >
+                <Folder className="size-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+                {entry.isRepository && (
+                  <Badge variant="outline" className="shrink-0">
+                    repository
+                  </Badge>
+                )}
+                <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        {data?.truncated && (
+          <p className="text-xs text-muted-foreground">
+            Only the first folders are listed. Type a path above to go straight there.
+          </p>
+        )}
+
+        {data && (
+          <p data-selectable className="break-words font-mono text-xs text-muted-foreground">
+            <Breakable text={data.path} />
+          </p>
+        )}
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        {/* Chooses the folder being *looked at*, not a highlighted row. Rows
+            navigate, because that is what a folder in a picker mostly means,
+            and "the one I am in" is unambiguous in a way a selection that
+            survives a navigation is not. */}
+        <Button type="button" disabled={!data} onClick={() => data && onChoose(data.path)}>
+          Use this folder
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}

--- a/src/renderer/src/features/repositories/repository-card.tsx
+++ b/src/renderer/src/features/repositories/repository-card.tsx
@@ -1,24 +1,55 @@
-import { ChevronRight, FolderOpen, Pencil, Trash2 } from 'lucide-react'
+/**
+ * One repository, as a row that opens it.
+ *
+ * Two things on it are decided by *which machine* the list belongs to, and both
+ * are the same decision made twice. `Show in file manager` is the shell's, and
+ * the shell is on the computer the person is sitting at - so on a repository
+ * that lives on `pc-wsl` it would open a Finder window on a path this Mac does
+ * not have. Absent, rather than disabled or pointed somewhere plausible.
+ *
+ * `alsoHere` is the other half of the clone grouping, and it is a *link*
+ * because that is the useful shape: the point of knowing that the thing you are
+ * looking at on `pc-wsl` is also checked out here is to be able to go and look
+ * at the other one. See `groupClones` in `repository-list.tsx` for how two rows
+ * on two machines are decided to be one repository.
+ */
+import { ChevronRight, FolderOpen, Laptop, Pencil, Trash2 } from 'lucide-react'
 import { Breakable } from '@/components/breakable'
 import { Button } from '@/components/ui/button'
 import { Tooltip } from '@/components/ui/tooltip'
 import { Card } from '@/components/ui/card'
 import { api } from '@/lib/api'
+import { useHost, useHostScope } from '@/lib/host-scope'
 import { navigate } from '@/lib/router'
 import { GitStateBadge } from './git-state'
+import type { Route } from '@shared/routes'
 import type { RepositoryWithGitState } from '@shared/schemas'
+
+/** The same repository, checked out on the computer the person is sitting at. */
+export interface Elsewhere {
+  path: string
+  route: Route
+}
 
 interface RepositoryCardProps {
   repository: RepositoryWithGitState
   onEdit: (repository: RepositoryWithGitState) => void
   onRemove: (repository: RepositoryWithGitState) => void
+  alsoHere?: Elsewhere | undefined
 }
 
-export function RepositoryCard({ repository, onEdit, onRemove }: RepositoryCardProps) {
+export function RepositoryCard({
+  repository,
+  onEdit,
+  onRemove,
+  alsoHere
+}: RepositoryCardProps) {
+  const host = useHost()
+  const scope = useHostScope()
   const missing = !repository.git.exists
 
   function open(): void {
-    navigate({ name: 'repository', repositoryId: repository.id })
+    navigate({ name: 'repository', repositoryId: repository.id, ...scope })
   }
 
   return (
@@ -50,6 +81,21 @@ export function RepositoryCard({ repository, onEdit, onRemove }: RepositoryCardP
         <p data-selectable className="mt-1 break-words font-mono text-xs text-muted-foreground">
           <Breakable text={repository.path} />
         </p>
+        {alsoHere && (
+          <button
+            type="button"
+            // Stops the row's own click: this goes to the *other* clone, which
+            // is the whole reason it is here rather than being a label.
+            onClick={(event) => {
+              event.stopPropagation()
+              navigate(alsoHere.route)
+            }}
+            className="mt-1.5 flex max-w-full items-center gap-1.5 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            <Laptop className="size-3 shrink-0" />
+            <span className="truncate">Also on this computer: {alsoHere.path}</span>
+          </button>
+        )}
       </div>
 
       {/* The row itself opens the repository, so the per-action buttons inside
@@ -62,8 +108,10 @@ export function RepositoryCard({ repository, onEdit, onRemove }: RepositoryCardP
       >
         {/* Absent rather than disabled in a browser tab: a disabled button is a
             promise the shell cannot keep, and there is no file manager to put
-            in front of someone reading this over loopback in Chrome. */}
-        {api.capabilities.revealPath && (
+            in front of someone reading this over loopback in Chrome. Absent for
+            the same reason on a remote host, where this machine's file manager
+            has no such folder to show. */}
+        {api.capabilities.revealPath && host === undefined && (
           <Tooltip label={missing ? 'Folder is missing' : 'Show in file manager'}>
             <Button
               variant="ghost"

--- a/src/renderer/src/features/repositories/repository-detail.tsx
+++ b/src/renderer/src/features/repositories/repository-detail.tsx
@@ -4,6 +4,12 @@
  * The repository itself is re-read here rather than plucked out of the list
  * cache, so the git state shown is current even if you arrived by a link or a
  * reload rather than by clicking through the list.
+ *
+ * On a host, the two shell affordances go away rather than doing something
+ * plausible-looking: `Show in file manager` would open a window on this Mac at
+ * a path only `pc-wsl` has, and the palette command that does the same thing
+ * goes with it. The `e` key and the edit dialog stay, because renaming a
+ * repository is a write to whoever owns it and travels perfectly well.
  */
 import { useMemo, useState } from 'react'
 import { AlertCircle, ArrowLeft, FolderOpen, Pencil } from 'lucide-react'
@@ -13,8 +19,9 @@ import { Button } from '@/components/ui/button'
 import { Tooltip } from '@/components/ui/tooltip'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { api, CACHE_KEYS } from '@/lib/api'
+import { CACHE_KEYS } from '@/lib/api'
 import { errorMessage } from '@/lib/errors'
+import { useApi, useHost, useHostScope } from '@/lib/host-scope'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
 import { navigate } from '@/lib/router'
 import { ReviewList } from '@/features/reviews/review-list'
@@ -23,10 +30,13 @@ import { RepositoryFormDialog } from './repository-form-dialog'
 import type { RepositoryWithGitState } from '@shared/schemas'
 
 export function RepositoryDetail({ repositoryId }: { repositoryId: number }) {
+  const api = useApi()
+  const host = useHost()
+  const scope = useHostScope()
   const [editing, setEditing] = useState(false)
 
   const { data: repository, error, isLoading } = useSWR<RepositoryWithGitState, unknown>(
-    `${CACHE_KEYS.repositories}:${repositoryId}`,
+    CACHE_KEYS.repository(repositoryId, host),
     () => api.repositories.get({ id: repositoryId })
   )
 
@@ -48,7 +58,9 @@ export function RepositoryDetail({ repositoryId }: { repositoryId: number }) {
               },
               // A shell with no file manager to reach contributes no command
               // and no `o` key, rather than one that answers with a sentence.
-              ...(api.capabilities.revealPath
+              // Neither does a repository on another machine, whose folder this
+              // machine's file manager does not have.
+              ...(api.capabilities.revealPath && host === undefined
                 ? ([
                     {
                       id: 'repository:reveal',
@@ -66,7 +78,7 @@ export function RepositoryDetail({ repositoryId }: { repositoryId: number }) {
                   ] satisfies Command[])
                 : [])
             ],
-      [repository]
+      [api, host, repository]
     )
   )
 
@@ -95,7 +107,7 @@ export function RepositoryDetail({ repositoryId }: { repositoryId: number }) {
             {error === undefined ? 'It may have been removed.' : errorMessage(error)}
           </p>
         </div>
-        <Button variant="outline" onClick={() => navigate({ name: 'repositories' })}>
+        <Button variant="outline" onClick={() => navigate({ name: 'repositories', ...scope })}>
           <ArrowLeft />
           Back to repositories
         </Button>
@@ -112,7 +124,7 @@ export function RepositoryDetail({ repositoryId }: { repositoryId: number }) {
           variant="ghost"
           size="sm"
           className="-ml-2 mb-2 text-muted-foreground"
-          onClick={() => navigate({ name: 'repositories' })}
+          onClick={() => navigate({ name: 'repositories', ...scope })}
         >
           <ArrowLeft />
           Repositories
@@ -135,7 +147,7 @@ export function RepositoryDetail({ repositoryId }: { repositoryId: number }) {
           </div>
 
           <div className="flex shrink-0 items-center gap-1">
-            {api.capabilities.revealPath && (
+            {api.capabilities.revealPath && host === undefined && (
               <Tooltip label={missing ? 'Folder is missing' : 'Show in file manager'}>
                 <Button
                   variant="ghost"

--- a/src/renderer/src/features/repositories/repository-form-dialog.tsx
+++ b/src/renderer/src/features/repositories/repository-form-dialog.tsx
@@ -11,9 +11,27 @@
  * That is what resets it between openings: fresh mount, fresh `useState`, no
  * effect writing state back on open and no values left over from a previous
  * attempt.
+ *
+ * ## Which machine the folder is on
+ *
+ * There is no host picker on this form, and there was very nearly one. The
+ * reason there is not is that the form is already *on* a machine: it is opened
+ * from a repository list, and a repository list belongs to exactly one install.
+ * Adding a host dropdown here would be a second way to say the same thing, and
+ * two ways to say it means they can disagree - a form set to `pc-wsl` sitting
+ * on this Mac's list, submitting a row that then does not appear above it. The
+ * way to add a repository on `pc-wsl` is to be looking at `pc-wsl`, which is
+ * one click from the Hosts screen and is also where the result shows up.
+ *
+ * What that leaves is the folder, and browsing for it is the part that had to
+ * be built: `api.system.pickDirectory` opens a window on the machine the person
+ * is sitting at, which is the wrong machine whenever this form is on a host.
+ * So the native picker is used in exactly one case - a local form in the
+ * Electron window - and `DirectoryBrowserDialog` covers the other two, a
+ * browser tab and any host. See the note at the top of that file.
  */
 import { useState, type FormEvent } from 'react'
-import { FolderOpen, Loader2 } from 'lucide-react'
+import { FolderOpen, FolderSearch, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -27,7 +45,9 @@ import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui
 import { Input } from '@/components/ui/input'
 import { api } from '@/lib/api'
 import { errorCode, errorMessage, firstFieldError } from '@/lib/errors'
+import { useHost } from '@/lib/host-scope'
 import { basename } from '@/lib/path'
+import { DirectoryBrowserDialog } from './directory-browser-dialog'
 import { useRepositoryMutations } from './use-repositories'
 import { addRepositoryInputSchema, updateRepositoryInputSchema } from '@shared/schemas'
 import { parseWithSchema } from '@shared/validation'
@@ -67,16 +87,27 @@ interface RepositoryFormProps {
 
 function RepositoryForm({ repository, onDone }: RepositoryFormProps) {
   const isEditing = repository !== undefined
+  const host = useHost()
   const { addRepository, updateRepository } = useRepositoryMutations()
 
   const [path, setPath] = useState(repository?.path ?? '')
   const [name, setName] = useState(repository?.name ?? '')
+  const [browsing, setBrowsing] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<unknown>(null)
 
-  async function browse(): Promise<void> {
+  // The native dialog only where it would open on the right machine. See the
+  // note at the top of the file.
+  const nativePicker = api.capabilities.pickDirectory && host === undefined
+
+  async function browseNatively(): Promise<void> {
     const picked = await api.system.pickDirectory()
     if (!picked) return
+    setPath(picked)
+    setError(null)
+  }
+
+  function chose(picked: string): void {
     setPath(picked)
     setError(null)
   }
@@ -132,11 +163,11 @@ function RepositoryForm({ repository, onDone }: RepositoryFormProps) {
         <DialogDescription>
           {isEditing
             ? 'Rename this repository, or point it at a new location if you moved it.'
-            : api.capabilities.pickDirectory
+            : host === undefined
               ? 'Choose any folder inside a git repository. GitWarren stores the repository root.'
-              : // No Browse button to choose with, so the sentence says what the
-                // remaining half of the form actually wants.
-                'Type the path of any folder inside a git repository. GitWarren stores the repository root.'}
+              : // Said plainly, because the path about to be typed is a path on
+                // a machine that is not the one under the keyboard.
+                'Choose a folder on that machine. GitWarren stores the repository root.'}
         </DialogDescription>
       </DialogHeader>
 
@@ -154,17 +185,28 @@ function RepositoryForm({ repository, onDone }: RepositoryFormProps) {
               autoComplete="off"
               spellCheck={false}
             />
-            {/* A tab has no folder picker, so the field beside this is the
-                whole of the interaction there - which is also what adding a
-                repository on a remote host will look like in M4. */}
-            {api.capabilities.pickDirectory && (
+            {/* Two buttons that do the same job on two different machines, and
+                never both: the shell's own dialog when the folder is on the
+                machine with the window, and a listing read over the carrier
+                otherwise - a browser tab, or any host. */}
+            {nativePicker ? (
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => void browse()}
+                onClick={() => void browseNatively()}
                 className="shrink-0"
               >
                 <FolderOpen />
+                Browse
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setBrowsing(true)}
+                className="shrink-0"
+              >
+                <FolderSearch />
                 Browse
               </Button>
             )}
@@ -207,6 +249,13 @@ function RepositoryForm({ repository, onDone }: RepositoryFormProps) {
           </p>
         )}
       </div>
+
+      <DirectoryBrowserDialog
+        open={browsing}
+        onOpenChange={setBrowsing}
+        initialPath={path.trim() === '' ? undefined : path.trim()}
+        onChoose={chose}
+      />
 
       <DialogFooter>
         <Button type="button" variant="ghost" onClick={onDone}>

--- a/src/renderer/src/features/repositories/repository-list.tsx
+++ b/src/renderer/src/features/repositories/repository-list.tsx
@@ -3,23 +3,99 @@
  *
  * The states are kept in one place rather than scattered through the tree so
  * it is obvious that all four are actually handled.
+ *
+ * Since M4.3 this is also a whole screen on its own: `#/h/<instance>/` is a
+ * host's repositories, and it is the same component, reading through the api
+ * the route bound it to. There is no second list component and no `host` prop -
+ * see `lib/host-scope.tsx`.
+ *
+ * ## The list that is offline is a list, not a blank page
+ *
+ * On a remote host every read here is an `ssh` connection, so "could not load"
+ * stops being a broken app and becomes an ordinary answer: the machine is
+ * asleep. `HOST_OFFLINE` therefore gets its own state with the sentence `ssh`
+ * produced and a Try again, rather than the generic failure a missing git would
+ * give - the two need completely different things done about them. What that
+ * state currently depends on, and where it therefore does and does not render,
+ * is written down next to it in `ErrorState`.
+ *
+ * ## Clones, and which direction the comparison runs
+ *
+ * Two checkouts of one project on two machines share a root commit and nothing
+ * else - not their path, and usually not their name. So when the list belongs
+ * to a host, each row is matched against *this computer's* repositories by root
+ * commit, and a match becomes a link to the local clone.
+ *
+ * It runs in that direction and not the other because of what each list costs.
+ * This machine's repositories are one local SQLite read, free from anywhere;
+ * another machine's are a connection, and a home screen that annotated its rows
+ * with "also on ..." would have to open an `ssh` session to every host in the
+ * list in order to render - which is exactly the thing `core/hosts/pool.ts`
+ * exists to avoid. The comparison is made where it is free.
  */
 import { useCallback, useMemo, useState } from 'react'
-import { AlertCircle, FolderGit2, Plus, RefreshCw } from 'lucide-react'
+import useSWR from 'swr'
+import { AlertCircle, FolderGit2, Plus, PlugZap, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip } from '@/components/ui/tooltip'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { api, CACHE_KEYS } from '@/lib/api'
 import { errorCode, errorMessage } from '@/lib/errors'
+import { useHost } from '@/lib/host-scope'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
-import { RepositoryCard } from './repository-card'
+import { RepositoryCard, type Elsewhere } from './repository-card'
 import { RepositoryFormDialog } from './repository-form-dialog'
 import { RemoveRepositoryDialog } from './remove-repository-dialog'
 import { useRepositories } from './use-repositories'
 import type { RepositoryWithGitState } from '@shared/schemas'
 
+/**
+ * The local clone of each of these, by root commit.
+ *
+ * Empty when the list already *is* this computer's - a row is not "also" where
+ * it already is. Repositories with no commits yet have no root and are not a
+ * group: two empty repositories are two empty repositories.
+ *
+ * First match wins where a machine has the same project checked out twice. The
+ * card carries one line, and "one of the places this also is" is a more useful
+ * thing to be told than nothing.
+ */
+function localClonesByRoot(
+  host: string | undefined,
+  local: RepositoryWithGitState[] | undefined
+): Map<string, Elsewhere> {
+  const byRoot = new Map<string, Elsewhere>()
+  if (host === undefined || !local) return byRoot
+
+  for (const repository of local) {
+    const root = repository.git.rootCommit
+    if (root === null || byRoot.has(root)) continue
+    byRoot.set(root, {
+      path: repository.path,
+      // No host on the route: this is the local clone, and a local route is
+      // what takes the reader back to this machine.
+      route: { name: 'repository', repositoryId: repository.id }
+    })
+  }
+  return byRoot
+}
+
 export function RepositoryList() {
+  const host = useHost()
   const { repositories, error, isLoading, isRefreshing, refresh } = useRepositories()
+
+  // Always this machine's, whatever the screen is showing. On a local screen
+  // this is the same SWR key the line above used, so it costs nothing; on a
+  // host's screen it is one local SQLite read.
+  const { data: localRepositories } = useSWR<RepositoryWithGitState[], unknown>(
+    CACHE_KEYS.repositories(),
+    () => api.repositories.list()
+  )
+  const clones = useMemo(
+    () => localClonesByRoot(host, localRepositories),
+    [host, localRepositories]
+  )
 
   const [formOpen, setFormOpen] = useState(false)
   const [editing, setEditing] = useState<RepositoryWithGitState | undefined>(undefined)
@@ -93,7 +169,9 @@ export function RepositoryList() {
 
       {isLoading && <LoadingState />}
 
-      {!isLoading && error !== undefined && <ErrorState error={error} onRetry={() => void refresh()} />}
+      {!isLoading && error !== undefined && (
+        <ErrorState error={error} onRetry={() => void refresh()} />
+      )}
 
       {!isLoading && error === undefined && repositories?.length === 0 && (
         <EmptyState onAdd={openAdd} />
@@ -107,6 +185,11 @@ export function RepositoryList() {
                 repository={repository}
                 onEdit={openEdit}
                 onRemove={setRemoving}
+                alsoHere={
+                  repository.git.rootCommit === null
+                    ? undefined
+                    : clones.get(repository.git.rootCommit)
+                }
               />
             </li>
           ))}
@@ -168,6 +251,40 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
 
 function ErrorState({ error, onRetry }: { error: unknown; onRetry: () => void }) {
   const code = errorCode(error)
+
+  // A machine that is asleep is not a broken app, and the sentence `ssh`
+  // produced ("Could not resolve hostname", "Permission denied (publickey)")
+  // is the only thing on the screen that says what to go and fix.
+  //
+  // This branch reaches a browser tab today and not the Electron window, and
+  // the reason is older than this slice: `contextBridge` strips everything but
+  // `message` off a rejection, so `AppError.code` and `fieldErrors` do not
+  // survive the preload - which is also why the add-repository form has been
+  // showing duplicate-path errors in its general slot rather than under the
+  // field. M4.3 found it and deliberately did not fix it here; see "What
+  // M4.3 found and left alone" in docs/across-hosts.md. In the window the
+  // generic state below still renders `errorMessage(error)`, which is the same
+  // sentence - it just arrives under a heading about git rather than about a
+  // sleeping machine.
+  if (code === 'HOST_OFFLINE') {
+    return (
+      <Card className="flex flex-col items-center gap-3 border-dashed px-6 py-12 text-center">
+        <div className="rounded-full bg-muted p-3 text-muted-foreground">
+          <PlugZap className="size-6" />
+        </div>
+        <div>
+          <h3 className="font-medium">This host is not answering</h3>
+          <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+            {errorMessage(error)}
+          </p>
+        </div>
+        <Button variant="outline" onClick={onRetry} className="mt-1">
+          <RefreshCw />
+          Try again
+        </Button>
+      </Card>
+    )
+  }
 
   return (
     <Card className="flex flex-col items-center gap-3 border-destructive/40 px-6 py-12 text-center">

--- a/src/renderer/src/features/repositories/use-repositories.ts
+++ b/src/renderer/src/features/repositories/use-repositories.ts
@@ -9,7 +9,8 @@
  */
 import useSWR, { useSWRConfig } from 'swr'
 import { useCallback } from 'react'
-import { api, CACHE_KEYS } from '@/lib/api'
+import { CACHE_KEYS } from '@/lib/api'
+import { useApi, useHost } from '@/lib/host-scope'
 import type {
   AddRepositoryInput,
   Repository,
@@ -27,10 +28,12 @@ export interface UseRepositoriesResult {
 }
 
 export function useRepositories(): UseRepositoriesResult {
+  const api = useApi()
+  const host = useHost()
   const { data, error, isLoading, isValidating, mutate } = useSWR<
     RepositoryWithGitState[],
     unknown
-  >(CACHE_KEYS.repositories, () => api.repositories.list())
+  >(CACHE_KEYS.repositories(host), () => api.repositories.list())
 
   return {
     repositories: data,
@@ -48,8 +51,10 @@ export interface RepositoryMutations {
 }
 
 export function useRepositoryMutations(): RepositoryMutations {
+  const api = useApi()
+  const host = useHost()
   const { mutate } = useSWRConfig()
-  const revalidate = useCallback(() => mutate(CACHE_KEYS.repositories), [mutate])
+  const revalidate = useCallback(() => mutate(CACHE_KEYS.repositories(host)), [host, mutate])
 
   return {
     addRepository: useCallback(
@@ -58,7 +63,7 @@ export function useRepositoryMutations(): RepositoryMutations {
         await revalidate()
         return created
       },
-      [revalidate]
+      [api, revalidate]
     ),
     updateRepository: useCallback(
       async (input) => {
@@ -66,14 +71,14 @@ export function useRepositoryMutations(): RepositoryMutations {
         await revalidate()
         return updated
       },
-      [revalidate]
+      [api, revalidate]
     ),
     removeRepository: useCallback(
       async (id) => {
         await api.repositories.remove({ id })
         await revalidate()
       },
-      [revalidate]
+      [api, revalidate]
     )
   }
 }

--- a/src/renderer/src/features/reviews/review-detail.tsx
+++ b/src/renderer/src/features/reviews/review-detail.tsx
@@ -37,6 +37,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsCount, TabsList, TabsPanel, TabsTab } from '@/components/ui/tabs'
 import { errorMessage } from '@/lib/errors'
 import { plural } from '@/lib/format'
+import { useHostScope } from '@/lib/host-scope'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
 import { navigate, replace, REVIEW_TABS, type DiffFocus, type ReviewTab } from '@/lib/router'
 import { useReviewComments } from '../comments/use-comments'
@@ -78,6 +79,10 @@ interface ReviewDetailProps {
 }
 
 export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
+  // Every link out of this screen has to carry the host, or a reviewer three
+  // clicks into a machine's diff is walked back to their own repositories by a
+  // breadcrumb.
+  const scope = useHostScope()
   const { data: review, error, isLoading } = useReview(reviewId)
   const { updateReview } = useReviewMutations()
   const commits = useReviewCommits(reviewId)
@@ -124,7 +129,7 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
                   keywords: 'tab',
                   icon: TAB_ICONS[name],
                   disabled: tab === name,
-                  run: () => replace({ name: 'review', reviewId, tab: name })
+                  run: () => replace({ name: 'review', reviewId, tab: name, ...scope })
                 })
               ),
               {
@@ -154,7 +159,8 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
                 keys: 'g r',
                 keywords: 'repository parent',
                 icon: ArrowLeft,
-                run: () => navigate({ name: 'repository', repositoryId: review.repositoryId })
+                run: () =>
+                  navigate({ name: 'repository', repositoryId: review.repositoryId, ...scope })
               },
               {
                 id: 'review:remove',
@@ -167,7 +173,7 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
                 run: () => setRemoving(review)
               }
             ],
-      [review, reviewId, tab, statusBusy, toggleStatus]
+      [review, reviewId, scope, tab, statusBusy, toggleStatus]
     )
   )
 
@@ -185,7 +191,7 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
             {error === undefined ? 'It may have been deleted.' : errorMessage(error)}
           </p>
         </div>
-        <Button variant="outline" onClick={() => navigate({ name: 'repositories' })}>
+        <Button variant="outline" onClick={() => navigate({ name: 'repositories', ...scope })}>
           <ArrowLeft />
           Back to repositories
         </Button>
@@ -205,7 +211,9 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
           variant="ghost"
           size="sm"
           className="-ml-2 mb-2 text-muted-foreground"
-          onClick={() => navigate({ name: 'repository', repositoryId: review.repositoryId })}
+          onClick={() =>
+            navigate({ name: 'repository', repositoryId: review.repositoryId, ...scope })
+          }
         >
           <ArrowLeft />
           {review.repository.name}
@@ -299,7 +307,7 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
         onValueChange={(next) =>
           // No focus: clicking a tab is a fresh arrival, not a jump to a line
           // someone asked for a moment ago.
-          replace({ name: 'review', reviewId, tab: next as ReviewTab })
+          replace({ name: 'review', reviewId, tab: next as ReviewTab, ...scope })
         }
       >
         <TabsList>
@@ -339,7 +347,9 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
         onOpenChange={(open) => {
           if (!open) setRemoving(null)
         }}
-        onRemoved={() => navigate({ name: 'repository', repositoryId: review.repositoryId })}
+        onRemoved={() =>
+          navigate({ name: 'repository', repositoryId: review.repositoryId, ...scope })
+        }
       />
     </div>
   )

--- a/src/renderer/src/features/reviews/review-files-tab.tsx
+++ b/src/renderer/src/features/reviews/review-files-tab.tsx
@@ -40,6 +40,7 @@ import { api } from '@/lib/api'
 import { errorMessage } from '@/lib/errors'
 import { formatStep } from '@/lib/keys'
 import { plural } from '@/lib/format'
+import { useHost } from '@/lib/host-scope'
 import { useNarrow } from '@/lib/narrow'
 import { useStoredFlag, useStoredPreference } from '@/lib/preferences'
 import { revealElement } from '@/lib/reveal'
@@ -339,6 +340,7 @@ function useFilesLayout(): {
 }
 
 export function ReviewFilesTab({ review, focus }: { review: Review; focus?: DiffFocus }) {
+  const host = useHost()
   const [changes, setChanges] = useState<DiffChanges>(DEFAULT_DIFF_CHANGES)
   const [editorId, setEditorId] = useStoredPreference('editor', null)
   const [openError, setOpenError] = useState<unknown>(null)
@@ -346,7 +348,19 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
   const { data, error, isLoading, isRefreshing, refresh } = useReviewDiff(review.id, changes)
   const { threads } = useReviewComments(review.id)
   const mutations = useCommentMutations()
-  const editors = useEditors()
+  const localEditors = useEditors()
+  /**
+   * No editors on a review that belongs to another machine, and therefore no
+   * open-in-editor buttons and no editor picker.
+   *
+   * `reviews.filePath` answers with a path on the *host*, and `openInEditor` is
+   * this machine's shell - so the two halves that M1 deliberately kept separate
+   * would be joined across a network and hand a Mac editor a path only WSL has.
+   * The honest form of that is an editor list with nothing in it, which every
+   * control below already knows how to render: this is the same shape a browser
+   * tab has had since M3.
+   */
+  const editors = host === undefined ? localEditors : undefined
 
   const threadsByFile = useMemo(
     () => anchorByFile(data?.files ?? [], threads),
@@ -426,7 +440,18 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
     return counts
   }, [threadsByFile])
 
-  const openInEditor = useCallback(
+  /**
+   * Opening a file, and the reason there is a second name for it below.
+   *
+   * `FileActions` in `diff-view.tsx` decides whether to draw the button from
+   * whether it was given a *callback*, not from whether there is an editor
+   * list - so leaving the list empty for a remote host turned off the picker
+   * and left the button, and pressing it asked *this* install for
+   * `reviews.filePath` of a review id that means something else over there.
+   * Found by pressing it against `pc-wsl`, which is the one failure shape this
+   * slice set out to avoid: doing something plausible to the wrong file.
+   */
+  const openLocally = useCallback(
     (path: string, line: number) => {
       setOpenError(null)
       api.reviews
@@ -441,6 +466,9 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
     },
     [review.id, changes, editorId]
   )
+
+  // Undefined on a review that belongs to another machine - see the note above.
+  const openInEditor = host === undefined ? openLocally : undefined
 
   const marked = useFocusScroll(focus, !isLoading && data !== undefined)
 

--- a/src/renderer/src/features/reviews/review-list.tsx
+++ b/src/renderer/src/features/reviews/review-list.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { errorMessage } from '@/lib/errors'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
 import { absoluteTime, relativeTime } from '@/lib/format'
+import { useHostScope } from '@/lib/host-scope'
 import { navigate } from '@/lib/router'
 import { cn } from '@/lib/utils'
 import { ReviewFormDialog } from './review-form-dialog'
@@ -29,6 +30,7 @@ const FILTERS: { value: Filter; label: string }[] = [
 ]
 
 export function ReviewList({ repositoryId }: { repositoryId: number }) {
+  const scope = useHostScope()
   const [filter, setFilter] = useState<Filter>('open')
   const [formOpen, setFormOpen] = useState(false)
 
@@ -150,24 +152,32 @@ export function ReviewList({ repositoryId }: { repositoryId: number }) {
         open={formOpen}
         onOpenChange={setFormOpen}
         repositoryId={repositoryId}
-        onCreated={(review) => navigate({ name: 'review', reviewId: review.id, tab: 'files' })}
+        onCreated={(review) =>
+          navigate({ name: 'review', reviewId: review.id, tab: 'files', ...scope })
+        }
       />
     </section>
   )
 }
 
 function ReviewCard({ review }: { review: Review }) {
+  const scope = useHostScope()
+
+  function open(): void {
+    navigate({ name: 'review', reviewId: review.id, tab: 'conversation', ...scope })
+  }
+
   return (
     <Card
       role="button"
       tabIndex={0}
       // Picked up by the j/k shortcuts; the browser's own focus does the rest.
       data-nav-item
-      onClick={() => navigate({ name: 'review', reviewId: review.id, tab: 'conversation' })}
+      onClick={open}
       onKeyDown={(event) => {
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault()
-          navigate({ name: 'review', reviewId: review.id, tab: 'conversation' })
+          open()
         }
       }}
       className="flex cursor-pointer items-center gap-4 p-4 transition-colors hover:border-foreground/20"

--- a/src/renderer/src/features/reviews/use-reviews.ts
+++ b/src/renderer/src/features/reviews/use-reviews.ts
@@ -15,6 +15,7 @@
 import useSWR, { useSWRConfig, type SWRResponse } from 'swr'
 import { useCallback, useMemo, useState } from 'react'
 import { api, CACHE_KEYS, CACHE_PREFIXES } from '@/lib/api'
+import { useApi, useHost } from '@/lib/host-scope'
 import type { EditorList } from '@shared/api'
 import type { ReviewOpen } from '@shared/rpc'
 import type {
@@ -72,8 +73,10 @@ export function useReviews(
   repositoryId: number | undefined,
   status?: ReviewStatus
 ): ListState<Review[]> {
+  const api = useApi()
+  const host = useHost()
   return toState(
-    useSWR<Review[], unknown>(CACHE_KEYS.reviews(repositoryId, status), () =>
+    useSWR<Review[], unknown>(CACHE_KEYS.reviews(repositoryId, status, host), () =>
       api.reviews.list({
         ...(repositoryId === undefined ? {} : { repositoryId }),
         ...(status === undefined ? {} : { status })
@@ -99,8 +102,10 @@ export function useReviews(
  * them separately would cost a round trip each.
  */
 function useReviewOpen(reviewId: number): SWRResponse<ReviewOpen, unknown> {
+  const api = useApi()
+  const host = useHost()
   return useSWR<ReviewOpen, unknown>(
-    CACHE_KEYS.review(reviewId),
+    CACHE_KEYS.review(reviewId, host),
     () => api.reviews.open({ id: reviewId }),
     { revalidateOnFocus: true, refreshInterval: 15_000 }
   )
@@ -118,9 +123,11 @@ export function useReviewThreads(reviewId: number): ListState<CommentThread[]> {
 }
 
 export function useReviewCommits(reviewId: number): ListState<ReviewCommits> {
+  const api = useApi()
+  const host = useHost()
   return toState(
     useSWR<ReviewCommits, unknown>(
-      CACHE_KEYS.reviewCommits(reviewId),
+      CACHE_KEYS.reviewCommits(reviewId, host),
       () => api.reviews.commits({ id: reviewId }),
       LIVE_READ_OPTIONS
     )
@@ -138,9 +145,11 @@ export function useReviewCommits(reviewId: number): ListState<ReviewCommits> {
 export const DEFAULT_DIFF_CHANGES: DiffChanges = 'all'
 
 export function useReviewDiff(reviewId: number, changes: DiffChanges): ListState<ReviewDiff> {
+  const api = useApi()
+  const host = useHost()
   return toState(
     useSWR<ReviewDiff, unknown>(
-      CACHE_KEYS.reviewDiff(reviewId, changes),
+      CACHE_KEYS.reviewDiff(reviewId, changes, host),
       () => api.reviews.diff({ id: reviewId, changes }),
       LIVE_READ_OPTIONS
     )
@@ -170,9 +179,11 @@ export function useReviewFile(
   path: string,
   changes: DiffChanges
 ): FileContentState {
+  const api = useApi()
+  const host = useHost()
   const [requested, setRequested] = useState(false)
   const result = useSWR<FileContent, unknown>(
-    requested && reviewId !== null ? CACHE_KEYS.reviewFile(reviewId, path, changes) : null,
+    requested && reviewId !== null ? CACHE_KEYS.reviewFile(reviewId, path, changes, host) : null,
     () => api.reviews.file({ id: reviewId as number, path, changes }),
     LIVE_READ_OPTIONS
   )
@@ -200,8 +211,10 @@ export function useReviewImage(
   side: DiffFileSide,
   changes: DiffChanges
 ): { image: FileImage | undefined; error: unknown; isLoading: boolean } {
+  const api = useApi()
+  const host = useHost()
   const result = useSWR<FileImage, unknown>(
-    path === null ? null : CACHE_KEYS.reviewImage(reviewId, path, side, changes),
+    path === null ? null : CACHE_KEYS.reviewImage(reviewId, path, side, changes, host),
     () => api.reviews.image({ id: reviewId, path: path as string, side, changes }),
     LIVE_READ_OPTIONS
   )
@@ -222,9 +235,11 @@ export function useEditors(): EditorList | undefined {
 
 /** Branches, tags and worktrees for the endpoint pickers. */
 export function useRepositoryRefs(repositoryId: number | null): ListState<RepositoryRefs> {
+  const api = useApi()
+  const host = useHost()
   return toState(
     useSWR<RepositoryRefs, unknown>(
-      repositoryId === null ? null : CACHE_KEYS.repositoryRefs(repositoryId),
+      repositoryId === null ? null : CACHE_KEYS.repositoryRefs(repositoryId, host),
       () => api.repositories.refs({ id: repositoryId as number }),
       LIVE_READ_OPTIONS
     )
@@ -259,6 +274,7 @@ export interface ReviewedFilesState {
  * and revalidates, which is the same read the screen already trusts.
  */
 export function useReviewedFiles(reviewId: number): ReviewedFilesState {
+  const api = useApi()
   const { data, isLoading, mutate } = useReviewOpen(reviewId)
 
   const files = data?.reviewedFiles ?? NO_REVIEWED_FILES
@@ -297,7 +313,7 @@ export function useReviewedFiles(reviewId: number): ReviewedFilesState {
         { optimisticData: next, revalidate: false, rollbackOnError: true }
       )
     },
-    [data, mutate, reviewId]
+    [api, data, mutate, reviewId]
   )
 
   return { digests, isLoading, setReviewed }
@@ -310,6 +326,7 @@ export interface ReviewMutations {
 }
 
 export function useReviewMutations(): ReviewMutations {
+  const api = useApi()
   const { mutate } = useSWRConfig()
 
   // Every review family at once: a change to one review can move it between
@@ -331,7 +348,7 @@ export function useReviewMutations(): ReviewMutations {
         await revalidate()
         return created
       },
-      [revalidate]
+      [api, revalidate]
     ),
     updateReview: useCallback(
       async (input) => {
@@ -339,14 +356,14 @@ export function useReviewMutations(): ReviewMutations {
         await revalidate()
         return updated
       },
-      [revalidate]
+      [api, revalidate]
     ),
     removeReview: useCallback(
       async (id) => {
         await api.reviews.remove({ id })
         await revalidate()
       },
-      [revalidate]
+      [api, revalidate]
     )
   }
 }

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -7,6 +7,25 @@
  * object method below is one `carrier.request`, so the day a browser tab
  * supplies a WebSocket carrier instead of the IPC one, nothing above this file
  * changes. There is still no fetch client and no API base URL.
+ *
+ * ## Since M4.3 there is one of these per machine
+ *
+ * `apiFor(host)` binds every method to an install, and `api` is `apiFor()` -
+ * this one. A screen never passes a host to a call; it uses the api it was
+ * handed, and `useApi()` in `lib/host-scope.tsx` hands it the one the current
+ * route is about. Which is why nothing in `features/` had to learn what a host
+ * is: `api.reviews.diff(...)` on a host-scoped screen already means "on that
+ * host", because the object it was called on says so.
+ *
+ * Binding rather than a parameter also keeps a whole class of bug out of reach.
+ * A host threaded through as an argument is a host that can be *forgotten* at
+ * one call site out of forty, and the failure mode of forgetting it is silent:
+ * the local answer, rendered under a remote heading. There is no argument to
+ * forget.
+ *
+ * The shell half is not bound to anything and never will be. Revealing a path,
+ * opening a picker, launching an editor: those happen on the machine with the
+ * screen on it, whatever the screen is showing. See `ShellCapabilities`.
  */
 import type { GitWarrenApi, GitWarrenBridge } from '@shared/api'
 import type { DiffChanges } from '@shared/git'
@@ -35,72 +54,135 @@ function once<T>(read: () => Promise<T>): () => Promise<T> {
   return () => (pending ??= read())
 }
 
-export const api: GitWarrenApi = {
-  // Read once, at module scope, because it is read during render and cannot
-  // change while the page is open. A screen asks `api.capabilities.revealPath`
-  // and leaves the button out; see `ShellCapabilities` on why that is better
-  // than a button that explains itself when pressed.
-  capabilities: shell.capabilities,
-  hosts: {
-    list: () => carrier.request('hosts.list', undefined),
-    get: (input) => carrier.request('hosts.get', input),
-    add: (input) => carrier.request('hosts.add', input),
-    update: (input) => carrier.request('hosts.update', input),
-    remove: (input) => carrier.request('hosts.remove', input),
-    probe: (input) => carrier.request('hosts.probe', input),
-    install: (input) => carrier.request('hosts.install', input)
-  },
-  repositories: {
-    list: () => carrier.request('repositories.list', undefined),
-    get: (input) => carrier.request('repositories.get', input),
-    add: (input) => carrier.request('repositories.add', input),
-    update: (input) => carrier.request('repositories.update', input),
-    remove: (input) => carrier.request('repositories.remove', input),
-    refs: (input) => carrier.request('repositories.refs', input)
-  },
-  reviews: {
-    list: (input) => carrier.request('reviews.list', input),
-    open: (input) => carrier.request('reviews.open', input),
-    get: (input) => carrier.request('reviews.get', input),
-    create: (input) => carrier.request('reviews.create', input),
-    update: (input) => carrier.request('reviews.update', input),
-    remove: (input) => carrier.request('reviews.remove', input),
-    commits: (input) => carrier.request('reviews.commits', input),
-    diff: (input) => carrier.request('reviews.diff', input),
-    file: (input) => carrier.request('reviews.file', input),
-    image: (input) => carrier.request('reviews.image', input),
-    reviewedFiles: (input) => carrier.request('reviews.reviewedFiles', input),
-    setFileReviewed: (input) => carrier.request('reviews.setFileReviewed', input),
-    // Where the file is comes from whoever owns the review; opening it is the
-    // shell's job. The two halves are joined in the main process.
-    openInEditor: (input) => shell.openInEditor(input)
-  },
-  comments: {
-    list: (input) => carrier.request('comments.list', input),
-    createThread: (input) => carrier.request('comments.createThread', input),
-    reply: (input) => carrier.request('comments.reply', input),
-    update: (input) => carrier.request('comments.update', input),
-    remove: (input) => carrier.request('comments.remove', input),
-    setResolved: (input) => carrier.request('comments.setResolved', input)
-  },
-  attachments: {
-    ingest: (input) => carrier.request('attachments.ingest', input),
-    pick: () => shell.pickAttachment(),
-    src: (url) => shell.attachmentSrc(url)
-  },
-  system: {
-    pickDirectory: () => shell.system.pickDirectory(),
-    revealPath: (path) => shell.system.revealPath(path),
-    appInfo: once(() => shell.system.appInfo()),
-    editors: once(() => shell.system.editors()),
-    // Not memoised, unlike the two above: the user can turn this on in System
-    // Settings while the window is open, and a value cached for the life of the
-    // document would show them a switch that disagrees with their machine.
-    getOpenAtLogin: () => shell.system.getOpenAtLogin(),
-    setOpenAtLogin: (openAtLogin) => shell.system.setOpenAtLogin(openAtLogin)
-  },
-  navigation: shell.navigation,
-  updates: shell.updates
+/**
+ * The api objects handed out so far, by host.
+ *
+ * Memoised because these end up in `useMemo` dependency lists and in SWR
+ * fetchers: a fresh object every render would make every one of those look like
+ * a change. `''` stands for this install, since `undefined` is not a key.
+ */
+const byHost = new Map<string, GitWarrenApi>()
+
+/**
+ * The app, as reached on one machine.
+ *
+ * `host` is an instance id, and omitting it means this install - the same
+ * asymmetry the routes have, and the reason a call written before hosts existed
+ * still means what it meant.
+ */
+export function apiFor(host?: string): GitWarrenApi {
+  const cached = byHost.get(host ?? '')
+  if (cached) return cached
+  const built = buildApi(host)
+  byHost.set(host ?? '', built)
+  return built
+}
+
+function buildApi(host: string | undefined): GitWarrenApi {
+  return {
+    // Read once, at module scope, because it is read during render and cannot
+    // change while the page is open. A screen asks `api.capabilities.revealPath`
+    // and leaves the button out; see `ShellCapabilities` on why that is better
+    // than a button that explains itself when pressed.
+    //
+    // Not scoped by host, and that is not an omission: these describe the shell
+    // the person is *using*, which does not change because the screen is
+    // showing another machine. What a remote screen must not do with them is a
+    // separate question, and the screens answer it - `revealPath` on a path
+    // that only exists on `pc-wsl` would open a Finder window on nothing.
+    capabilities: shell.capabilities,
+    // Deliberately unbound even here. A host's list of hosts is its own
+    // business, and the carrier refuses to send one; passing `host` would build
+    // a request that could only ever be refused. See `isLocalOnly`.
+    hosts: {
+      list: () => carrier.request('hosts.list', undefined),
+      get: (input) => carrier.request('hosts.get', input),
+      add: (input) => carrier.request('hosts.add', input),
+      update: (input) => carrier.request('hosts.update', input),
+      remove: (input) => carrier.request('hosts.remove', input),
+      probe: (input) => carrier.request('hosts.probe', input),
+      install: (input) => carrier.request('hosts.install', input)
+    },
+    fs: {
+      list: (input) => carrier.request('fs.list', input, host)
+    },
+    repositories: {
+      list: () => carrier.request('repositories.list', undefined, host),
+      get: (input) => carrier.request('repositories.get', input, host),
+      add: (input) => carrier.request('repositories.add', input, host),
+      update: (input) => carrier.request('repositories.update', input, host),
+      remove: (input) => carrier.request('repositories.remove', input, host),
+      refs: (input) => carrier.request('repositories.refs', input, host)
+    },
+    reviews: {
+      list: (input) => carrier.request('reviews.list', input, host),
+      open: (input) => carrier.request('reviews.open', input, host),
+      get: (input) => carrier.request('reviews.get', input, host),
+      create: (input) => carrier.request('reviews.create', input, host),
+      update: (input) => carrier.request('reviews.update', input, host),
+      remove: (input) => carrier.request('reviews.remove', input, host),
+      commits: (input) => carrier.request('reviews.commits', input, host),
+      diff: (input) => carrier.request('reviews.diff', input, host),
+      file: (input) => carrier.request('reviews.file', input, host),
+      image: (input) => carrier.request('reviews.image', input, host),
+      reviewedFiles: (input) => carrier.request('reviews.reviewedFiles', input, host),
+      setFileReviewed: (input) => carrier.request('reviews.setFileReviewed', input, host),
+      // Where the file is comes from whoever owns the review; opening it is the
+      // shell's job. The two halves are joined in the main process - which is
+      // why this one is still local-only, and why the screens hide it on a
+      // remote review rather than opening the wrong machine's file. M4.4 gives
+      // it `(host, path, line)`.
+      openInEditor: (input) => shell.openInEditor(input)
+    },
+    comments: {
+      list: (input) => carrier.request('comments.list', input, host),
+      createThread: (input) => carrier.request('comments.createThread', input, host),
+      reply: (input) => carrier.request('comments.reply', input, host),
+      update: (input) => carrier.request('comments.update', input, host),
+      remove: (input) => carrier.request('comments.remove', input, host),
+      setResolved: (input) => carrier.request('comments.setResolved', input, host)
+    },
+    attachments: {
+      ingest: (input) => carrier.request('attachments.ingest', input, host),
+      pick: () => shell.pickAttachment(),
+      src: (url) => shell.attachmentSrc(url)
+    },
+    system: {
+      pickDirectory: () => shell.system.pickDirectory(),
+      revealPath: (path) => shell.system.revealPath(path),
+      appInfo: once(() => shell.system.appInfo()),
+      editors: once(() => shell.system.editors()),
+      // Not memoised, unlike the two above: the user can turn this on in System
+      // Settings while the window is open, and a value cached for the life of the
+      // document would show them a switch that disagrees with their machine.
+      getOpenAtLogin: () => shell.system.getOpenAtLogin(),
+      setOpenAtLogin: (openAtLogin) => shell.system.setOpenAtLogin(openAtLogin)
+    },
+    navigation: shell.navigation,
+    updates: shell.updates
+  }
+}
+
+/** This install. What every screen used before there was more than one. */
+export const api: GitWarrenApi = apiFor()
+
+/**
+ * Tie a cache key to the machine its answer came from.
+ *
+ * Every id in this app is a per-host autoincrement integer, which is the point
+ * `shared/routes.ts` makes about links and is just as true of a cache: review 4
+ * here and review 4 on `pc-wsl` are two different reviews, and one key for both
+ * would put one machine's discussion under the other machine's heading. This is
+ * the same argument as the read-coalescing key in the carrier, one layer up.
+ *
+ * The host goes on the *end*, after the prefix, so that the family-wide
+ * invalidation below still works by `startsWith`. Invalidating `reviews:` then
+ * covers every host at once, which is the honest thing after a write: nothing
+ * unmounted refetches until it is looked at again, and what is on screen is one
+ * host's worth of reads.
+ */
+function scoped(key: string, host: string | undefined): string {
+  return host === undefined ? key : `${key}@${host}`
 }
 
 /**
@@ -110,6 +192,10 @@ export const api: GitWarrenApi = {
  * can invalidate a whole family at once - `mutate(key => key.startsWith('reviews:'))`
  * refreshes every list regardless of which repository or status filter it was
  * built with, which is what you want after creating or closing a review.
+ *
+ * Every key that names something a host owns takes that host as its last
+ * argument, and omitting it means this install - so a call site that predates
+ * hosts produces the string it always did.
  */
 export const CACHE_KEYS = {
   /**
@@ -123,10 +209,16 @@ export const CACHE_KEYS = {
    * screen disagree about what time it is.
    */
   hosts: 'hosts',
-  repositories: 'repositories',
-  repositoryRefs: (repositoryId: number) => `repository-refs:${repositoryId}`,
-  reviews: (repositoryId?: number, status?: string) =>
-    `reviews:${repositoryId ?? 'all'}:${status ?? 'any'}`,
+  repositories: (host?: string) => scoped('repositories', host),
+  repository: (repositoryId: number, host?: string) =>
+    scoped(`repository:${repositoryId}`, host),
+  repositoryRefs: (repositoryId: number, host?: string) =>
+    scoped(`repository-refs:${repositoryId}`, host),
+  /** One folder of one machine's filesystem, as the browse dialog sees it. */
+  directory: (path: string | undefined, host?: string) =>
+    scoped(`directory:${path ?? ''}`, host),
+  reviews: (repositoryId?: number, status?: string, host?: string) =>
+    scoped(`reviews:${repositoryId ?? 'all'}:${status ?? 'any'}`, host),
   /**
    * A whole review, as `reviews.open` answers it: the review itself, its
    * threads and its reviewed marks.
@@ -142,22 +234,29 @@ export const CACHE_KEYS = {
    * refresh brings back the discussion, the marks and any change to the review
    * itself together - one request where there used to be two.
    */
-  review: (reviewId: number) => `review:${reviewId}`,
-  reviewCommits: (reviewId: number) => `review-commits:${reviewId}`,
-  reviewDiff: (reviewId: number, changes: DiffChanges) => `review-diff:${reviewId}:${changes}`,
+  review: (reviewId: number, host?: string) => scoped(`review:${reviewId}`, host),
+  reviewCommits: (reviewId: number, host?: string) =>
+    scoped(`review-commits:${reviewId}`, host),
+  reviewDiff: (reviewId: number, changes: DiffChanges, host?: string) =>
+    scoped(`review-diff:${reviewId}:${changes}`, host),
   /**
    * Keyed by the same setting as the diff: expanded context read from another
    * version of the file would not line up with the hunks it sits between.
    */
-  reviewFile: (reviewId: number, path: string, changes: DiffChanges) =>
-    `review-file:${reviewId}:${changes}:${path}`,
+  reviewFile: (reviewId: number, path: string, changes: DiffChanges, host?: string) =>
+    scoped(`review-file:${reviewId}:${changes}:${path}`, host),
   /**
    * One side of an image preview, keyed by the same setting for the same
    * reason: which version of the picture is "before" depends on what the diff
    * is made of.
    */
-  reviewImage: (reviewId: number, path: string, side: string, changes: DiffChanges) =>
-    `review-image:${reviewId}:${changes}:${side}:${path}`,
+  reviewImage: (
+    reviewId: number,
+    path: string,
+    side: string,
+    changes: DiffChanges,
+    host?: string
+  ) => scoped(`review-image:${reviewId}:${changes}:${side}:${path}`, host),
   /**
    * The two reads that never change while the app runs. They keep keys so the
    * components that show them keep a loading state, but the reads underneath

--- a/src/renderer/src/lib/host-scope.tsx
+++ b/src/renderer/src/lib/host-scope.tsx
@@ -1,0 +1,79 @@
+/**
+ * Which machine the screen is about.
+ *
+ * The route already says it - `#/h/<instance>/reviews/4` is review 4 on that
+ * install - but a route is read at the top of the tree and needed at the
+ * bottom, by a diff line's comment composer thirty components down. Passing it
+ * as a prop the whole way would mean touching every component between the two,
+ * and every one of those props would be one somebody could forget to forward.
+ *
+ * A context instead, and one that is *read through an api* rather than as a
+ * string. `useApi()` is what nearly everything uses: it hands back the app
+ * bound to the current machine, so a screen goes on calling
+ * `api.reviews.diff(...)` and gets the right machine's diff because of where it
+ * is mounted. `useHost()` exists for the two things that genuinely need the id
+ * itself - building a link that has to carry it, and keying a cache.
+ *
+ * ## Why a screen must never fall back to "local"
+ *
+ * The dangerous version of this file is one where a missing provider means
+ * `undefined` means this machine. That is exactly the bug it would cause:
+ * a component mounted outside the provider would quietly render local data
+ * under a remote heading, and nothing about it would look wrong. So the
+ * provider wraps the whole app in `App.tsx` and always supplies a value; the
+ * default here is the local one because the app *is* local until a route says
+ * otherwise, and there is only one route reader.
+ */
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
+import { apiFor } from './api'
+import type { GitWarrenApi } from '@shared/api'
+import type { HostScoped } from '@shared/routes'
+
+interface HostScope {
+  /** Instance id, or undefined for this install. */
+  host: string | undefined
+  api: GitWarrenApi
+}
+
+const LOCAL: HostScope = { host: undefined, api: apiFor() }
+
+const HostScopeContext = createContext<HostScope>(LOCAL)
+
+export function HostScopeProvider({
+  host,
+  children
+}: {
+  host: string | undefined
+  children: ReactNode
+}) {
+  // Memoised on the id rather than rebuilt: this value is in the dependency
+  // list of every fetcher below it, and a new object per render would make each
+  // of them look like a change.
+  const value = useMemo<HostScope>(() => ({ host, api: apiFor(host) }), [host])
+  return <HostScopeContext.Provider value={value}>{children}</HostScopeContext.Provider>
+}
+
+/** The app, bound to the machine this screen is about. */
+export function useApi(): GitWarrenApi {
+  return useContext(HostScopeContext).api
+}
+
+/** The instance id, for a link or a cache key. Undefined means this install. */
+export function useHost(): string | undefined {
+  return useContext(HostScopeContext).host
+}
+
+/**
+ * The host as a spreadable route fragment: `{...useHostScope()}`.
+ *
+ * Every `navigate` in a host-scoped screen has to carry the host or it walks
+ * the user back to this machine mid-review, and a spread is the form that makes
+ * that hard to get wrong - the property is either there or it is not, and
+ * `{ host: undefined }` is not the same object as `{}` to anything comparing
+ * two routes. That distinction is `parseRoute`'s, and this is the other end of
+ * it.
+ */
+export function useHostScope(): HostScoped {
+  const host = useHost()
+  return useMemo(() => (host === undefined ? {} : { host }), [host])
+}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -23,6 +23,8 @@ import type {
   AddHostInput,
   AddRepositoryInput,
   Attachment,
+  DirectoryListing,
+  ListDirectoryInput,
   GetHostInput,
   HostWithState,
   InstallOnHostInput,
@@ -296,6 +298,18 @@ export interface GitWarrenApi {
     probe(input: GetHostInput): Promise<HostWithState>
     /** Slow, and the only method here that changes the other machine. */
     install(input: InstallOnHostInput): Promise<InstallReport>
+  }
+  /**
+   * What is inside a folder, on the machine this api is pointed at.
+   *
+   * Not part of `system` even though the shell's own picker is, and the
+   * difference is the whole of M4.3's answer to the missing picker: opening a
+   * window is something only the machine with a screen can do, while reading a
+   * directory is something the machine holding the directory does. On a remote
+   * host those are two different computers.
+   */
+  fs: {
+    list(input: ListDirectoryInput): Promise<DirectoryListing>
   }
   repositories: {
     list(): Promise<RepositoryWithGitState[]>

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -34,9 +34,11 @@ import type {
   CommentThread,
   CreateReviewInput,
   CreateThreadInput,
+  DirectoryListing,
   GetRepositoryInput,
   GetReviewInput,
   ListCommentsInput,
+  ListDirectoryInput,
   ListReviewedFilesInput,
   ListReviewsInput,
   RemoveCommentInput,
@@ -96,6 +98,18 @@ export interface RpcRequest<M extends RpcMethod = RpcMethod> {
   id: number
   method: M
   params?: RpcParams<M>
+  /**
+   * Which install this is for: an instance id, or absent for whoever receives
+   * it.
+   *
+   * On the envelope rather than in `params`, because where a request goes is
+   * not part of what the method means - `reviews.diff` has one meaning and it
+   * is the same on every machine. It is also the field the router *removes*
+   * before forwarding, which is what stops a chain of hosts forming: what
+   * arrives at the far end has no host on it, so the far end answers it itself.
+   * See `core/hosts/router.ts`.
+   */
+  host?: string
 }
 
 /**
@@ -181,8 +195,9 @@ export interface RpcMethods {
    * host. A host's list of hosts is its own business, and routing these onward
    * would turn a hub and its spokes into a mesh, where removing a machine from
    * one list could remove it from another. `isLocalOnly` in `core/hosts/ssh.ts`
-   * is the backstop that makes that structural; M4.3's router is where the
-   * general local-versus-remote decision will live.
+   * is the backstop that makes that structural, and `core/hosts/router.ts` is
+   * where the general local-versus-remote decision lives: it answers these here
+   * before it ever looks at the host on the envelope.
    */
   'hosts.list': { params: void; result: HostWithState[] }
   'hosts.get': { params: GetHostInput; result: HostWithState }
@@ -201,6 +216,23 @@ export interface RpcMethods {
    * on why it reports nothing until it is done.
    */
   'hosts.install': { params: InstallOnHostInput; result: InstallReport }
+
+  /**
+   * What is inside a folder, on the machine that answers.
+   *
+   * The one method here that exists because of a *capability* rather than a
+   * domain, and the reason it is a method at all is M4.3. Opening a folder
+   * picker is a thing the shell does on the machine the person is sitting at -
+   * so it stays out of this map, per the note above - but on a remote host that
+   * picker would browse the wrong filesystem, and in a browser tab there is no
+   * picker to open. Splitting the gesture in two puts the window where the
+   * screen is and the directory where the files are.
+   *
+   * Reads nothing but names, and never a file's contents: see
+   * `core/services/fs.ts` on why there is no sandbox and what the real
+   * boundary is.
+   */
+  'fs.list': { params: ListDirectoryInput; result: DirectoryListing }
 
   'repositories.list': { params: void; result: RepositoryWithGitState[] }
   'repositories.get': { params: GetRepositoryInput; result: RepositoryWithGitState }
@@ -314,6 +346,7 @@ export const READ_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   // no host row a caller can see, but it opens a connection and clears a
   // backoff, and two people pressing "try now" at the same moment should mean
   // two attempts - which is the whole reason the button exists.
+  'fs.list',
   'repositories.list',
   'repositories.get',
   'repositories.refs',
@@ -344,7 +377,22 @@ export function isReadMethod(method: string): boolean {
  * inspects `params` or decides what a method means.
  */
 export interface Carrier {
-  request<M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>>
+  /**
+   * `host` is an instance id, and absent means "this install" - the same
+   * asymmetry `HostScoped` has in `shared/routes.ts`, and for the same reason:
+   * every call written before hosts existed is still the call it was.
+   *
+   * A carrier does not resolve it, look at it, or know what a host is. It puts
+   * it on the envelope and hands it over; `core/hosts/router.ts` decides. What
+   * a carrier *must* do is keep it out of anything it uses as an identity for
+   * the request - a read-coalescing key that ignored the host would answer
+   * "the repositories on `pc-wsl`" with the repositories on this Mac.
+   */
+  request<M extends RpcMethod>(
+    method: M,
+    params: RpcParams<M>,
+    host?: string
+  ): Promise<RpcResult<M>>
 }
 
 /**

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -43,6 +43,20 @@ export const repositoryGitStateSchema = z.object({
   detachedAt: z.string().nullable(),
   /** True for a freshly `git init`-ed repo with no commits yet. */
   isEmpty: z.boolean(),
+  /**
+   * The commit this history starts at, or null in a repository with no commits.
+   *
+   * The one field here that is not about *this* checkout. It is the same forty
+   * characters in every clone of a project on every machine, which makes it the
+   * only honest way to say "the thing on `pc-wsl` under `~/github.com` and the
+   * thing on this Mac under `~/github.com` are the same repository". Neither
+   * the path nor the name can say that: two clones are usually in different
+   * places and are often called different things.
+   *
+   * Null is not a group. Two repositories with no commits yet are two empty
+   * repositories, not one repository seen twice.
+   */
+  rootCommit: z.string().nullable(),
   /** Human-readable reason the state could not be read, if any. */
   error: z.string().nullable()
 })
@@ -678,3 +692,53 @@ export type ReplyToThreadInput = z.input<typeof replyToThreadInputSchema>
 export type UpdateCommentInput = z.input<typeof updateCommentInputSchema>
 export type RemoveCommentInput = z.input<typeof removeCommentInputSchema>
 export type SetThreadResolvedInput = z.input<typeof setThreadResolvedInputSchema>
+
+/* -------------------------------------------------------------------------- */
+/* Browsing a filesystem                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Which folder to look inside. Absent means "wherever a person starts", which
+ * is the answering machine's home directory.
+ *
+ * A leading `~` is expanded by whoever answers, because that is the only
+ * machine that knows what it stands for - see `core/services/fs.ts`.
+ */
+export const listDirectoryInputSchema = z.object({
+  path: z.string().max(4096).optional()
+})
+
+/** One subdirectory of the folder being listed. */
+export const directoryEntrySchema = z.object({
+  name: z.string(),
+  /** Absolute, on the answering machine. What goes into the path field. */
+  path: z.string(),
+  /** It holds a `.git`, so it can be added without going any deeper. */
+  isRepository: z.boolean(),
+  /** Whether the screen should keep it behind the "show hidden" switch. */
+  isHidden: z.boolean()
+})
+
+/**
+ * One folder, as seen from a machine that cannot look at it itself.
+ *
+ * More than a list of names, because the asking side has to draw a picker for a
+ * filesystem it has never seen: `parent` is the way up (null at the root, which
+ * is how the screen knows to stop offering it), `home` is where the "Home"
+ * button goes, and `separator` is the difference between a Mac driving a Linux
+ * host and a Windows one.
+ */
+export const directoryListingSchema = z.object({
+  /** The folder actually listed, resolved - `~` expanded, `..` collapsed. */
+  path: z.string(),
+  parent: z.string().nullable(),
+  home: z.string(),
+  separator: z.string(),
+  entries: z.array(directoryEntrySchema),
+  /** True when there were more subdirectories than one listing may carry. */
+  truncated: z.boolean()
+})
+
+export type ListDirectoryInput = z.input<typeof listDirectoryInputSchema>
+export type DirectoryEntry = z.infer<typeof directoryEntrySchema>
+export type DirectoryListing = z.infer<typeof directoryListingSchema>

--- a/src/web/carrier.ts
+++ b/src/web/carrier.ts
@@ -158,11 +158,18 @@ export function createWebCarrier(): WebCarrier {
 
   const inFlight = new Map<string, Promise<unknown>>()
 
-  const ask = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
+  const ask = <M extends RpcMethod>(
+    method: M,
+    params: RpcParams<M>,
+    host?: string
+  ): Promise<RpcResult<M>> => {
     const id = nextId++
     const answered = new Promise<RpcOutcome>((resolve, reject) => {
       pending.set(id, { resolve, reject })
-      send({ id, method, params })
+      // Spread rather than always set, so a local request is byte-for-byte the
+      // frame it was before hosts existed - which is what lets a tab served by
+      // an older daemon go on working.
+      send({ id, method, params, ...(host === undefined ? {} : { host }) })
     })
 
     // A response carries whatever its method returns, and the socket cannot
@@ -173,14 +180,19 @@ export function createWebCarrier(): WebCarrier {
   }
 
   return {
-    request<M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> {
-      if (!isReadMethod(method)) return ask(method, params)
+    request<M extends RpcMethod>(
+      method: M,
+      params: RpcParams<M>,
+      host?: string
+    ): Promise<RpcResult<M>> {
+      if (!isReadMethod(method)) return ask(method, params, host)
 
-      const key = `${method}:${JSON.stringify(params ?? null)}`
+      // Keyed by host as well as method: see the same note in the preload.
+      const key = `${host ?? ''}:${method}:${JSON.stringify(params ?? null)}`
       const existing = inFlight.get(key) as Promise<RpcResult<M>> | undefined
       if (existing) return existing
 
-      const promise = ask(method, params).finally(() => inFlight.delete(key))
+      const promise = ask(method, params, host).finally(() => inFlight.delete(key))
       inFlight.set(key, promise)
       return promise
     },


### PR DESCRIPTION
Third of M4's five slices. Based on **#47** (M4.2), not on `main` — review that
one first, or read this diff against `worktree-m4-2-hosts-installer`.

A host stops being a machine you can install onto and becomes a machine you can
review. The full reasoning is in `docs/across-hosts.md` under "How it is being
built"; this is the shape of it.

## Three pieces

**`core/hosts/router.ts`** — the local-versus-remote decision M4.1 deferred to
this slice. `RpcRequest.host` carries an instance id on the *envelope*, not in
any method's params: where a request goes is not part of what the method means,
and the router strips it before forwarding, which is what makes a chain of hosts
impossible to build by accident. Three ways a request stays local — no host at
all (nearly every request, byte-for-byte what it was in M0), our own instance id
(rule 4 in one comparison), and `hosts.*`, checked before the host is even
resolved. Carriers come through `handleRoutedRequest` now, so the decision is
made once and a browser tab gets remote hosts for free.

**`fs.list`** — the answer to the comment `repository-form-dialog.tsx` has been
carrying since M3. A tab has no folder picker; on a host the picker the shell
*does* have would browse the wrong machine. So opening a window stays in the
shell and "what is inside this folder" becomes a method. The listing carries the
parent, home, the separator and a `.git` mark, because the asking side has to
draw a picker for a filesystem it has never seen.

**`#/h/<instance>/`** — a host's repository list, fetched from the host when
somebody asks. The host card on the Hosts screen finally leads somewhere, and
only once the machine has said who it is, because a route needs an instance id.

## The design question this slice had to settle

Nothing is mirrored here. `repositories.host_id` — a column M0 added and nothing
ever wrote — stays unwritten, because rules 1 and 2 say a host owns its
repositories and nothing syncs. A row over here would be a copy of a name and a
path only that machine can keep true, and would give one repository two ids
while `#/h/<instance>/repositories/<id>` has always meant "that id, as that host
knows it".

That settles the cascade M4.1 left open too: **`hosts.remove` has nothing to
cascade to.** Forgetting a host forgets a way of reaching a computer.

Not fanning out is deliberate and is the same argument as connect-on-use: a home
screen listing every host's repositories would open an `ssh` connection to every
machine on the list in order to render.

## Clones across hosts

`rootCommit` joins `RepositoryGitState`, using `--first-parent` so that a
history which has absorbed another project still has *one* root — a set is not a
key. A row on a host's list that matches a local repository becomes a link to
it. The comparison runs from the host towards this machine because that is the
direction that is free.

## Absent, not disabled

Revealing a path, opening a file in an editor and attaching an image all
disappear on a remote screen rather than doing something plausible to the wrong
machine. Attachments and editors per host are M4.4.

## Verified against `pc-wsl`, and what that found

Daemon reinstalled from this build (46.4 MB in 4.5 s), then `fs.list` in 129 ms
cold / 6 ms warm, `~/github.com/klarluft` expanded over there into five marked
repositories, two repositories added and listed from the Mac, the clone marker
on exactly one of two rows linking back to this machine, a review created on the
host and commented into its database from here — while review 2 *here* was a
different review, which is why the segment exists. No console errors, no
horizontal scroll at 390 px.

Two bugs found by doing that rather than by a test passing:

- the open-in-editor button is drawn from a *callback*, not from the editor
  list, so emptying the list for a host left the button — and pressing it asked
  this install for a review id that means something else over there;
- cache keys that ignore the host make two machines' repository lists the same
  question, and hand the second asker the first one's answer.

Both fixed. The write-up also records the version skew a host running an older
daemon produces (**a host must be reinstalled from the GUI before these screens
work against it**) and one pre-existing bug this slice found and deliberately
did not fix: Electron's `contextBridge` strips `code` and `fieldErrors` off
every rejected promise, so `errorCode()` is always null in the packaged window.
That predates M4 — duplicate-path errors have been landing in the add form's
general slot rather than under the field since M1 — and the fix belongs in its
own change.

## Checks

`lint`, `typecheck`, `build` clean; 493 tests pass (26 new, covering the router's
decision, the directory listing, and the root-commit key against real `git`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdoeT2B1TM3qUdvQUtmydn
