### PR TITLE
Error codes survive the contextBridge again

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -1957,7 +1957,7 @@ back — while review 2 *here* was a different review entirely, which is the
 clearest possible demonstration of why the segment had to exist. No console
 errors, and no horizontal scroll at 390 px.
 
-**What M4.3 found and left alone.** Electron's `contextBridge` strips everything
+**What M4.3 found next door.** Electron's `contextBridge` strips everything
 but `message` off a rejected promise, so `AppError.code` and `fieldErrors` do
 not survive the preload: in the packaged window `errorCode(error)` is always
 null and `firstFieldError` always undefined. This predates the milestone —
@@ -1965,13 +1965,25 @@ adding an already-tracked repository has been showing its duplicate-path message
 in the form's general slot rather than under the field since M1 — and it is not
 specific to hosts; the shell channels lose their codes the same way. A browser
 tab is unaffected, because its carrier throws in the same world it is caught in.
-The fix is to stop throwing across the bridge: the preload's carrier should hand
-back the `RpcOutcome` it already has and let the renderer call `resultOf`, which
-is what `shared/rpc.ts` says that function is for. It is its own change, with
-its own reasoning about where the M1 boundary sits, so it was not folded into
-this one — the cost meanwhile is that the "this host is not answering" state
-renders in a tab and not in the window, where the same sentence arrives under a
-more generic heading.
+The fix is to stop throwing across the bridge, and it landed immediately
+afterwards as a change of its own rather than being folded in here, because it
+is about where M1's boundary sits and not about hosts. `window.gitwarren` now
+exposes a `BridgeCarrier` that answers with an `RpcOutcome`; `outcomeOf` in
+`shared/rpc.ts` is the counterpart to `resultOf` that builds one, and
+`lib/api.ts` unwraps in the renderer's own world, where a thrown `AppError` is
+still an `AppError`. It is the rule every other carrier already followed,
+arriving at the one boundary nobody had thought of as a wire. The shell channels
+still throw and still lose their codes, deliberately: nothing branches on a
+shell error's code, so converting twenty signatures would be churn.
+
+Two things that had been silently broken came back with it — a duplicate
+repository path is reported under the path input again rather than in the
+dialog's banner, and M4.3's "this host is not answering" state renders in the
+window and not only in a tab. The second was proved by moving
+`~/.gitwarren/bin/gitwarren` aside on `pc-wsl` mid-session and killing the
+daemon that was already running: the screen showed *GitWarren is not installed
+on xfor@pc-wsl: ~/.gitwarren/bin/gitwarren was not found*, with a Try again, and
+came back on its own once the launcher was put back.
 
 **Not done in M4.3, and why.** Attachments, editors and per-host agent access
 are M4.4, and the three controls above are switched off rather than half-built

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,9 +8,31 @@
  * The carrier is one function over one channel. It is deliberately not a method
  * per object any more - the list of methods lives in `shared/rpc.ts`, and a
  * preload that had to be edited every time one was added would be a third place
- * to keep the same list. What this file still does is unwrap the outcome, so a
- * failure in the main process surfaces in React as a thrown `AppError` with its
- * code intact, which is what lets the forms show field-level messages.
+ * to keep the same list.
+ *
+ * ## What it deliberately does not do any more: throw
+ *
+ * The carrier used to unwrap the outcome here, so that a failure arrived in
+ * React as a thrown `AppError`. It does not, and the reason is a property of
+ * `contextBridge` that is easy to miss because nothing about it looks broken: a
+ * promise rejected on this side is rebuilt in the renderer as a plain `Error`
+ * carrying `message` and nothing else. `code` and `fieldErrors` were being
+ * dropped on the way across, silently, which meant `errorCode(error)` was
+ * always null in the packaged window and every inline form message fell back to
+ * the banner - a duplicate repository path was reported at the top of the
+ * dialog rather than under the input it was about.
+ *
+ * So the carrier hands back the `RpcOutcome` as a *value*, which crosses
+ * intact, and `lib/api.ts` calls `resultOf` in the renderer's own world. It is
+ * the same rule the stdio and WebSocket carriers already follow, arriving at
+ * the one boundary nobody had thought of as a wire.
+ *
+ * The shell channels below still throw across the bridge, and that is a
+ * deliberate limit rather than the fix being half-applied: nothing branches on
+ * a *shell* error's code - revealing a path, launching an editor and picking a
+ * file are all rendered as their message - so converting twenty signatures
+ * would be churn with nothing behind it. The day one of them needs a code, it
+ * takes `outcomeOf` the same way.
  *
  * It also coalesces reads. Two identical reads in flight at the same moment are
  * the same read, and answering both from one round trip is free here and worth
@@ -28,7 +50,7 @@ import {
 import {
   isReadMethod,
   resultOf,
-  type Carrier,
+  type BridgeCarrier,
   type RpcMethod,
   type RpcOutcome,
   type RpcParams,
@@ -36,10 +58,19 @@ import {
 } from '../shared/rpc.js'
 import type { Attachment, OpenReviewFileInput } from '../shared/schemas.js'
 
+/**
+ * A shell channel. Unwrapped here, so these keep throwing - see the note above
+ * on why that is left as it is.
+ */
 async function invoke<T>(channel: string, payload?: unknown): Promise<T> {
   // `invoke` is typed as `any`; the envelope shape is guaranteed by `handle()`
   // in the main process, which is the only thing that answers these channels.
   return resultOf((await ipcRenderer.invoke(channel, payload)) as RpcOutcome<T>)
+}
+
+/** The carrier's channel. The outcome is the return value, not a throw. */
+async function invokeOutcome<T>(channel: string, payload?: unknown): Promise<RpcOutcome<T>> {
+  return (await ipcRenderer.invoke(channel, payload)) as RpcOutcome<T>
 }
 
 /**
@@ -49,14 +80,14 @@ async function invoke<T>(channel: string, payload?: unknown): Promise<T> {
  */
 const inFlight = new Map<string, Promise<unknown>>()
 
-const carrier: Carrier = {
+const carrier: BridgeCarrier = {
   request<M extends RpcMethod>(
     method: M,
     params: RpcParams<M>,
     host?: string
-  ): Promise<RpcResult<M>> {
-    const send = (): Promise<RpcResult<M>> =>
-      invoke<RpcResult<M>>(IPC_CHANNELS.rpcRequest, { method, params, host })
+  ): Promise<RpcOutcome<RpcResult<M>>> {
+    const send = (): Promise<RpcOutcome<RpcResult<M>>> =>
+      invokeOutcome<RpcResult<M>>(IPC_CHANNELS.rpcRequest, { method, params, host })
 
     if (!isReadMethod(method)) return send()
 
@@ -65,7 +96,7 @@ const carrier: Carrier = {
     // same question asked twice, and the second component to ask would be
     // handed the first one's answer.
     const key = `${host ?? ''}:${method}:${JSON.stringify(params ?? null)}`
-    const existing = inFlight.get(key) as Promise<RpcResult<M>> | undefined
+    const existing = inFlight.get(key) as Promise<RpcOutcome<RpcResult<M>>> | undefined
     if (existing) return existing
 
     const pending = send().finally(() => inFlight.delete(key))

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -26,7 +26,18 @@
  * The shell half is not bound to anything and never will be. Revealing a path,
  * opening a picker, launching an editor: those happen on the machine with the
  * screen on it, whatever the screen is showing. See `ShellCapabilities`.
+ *
+ * ## Where a failure becomes a thrown `AppError`
+ *
+ * Here, in `ask` below, and that is a fix rather than a detail. The bridge hands
+ * back an `RpcOutcome` because `contextBridge` cannot carry an exception with
+ * anything on it - see `BridgeCarrier` in `shared/rpc.ts` - so the unwrapping
+ * has to happen on this side of it, in the renderer's own world, where a thrown
+ * `AppError` is still an `AppError` with its `code` and its `fieldErrors`. That
+ * is what `errorCode` and `firstFieldError` read, and it is why a duplicate
+ * repository path can appear under the path input again.
  */
+import { resultOf, type RpcMethod, type RpcParams, type RpcResult } from '@shared/rpc'
 import type { GitWarrenApi, GitWarrenBridge } from '@shared/api'
 import type { DiffChanges } from '@shared/git'
 
@@ -38,6 +49,23 @@ if (typeof window.gitwarren === 'undefined') {
 
 const bridge: GitWarrenBridge = window.gitwarren
 const { carrier, shell } = bridge
+
+/**
+ * One carrier call, unwrapped.
+ *
+ * Every method below goes through this rather than calling `carrier.request`
+ * directly, so there is exactly one place where an outcome becomes a value or a
+ * throw. `resultOf` is the shared unwrapper every carrier uses, which is what
+ * makes a `NOT_FOUND` from a daemon over `ssh` reach a component as the same
+ * `AppError` a local call would have thrown.
+ */
+function ask<M extends RpcMethod>(
+  method: M,
+  params: RpcParams<M>,
+  host?: string
+): Promise<RpcResult<M>> {
+  return carrier.request(method, params, host).then(resultOf)
+}
 
 /**
  * Ask once, for the life of the window.
@@ -95,38 +123,38 @@ function buildApi(host: string | undefined): GitWarrenApi {
     // business, and the carrier refuses to send one; passing `host` would build
     // a request that could only ever be refused. See `isLocalOnly`.
     hosts: {
-      list: () => carrier.request('hosts.list', undefined),
-      get: (input) => carrier.request('hosts.get', input),
-      add: (input) => carrier.request('hosts.add', input),
-      update: (input) => carrier.request('hosts.update', input),
-      remove: (input) => carrier.request('hosts.remove', input),
-      probe: (input) => carrier.request('hosts.probe', input),
-      install: (input) => carrier.request('hosts.install', input)
+      list: () => ask('hosts.list', undefined),
+      get: (input) => ask('hosts.get', input),
+      add: (input) => ask('hosts.add', input),
+      update: (input) => ask('hosts.update', input),
+      remove: (input) => ask('hosts.remove', input),
+      probe: (input) => ask('hosts.probe', input),
+      install: (input) => ask('hosts.install', input)
     },
     fs: {
-      list: (input) => carrier.request('fs.list', input, host)
+      list: (input) => ask('fs.list', input, host)
     },
     repositories: {
-      list: () => carrier.request('repositories.list', undefined, host),
-      get: (input) => carrier.request('repositories.get', input, host),
-      add: (input) => carrier.request('repositories.add', input, host),
-      update: (input) => carrier.request('repositories.update', input, host),
-      remove: (input) => carrier.request('repositories.remove', input, host),
-      refs: (input) => carrier.request('repositories.refs', input, host)
+      list: () => ask('repositories.list', undefined, host),
+      get: (input) => ask('repositories.get', input, host),
+      add: (input) => ask('repositories.add', input, host),
+      update: (input) => ask('repositories.update', input, host),
+      remove: (input) => ask('repositories.remove', input, host),
+      refs: (input) => ask('repositories.refs', input, host)
     },
     reviews: {
-      list: (input) => carrier.request('reviews.list', input, host),
-      open: (input) => carrier.request('reviews.open', input, host),
-      get: (input) => carrier.request('reviews.get', input, host),
-      create: (input) => carrier.request('reviews.create', input, host),
-      update: (input) => carrier.request('reviews.update', input, host),
-      remove: (input) => carrier.request('reviews.remove', input, host),
-      commits: (input) => carrier.request('reviews.commits', input, host),
-      diff: (input) => carrier.request('reviews.diff', input, host),
-      file: (input) => carrier.request('reviews.file', input, host),
-      image: (input) => carrier.request('reviews.image', input, host),
-      reviewedFiles: (input) => carrier.request('reviews.reviewedFiles', input, host),
-      setFileReviewed: (input) => carrier.request('reviews.setFileReviewed', input, host),
+      list: (input) => ask('reviews.list', input, host),
+      open: (input) => ask('reviews.open', input, host),
+      get: (input) => ask('reviews.get', input, host),
+      create: (input) => ask('reviews.create', input, host),
+      update: (input) => ask('reviews.update', input, host),
+      remove: (input) => ask('reviews.remove', input, host),
+      commits: (input) => ask('reviews.commits', input, host),
+      diff: (input) => ask('reviews.diff', input, host),
+      file: (input) => ask('reviews.file', input, host),
+      image: (input) => ask('reviews.image', input, host),
+      reviewedFiles: (input) => ask('reviews.reviewedFiles', input, host),
+      setFileReviewed: (input) => ask('reviews.setFileReviewed', input, host),
       // Where the file is comes from whoever owns the review; opening it is the
       // shell's job. The two halves are joined in the main process - which is
       // why this one is still local-only, and why the screens hide it on a
@@ -135,15 +163,15 @@ function buildApi(host: string | undefined): GitWarrenApi {
       openInEditor: (input) => shell.openInEditor(input)
     },
     comments: {
-      list: (input) => carrier.request('comments.list', input, host),
-      createThread: (input) => carrier.request('comments.createThread', input, host),
-      reply: (input) => carrier.request('comments.reply', input, host),
-      update: (input) => carrier.request('comments.update', input, host),
-      remove: (input) => carrier.request('comments.remove', input, host),
-      setResolved: (input) => carrier.request('comments.setResolved', input, host)
+      list: (input) => ask('comments.list', input, host),
+      createThread: (input) => ask('comments.createThread', input, host),
+      reply: (input) => ask('comments.reply', input, host),
+      update: (input) => ask('comments.update', input, host),
+      remove: (input) => ask('comments.remove', input, host),
+      setResolved: (input) => ask('comments.setResolved', input, host)
     },
     attachments: {
-      ingest: (input) => carrier.request('attachments.ingest', input, host),
+      ingest: (input) => ask('attachments.ingest', input, host),
       pick: () => shell.pickAttachment(),
       src: (url) => shell.attachmentSrc(url)
     },

--- a/src/shared/__tests__/outcome.test.ts
+++ b/src/shared/__tests__/outcome.test.ts
@@ -1,0 +1,86 @@
+/**
+ * An error, as a value.
+ *
+ * `outcomeOf` and `resultOf` are the two halves of the one rule every boundary
+ * in this app that cannot carry an exception follows: report how it went as a
+ * *value*, and turn it back into a throw on the other side. The stdio and
+ * WebSocket carriers have always done this because a byte stream leaves no
+ * choice. Electron's `contextBridge` turned out to be the same kind of boundary
+ * without looking like one - it rebuilds a rejection as a bare `Error` carrying
+ * `message` and nothing else - which is what made `errorCode(error)` always
+ * null in the packaged window and sent every inline form message to the banner.
+ *
+ * So what is pinned here is the part that was being lost: the code and the
+ * field errors, through a full round trip. A test cannot run `contextBridge`,
+ * but it can hold still the property that makes crossing it survivable, and the
+ * real crossing was checked by hand against the running app.
+ */
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { AppError } from '../errors.js'
+import { outcomeOf, resultOf } from '../rpc.js'
+
+/** What a failed round trip leaves you holding. */
+async function roundTrip(work: () => Promise<unknown>): Promise<unknown> {
+  const outcome = await outcomeOf(work)
+  try {
+    return resultOf(outcome)
+  } catch (error) {
+    return error
+  }
+}
+
+test('a value comes back as itself', async () => {
+  const outcome = await outcomeOf(() => Promise.resolve({ id: 4, name: 'app' }))
+
+  assert.deepEqual(outcome, { result: { id: 4, name: 'app' } })
+  assert.deepEqual(resultOf(outcome), { id: 4, name: 'app' })
+})
+
+test('the code survives, which is the whole point', async () => {
+  const thrown = await roundTrip(() =>
+    Promise.reject(new AppError('HOST_OFFLINE', 'xfor@pc-wsl is not reachable.'))
+  )
+
+  assert.ok(thrown instanceof AppError)
+  assert.equal(thrown.code, 'HOST_OFFLINE')
+  assert.equal(thrown.message, 'xfor@pc-wsl is not reachable.')
+})
+
+test('field errors survive, which is what puts a message under an input', async () => {
+  // The case that was visibly broken: adding a repository that is already
+  // tracked reported itself in the dialog's banner rather than under the path
+  // field, because this object did not cross.
+  const thrown = await roundTrip(() =>
+    Promise.reject(
+      new AppError('DUPLICATE_REPOSITORY', 'That repository is already tracked.', {
+        path: ['Already tracked as "gitwarren-app".']
+      })
+    )
+  )
+
+  assert.ok(thrown instanceof AppError)
+  assert.equal(thrown.code, 'DUPLICATE_REPOSITORY')
+  assert.deepEqual(thrown.fieldErrors, { path: ['Already tracked as "gitwarren-app".'] })
+})
+
+test('an ordinary Error becomes INTERNAL rather than being lost', async () => {
+  const thrown = await roundTrip(() => Promise.reject(new TypeError('cannot read x of undefined')))
+
+  assert.ok(thrown instanceof AppError)
+  assert.equal(thrown.code, 'INTERNAL')
+  assert.equal(thrown.message, 'cannot read x of undefined')
+})
+
+test('a synchronous throw is an outcome too, not an escape', async () => {
+  // `outcomeOf` takes a function rather than a promise precisely so that a
+  // caller that throws before returning one is still reported as a value. A
+  // signature taking a promise would let that case past the boundary.
+  const outcome = await outcomeOf(() => {
+    throw new AppError('INVALID_INPUT', 'An image is required.')
+  })
+
+  assert.ok('error' in outcome)
+  assert.equal(outcome.error.code, 'INVALID_INPUT')
+})

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -18,7 +18,7 @@
  * that is deliberate: this file is transport, not behaviour.
  */
 import type { FileContent, FileImage, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
-import type { AttachmentIngestParams, Carrier, ReviewOpen, RpcMethod } from './rpc.js'
+import type { AttachmentIngestParams, BridgeCarrier, ReviewOpen, RpcMethod } from './rpc.js'
 import type {
   AddHostInput,
   AddRepositoryInput,
@@ -442,8 +442,12 @@ export interface GitWarrenApi {
  * above it do not change at all.
  */
 export interface GitWarrenBridge {
-  /** Every core method, in one function. See `shared/rpc.ts`. */
-  carrier: Carrier
+  /**
+   * Every core method, in one function, answering with an outcome rather than
+   * throwing - see `BridgeCarrier` in `shared/rpc.ts` for why that distinction
+   * is load-bearing across `contextBridge`. `lib/api.ts` unwraps it.
+   */
+  carrier: BridgeCarrier
   shell: ShellApi
 }
 

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -18,7 +18,7 @@
  * check that matters; a second one here would be a second place to keep in step
  * and a second opinion about what a valid review is.
  */
-import { deserializeAppError, type SerializedAppError } from './errors.js'
+import { AppError, deserializeAppError, type SerializedAppError } from './errors.js'
 import type { FileContent, FileImage, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
 import type {
   AddHostInput,
@@ -396,6 +396,35 @@ export interface Carrier {
 }
 
 /**
+ * A carrier that answers with an outcome instead of throwing.
+ *
+ * The shape `window.gitwarren` exposes, and the reason is one property of
+ * Electron's `contextBridge`: a promise rejected on the preload side is rebuilt
+ * in the renderer as a plain `Error` with a `message` and nothing else. Custom
+ * properties do not survive - so an `AppError` unwrapped in the preload arrived
+ * in React with `code` and `fieldErrors` gone, which is every inline form error
+ * in the app and the reason a duplicate path was reported in a banner rather
+ * than under the input it was about.
+ *
+ * So the bridge carries a *value*, which survives intact, and `lib/api.ts`
+ * calls `resultOf` in the renderer's own world where a thrown `AppError` is
+ * still an `AppError`. That is the same rule the byte-stream carriers already
+ * follow - a boundary that cannot carry an exception returns an outcome - and
+ * it is why `resultOf` was written to be shared in the first place.
+ *
+ * A browser tab has no such boundary and could throw perfectly well; it hands
+ * back outcomes anyway, because one shape means the renderer has one way of
+ * asking rather than two.
+ */
+export interface BridgeCarrier {
+  request<M extends RpcMethod>(
+    method: M,
+    params: RpcParams<M>,
+    host?: string
+  ): Promise<RpcOutcome<RpcResult<M>>>
+}
+
+/**
  * Unwrap an outcome, or throw the error it carries.
  *
  * Shared so that every carrier fails the same way: a `NOT_FOUND` from a daemon
@@ -406,4 +435,24 @@ export interface Carrier {
 export function resultOf<T>(outcome: RpcOutcome<T>): T {
   if ('error' in outcome) throw deserializeAppError(outcome.error)
   return outcome.result
+}
+
+/**
+ * The other direction: run something, and report how it went as a value.
+ *
+ * The inverse of `resultOf`, and it exists for the same reason `handleRequest`
+ * in the dispatcher never throws - some boundaries cannot carry an exception,
+ * so an outcome has to be the return value rather than the happy path.
+ *
+ * A byte stream is the obvious such boundary. Electron's `contextBridge` is the
+ * surprising one: it rebuilds a rejection as a bare `Error` carrying `message`
+ * and nothing else, so an `AppError` thrown on the preload side arrives in the
+ * renderer with no `code` and no `fieldErrors`. See `BridgeCarrier`.
+ */
+export async function outcomeOf<T>(work: () => Promise<T>): Promise<RpcOutcome<T>> {
+  try {
+    return { result: await work() }
+  } catch (error) {
+    return { error: AppError.from(error).toSerialized() }
+  }
 }

--- a/src/web/bootstrap.ts
+++ b/src/web/bootstrap.ts
@@ -16,7 +16,27 @@ import { createWebCarrier } from './carrier'
 import { createWebShell } from './shell'
 import { isLoopbackFragment, routeForLoopbackFragment } from './loopback-fragment'
 import { hrefFor } from '@shared/routes'
+import { outcomeOf, type BridgeCarrier, type Carrier } from '@shared/rpc'
 import type { GitWarrenBridge } from '@shared/api'
+
+/**
+ * The carrier, in the shape `window.gitwarren` promises.
+ *
+ * A tab has no `contextBridge` and could throw perfectly well - the socket
+ * carrier and the screens that read it are the same world, so an `AppError`
+ * crosses nothing and loses nothing. It hands back an outcome anyway, because
+ * the *Electron* bridge has no choice (see `BridgeCarrier` in `shared/rpc.ts`)
+ * and one shape means `lib/api.ts` has one way of asking rather than a branch
+ * for which shell it happens to be running in.
+ *
+ * The round trip through `toSerialized` and back is the price, and it is a
+ * plain object copy on a path that is already a network request.
+ */
+function asBridgeCarrier(carrier: Carrier): BridgeCarrier {
+  return {
+    request: (method, params, host) => outcomeOf(() => carrier.request(method, params, host))
+  }
+}
 
 export function installBridge(): GitWarrenBridge {
   // The shell is handed the carrier, which the preload's never needed. Two of
@@ -25,7 +45,9 @@ export function installBridge(): GitWarrenBridge {
   // host half is an ordinary method. See `shell.ts` on where that line falls.
   const carrier = createWebCarrier()
   const bridge: GitWarrenBridge = {
-    carrier,
+    carrier: asBridgeCarrier(carrier),
+    // The shell keeps the throwing carrier: it is ordinary in-world code, and
+    // `openInEditor` wants the path rather than an outcome to unwrap.
     shell: createWebShell(carrier)
   }
 


### PR DESCRIPTION
Based on **#48** (M4.3), which is based on #47 and #46. A bug fix rather than a
milestone slice — it sits on the stack because it touches the same files, but it
is independent of hosts and predates all of M4.

## The bug

`AppError.code` and `fieldErrors` have not reached the renderer since M1, and
nothing about it looked broken. Electron's `contextBridge` rebuilds a rejected
promise as a plain `Error` carrying `message` and nothing else, so the
`AppError` the preload's carrier threw arrived in React stripped:

```
// what the page actually saw, before
{"name":"Error","ownKeys":[],"message":"That repository is already tracked as \"gitwarren-app\"."}
```

`errorCode(error)` was therefore always null in the packaged window and
`firstFieldError` always undefined — every one of the nine places that read a
code. The visible symptom was quiet enough to live with for three milestones:
adding an already-tracked repository put "Already tracked as …" in the dialog's
banner instead of under the path input it was about, and the input was never
marked invalid. Same for the host form and the review form. A browser tab was
unaffected, because its carrier throws in the world that catches it.

## The fix

The rule every other carrier in this app already follows: **a boundary that
cannot carry an exception returns an outcome.** The stdio and WebSocket carriers
do this because a byte stream leaves no choice; `contextBridge` turned out to be
the same kind of boundary without looking like one.

- `BridgeCarrier` (`shared/rpc.ts`) is what `window.gitwarren` exposes — the
  same `request`, answering with an `RpcOutcome`.
- `outcomeOf` is the counterpart to `resultOf` that builds one.
- `lib/api.ts` unwraps in the renderer's own world, in one place (`ask`), where
  a thrown `AppError` is still an `AppError`.
- The web bridge hands back the same shape, so the renderer has one way of
  asking rather than a branch per shell.

Shell channels still throw across the bridge and still lose their codes. That is
a deliberate limit, not a half-applied fix: nothing branches on a shell error's
code — revealing a path, launching an editor and picking a file are all rendered
as their message — so converting twenty signatures would be churn with nothing
behind it. The day one needs a code, it takes `outcomeOf` the same way.

## Verified in the running app

- The raw bridge on a failure now answers
  `{"error":{"code":"NOT_FOUND","message":"No repository with id 999."}}` — a
  value, with the code intact.
- Adding a duplicate repository through the form marks the input invalid and
  prints *Already tracked as "gitwarren-app".* in red under it (screenshot in
  the thread).
- **M4.3's "this host is not answering" state now renders in the window**, which
  it could not before — it branches on `HOST_OFFLINE`. Proved by moving
  `~/.gitwarren/bin/gitwarren` aside on `pc-wsl` mid-session and killing the
  daemon already running: the screen showed *GitWarren is not installed on
  xfor@pc-wsl: ~/.gitwarren/bin/gitwarren was not found*, with a Try again, and
  recovered on its own once the launcher was put back.

## Also in here

One M4.3 bug found while doing the above, fixed on that branch and included in
this stack: the host banner rendered "a host this GitWarren no longer knows"
about a perfectly good machine while the host list was still loading. Undefined
now means "still on its way" and null means "arrived, and not in it" — the same
distinction `host-status.tsx` already makes between a host that is down and one
nobody has spoken to yet.

## Checks

`lint`, `typecheck`, `build` clean; 498 tests pass (5 new, pinning that the code
and the field errors survive a full outcome round trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdoeT2B1TM3qUdvQUtmydn
