### PR TITLE
M4.4: attachments, editors and agent access per host

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -223,6 +223,44 @@ Record the outcome under each one.
   There is also no `code` on `PATH` in a plain WSL shell here, so spawning a
   bare `code` inside the distro is not an option.
 
+- **Outcome, the `ssh-remote` half.** *Checked before M4.4 was written, because
+  the form the milestone actually ships had never been run. 11 September 2026,
+  VS Code 1.135.0 on macOS 26.6 (arm64), against `xfor@pc-wsl`.* The spike above
+  verified `wsl+Ubuntu` *from Windows*; a Mac opening
+  `ssh-remote+xfor@pc-wsl` is a different extension over a different transport,
+  and it passes:
+
+  `vscode://vscode-remote/ssh-remote+xfor@pc-wsl/home/xfor/…/README.md:5`,
+  handed to `open`, brings up a window whose workspace storage records
+  `resource.authority.os.ssh-remote+xfor@pc-wsl`, starts
+  `~/.vscode-server/code-08d4889f…` on the host — the Mac's own VS Code commit,
+  not the one the WSL spike left there — and puts the cursor on line 5. The line
+  is not a claim about what was on screen: VS Code writes its own
+  `memento/workbench.editors.files.textFileEditor` per window, and that entry
+  reads `lineNumber: 5` against the `vscode-remote://ssh-remote%2Bxfor@pc-wsl/…`
+  URI. The same memento later recorded `lineNumber: 3` for
+  `docs/across-hosts.md`, which was GitWarren's own button rather than a URL
+  typed by hand.
+
+  **Nothing happens at all without the Remote-SSH extension, and it is silent.**
+  With a stock VS Code the URL opens no window, starts no `ssh`, and leaves no
+  server on the host — the first run of this check produced exactly nothing, and
+  it took looking at `ps` on `pc-wsl` to establish that rather than a message.
+  `ms-vscode-remote.remote-ssh` was installed on the Mac for the check and is
+  what makes the form work; a person without it sees a prompt from VS Code
+  rather than a review file. That is not something GitWarren can detect —
+  `main/editors.ts` can see that VS Code is installed and cannot see which
+  extensions it has — so the honest position is that the button opens the
+  editor and the editor says what it needs.
+
+  Two things this did *not* separate. Both the URL form and
+  `code --remote ssh-remote+xfor@pc-wsl --goto <path>:5` were fired within
+  twenty seconds of each other on a cold start, and the server took ninety
+  seconds to appear, so which of them brought it up is unknown; the URL form is
+  what ships, and the memento above proves it lands. And a remote window already
+  connected cannot be closed from a script, so the "first ever connection"
+  timing was measured once and is not repeatable here.
+
 ### S5 — How chatty is a screen today?
 
 - **Question.** Count IPC calls and their dependency depth for: the repository
@@ -1547,7 +1585,7 @@ them verifiable against the real `pc-wsl` node rather than against a mock:
 3. **Repositories on hosts.** `fs.list`, the host segment in routes, reviews
    listed under their host, clones grouped by root commit across hosts.
    *(done — see below.)*
-4. **Attachments, editors and agent access per host.**
+4. **Attachments, editors and agent access per host.** *(done — see below.)*
 5. **Disconnection.** The stale banner and the silent refetch.
 
 **M4.1, done on the Mac against the WSL node, 10 September.** The novelty is
@@ -1998,6 +2036,169 @@ segment, and it belongs with M6's live links rather than here. There is no
 disconnection banner and no silent refetch — a host that goes away mid-review
 still empties the screen — which is M4.5, and the reason its error state already
 has a shape to grow into.
+
+**M4.4, done on the Mac against the WSL node, 11 September.** The three controls
+M4.3 switched off rather than half-built are back on, and each of them turned out
+to be the same shape: a thing that used to mean "this computer" implicitly, made
+to say which computer it means.
+
+    frame()                     a request becomes bytes, once
+    attachments.read            the store is over there
+    (host, path, line)          the editor is here, the file is not
+    app.mcp                     that machine's launcher, as it resolves it
+
+**One encoder, because two answers to "how does a request become bytes" is a
+hang.** `attachments.ingest` routed to a host correctly in M4.3 and still could
+not work, because `stdio-client.ts` wrote `JSON.stringify` and that is the one
+function an `ArrayBuffer` does not survive: the image arrived as `{}` and was
+refused for not being a PNG, which is a sentence about the *file* for a fault in
+the *wire*. The web carrier had already solved this in `web/wire.ts`, so the fix
+was to move it rather than to write it — `shared/rpc-wire.ts` now, read by the
+WebSocket carrier and by the stdio client. It is the same argument `ndjson.ts`
+records about framing, one layer up, and it is worth noticing that the two
+failures differ only in how loud they are: two framings hang, two encodings lie.
+
+**A body may not name a machine.** The obvious place for the host is the token —
+`gitwarren://attachment/<host>/<sha>.<ext>` — and it is wrong for the reason
+`repositories.host_id` was wrong in M4.3. A comment body is stored text on one
+machine; it is read by that machine's own agent over its local MCP, quoted into
+other comments, and edited by hand. An instance id inside it would be a claim
+about somewhere else that nothing keeps true. So the token is untouched and the
+host is attached at the `<img src>` — the one place that already differs between
+the two shells and the one place that knows which screen is being drawn. The
+local case is then the token byte for byte, which is what makes every comment
+written before this milestone render exactly as it did.
+
+A query rather than a path segment, so the pathname a server resolves is still
+`<sha>.<ext>` and the whitelist in `shared/attachments.ts` is still the whole of
+what reaches a filesystem. Both servers ask `isAnsweredLocally` rather than
+their own question, so "no host", "our own instance id" and "somebody else's"
+cannot come to mean something different in the custom scheme from what they mean
+in the router.
+
+**base64 on the way out, and one buffered read.** `attachments.read` answers
+with the file encoded, because the response is `JSON.stringify`d onto an ndjson
+frame and the carrier under it has no notion of a partial body. That costs a
+third in size and gives up streaming for remote images; the ingest limit bounds
+it at ten megabytes, and the name being the hash of the bytes means the
+`immutable` cache header is honest, so a tab or a window pays once. Inventing
+range requests over an `ssh` pipe for pictures that are already bounded would be
+a second protocol for no one.
+
+**Every fallback in an editor launch ends at this machine's filesystem, so each
+one had to be asked whether it can say "over there".** `main/editors.ts` has a
+URL form, a CLI form and the `GITWARREN_EDITOR` template, and the shape the host
+argument forces is that the ones with no remote spelling must *fail* rather than
+fall through: `shell.openPath('/home/xfor/…')` on a Mac opens a different file or
+none, which is precisely the failure M4.3 hid the button to avoid. Three editors
+have a remote form, so a Mac with only Zed on it gets an empty list and no
+button — the honest answer, and the thing M4.3 got wrong in the other direction
+by emptying the list while leaving the callback.
+
+`remotelyOpenable` is in `shared/editors.ts` and not in either shell, because two
+different questions are being asked and only one of them is about this machine.
+What is installed is detection; whether an editor can be pointed at another
+computer is a property of the editor.
+
+**`{host}` in the custom template expands to the editor target, and an argument
+that becomes empty is dropped.** That is what lets one template serve both cases:
+`--remote={host}` disappears on a local file, where `--remote {host}` as two
+arguments would leave the flag behind with nothing after it. `custom` counts as
+remote-capable on purpose — whether somebody's `emacsclient` wrapper works is
+theirs to find out, and refusing to offer it would remove the only way to try.
+
+**The editor target is a second name for a machine, and it is kept apart from the
+first.** `hosts.editor_target` has existed since M0 with nothing writing it; NULL
+means derive `ssh-remote+<target>`, which is right until somebody's SSH config
+aliases differ from their editor's, and stops coinciding by default at M5 where
+the carrier is `wsl.exe -d Ubuntu` and the editor form is `wsl+Ubuntu`.
+`editorTargetFor` sits next to `routeFor` in spirit — how the carrier names it,
+how an editor names it — but lives in `shared/` because a browser tab builds the
+same URL and cannot read a database.
+
+**Agent access per host is a fact travelling, not a capability.** `app.mcp`
+returns `~/.gitwarren/bin/gitwarren-mcp` *as the host resolves it*, which is the
+whole point: a Mac has no way to know what `~` is on `pc-wsl`, and a page that
+guessed would hand somebody a command that confidently does not exist. It says
+where a launcher is and does not start one, which is the line `shared/web.ts`
+draws and the reason it may be on the dispatcher at all. `describeMcpLaunch`
+moved into `core/mcp-launcher.ts` so the daemon's `app-info` and this method are
+one answer, and `gitwarren agent-setup` on the host prints the same sentence from
+the same `shared/agent-setup.ts` — verified by running both.
+
+What changes around the prompt matters as much as the prompt. This page is an
+instruction, and the one way it can do harm is by being confidently about the
+wrong computer — so a host's copy says "an agent running on that machine", and
+everything this install knows only about *itself* is left out rather than
+repeated under another machine's heading: the database path, the version, and
+the link-port warning, which is about whether a `gitwarren://` link will open on
+the computer you are sitting at.
+
+**Verified end to end against `pc-wsl` through the shipping code**, with every
+call made over `window.gitwarren.carrier` in the real window so that the preload,
+the router, the pool and the `ssh` carrier were all in the path. The daemon was
+reinstalled from this build first (46.4 MB in 5 s) and answered `Unknown method
+"app.mcp"` and `Unknown method "attachments.read"` before it — version skew
+behaving as designed, and the same reinstall M4.3 needed.
+
+A 5,035-byte PNG made in the renderer went out as an `ArrayBuffer`, crossed the
+pipe and landed in `/home/xfor/.config/GitWarren/attachments/…` with its
+dimensions read correctly on the far side, which is the proof the bytes were
+bytes rather than `{}`. `attachments.read` fetched it back in 11 ms warm;
+the same name asked of *this* machine answered `NOT_FOUND`, which is the
+clearest statement that nothing was copied here. The token in a comment body on
+the host rendered in the window as a 320×200 image in 15 ms, with the host in
+the `src` and the token unchanged in the body, and again after a cold reload. The
+same bytes came back over the loopback HTTP endpoint as `image/png`, 5,035
+bytes, behind the session cookie. The same token with no host, with an unknown
+host, and a percent-encoded traversal in place of the name all failed.
+`reviews.filePath` on the host answered a WSL path in 19 ms and
+`shell.openInEditor` opened it — line 3 of `docs/across-hosts.md`, per VS Code's
+own per-window memento, in a window whose authority is `ssh-remote+xfor@pc-wsl`.
+`app.mcp` answered `/home/xfor/.gitwarren/bin/gitwarren-mcp` in 18 ms and
+`/Users/michalwrzosek/…` with no host; `#/h/<instance>/agent` showed the first
+and no trace of the second. The remote files tab draws *Open in VS Code* again
+and no reveal button; the remote conversation tab draws *Attach an image*. A
+local paste still produces a `src` identical to its token and still renders. No
+console errors, and no horizontal scroll at 390 px.
+
+**Three things bit, and one of them is mine rather than the code's.**
+
+*The Agent Access page was reading the wrong machine by construction, and so was
+every image.* `agent-access-page.tsx` and `components/markdown.tsx` both imported
+the module-scope `api` — which is `apiFor()`, this install, always. M4.3's
+`useApi()` exists precisely so that a screen does not have to think about hosts,
+and the two files that predate it were quietly opting out. `markdown.tsx` needed
+a component extracted to call a hook at all, which is the small cost of the
+pattern and worth paying: there is now nowhere in a comment body's rendering
+path that *can* name the wrong store.
+
+*A picked file is a path on the machine with the picker, not on the machine with
+the store.* `attachments.pick` used to end in `attachmentsService.ingest({ path })`,
+and a path is the one form that cannot travel — `/Users/…/screenshot.png` means
+nothing on `pc-wsl`. So the shell channel takes a host, and for a remote review
+reads the bytes and sends those, stat-checking the size first exactly as the
+store does so that a wrong file is refused without being pulled into memory on
+its way to a wire. It is the same asymmetry M4.3 found with `fs.list`: the shell
+can open a window, and only the owning machine can hold the result.
+
+*`fetch` cannot test an `<img>`.* Probing the custom scheme with `fetch` from the
+renderer failed with `connect-src 'self'`, which for some minutes looked like the
+scheme being broken rather than the CSP doing its job — `img-src` is what an
+attachment is allowed under, and an `Image()` load is the only check that
+exercises the path the app actually uses. Worth writing down because the next
+person to verify this will reach for `fetch` too.
+
+**Not done in M4.4, and why.** The native picker's dialog cannot be driven from
+a script, so the remote branch behind it was exercised by sending the same bytes
+over the same carrier rather than by pressing the button; the stat guard and the
+basename are covered by nothing but reading. The editor picker never appeared
+during verification because this Mac has exactly one editor installed and it is
+remote-capable, so `remotelyOpenable` reducing a list is covered by its unit
+tests and not by the machine. A browser tab was checked at the HTTP endpoint and
+not with a browser open in front of it. And deep links still carry no host, so a
+`gitwarren://` link written on `pc-wsl` opens the Mac's review of that number —
+unchanged from M4.3, and still M6's.
 
 ### M5 — WSL from Windows
 

--- a/src/core/hosts/router.ts
+++ b/src/core/hosts/router.ts
@@ -55,12 +55,9 @@
  * answer, not a gap: until the machine has said who it is, this install cannot
  * tell it apart from any other.
  */
-import { eq } from 'drizzle-orm'
-import { getDatabase } from '../db/client.js'
-import { hosts } from '../db/schema.js'
 import { getInstanceId } from '../instance.js'
 import { hostPool } from './pool.js'
-import { routeFor } from '../services/hosts.js'
+import { requireInstance, routeFor } from '../services/hosts.js'
 import { isLocalOnly } from './ssh.js'
 import { dispatch } from '../rpc/dispatcher.js'
 import { AppError } from '../../shared/errors.js'
@@ -94,20 +91,10 @@ export async function route<M extends RpcMethod>(
 ): Promise<RpcResult<M>> {
   if (isAnsweredLocally(host, method)) return dispatch(method, params)
 
-  const row = getDatabase().select().from(hosts).where(eq(hosts.instanceId, host as string)).get()
-  if (!row) {
-    // Names the id rather than saying "unknown host", because the id is what
-    // the link contained and is the only thing the person can compare against
-    // their Hosts screen. This is what a link to a machine that has since been
-    // forgotten produces, and it should read like one.
-    throw new AppError(
-      'NOT_FOUND',
-      `This GitWarren does not know a host with id ${host as string}. ` +
-        'It may have been removed, or the link may have come from somewhere else.'
-    )
-  }
-
-  return hostPool.request(routeFor(row), method, params)
+  // `requireInstance` rather than a lookup here, because the editor launch in
+  // `main/ipc.ts` resolves the same id for a different purpose and a link to a
+  // machine that has since been forgotten should read the same either way.
+  return hostPool.request(routeFor(requireInstance(host as string)), method, params)
 }
 
 /**

--- a/src/core/mcp-launcher.ts
+++ b/src/core/mcp-launcher.ts
@@ -15,8 +15,10 @@
  * directory is shared on purpose - one place a user can look at, inspect and
  * delete, holding every generated file GitWarren asks another program to run.
  */
+import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import type { McpLaunchInfo } from '../shared/api.js'
 
 /** `~/.gitwarren/bin`. The same on Windows, where `~` is the user profile. */
 export function getLauncherDirectory(): string {
@@ -42,4 +44,39 @@ export function getCliLauncherPath(): string {
     getLauncherDirectory(),
     process.platform === 'win32' ? 'gitwarren.cmd' : 'gitwarren'
   )
+}
+
+/**
+ * What an agent needs in order to start this install's MCP server, as far as a
+ * process with no Electron around it can say.
+ *
+ * Lifted out of `daemon/listen.ts` at M4.4, when it grew a second reader.
+ * `app.mcp` on the dispatcher answers with this, because the Agent Access page
+ * for a *host* has to print the launcher path on that machine and only that
+ * machine knows where `~` is - so a GUI on a Mac asks, and what answers is a
+ * daemon over `ssh`.
+ *
+ * The Electron app keeps its own `getMcpLaunchInfo` in `main/mcp-launch.ts`,
+ * and the difference is not duplication: that one *writes* the launcher, knows
+ * about running Electron as node, and has something to say about a checkout
+ * that has not been built. This one describes a machine where the launcher is
+ * written by `gitwarren service install` and there is nothing behind it. The
+ * one field both must agree on is `command`, and they agree because they both
+ * call `getMcpLauncherPath` above.
+ */
+export function describeMcpLaunch(): McpLaunchInfo {
+  const launcher = getMcpLauncherPath()
+  const available = existsSync(launcher)
+
+  return {
+    command: launcher,
+    args: [],
+    env: {},
+    available,
+    stable: true,
+    direct: { command: launcher, args: [], env: {} },
+    note: available
+      ? undefined
+      : 'No MCP launcher on this machine yet. `gitwarren service install` writes it.'
+  }
 }

--- a/src/core/rpc/dispatcher.ts
+++ b/src/core/rpc/dispatcher.ts
@@ -27,6 +27,7 @@
  * never enter this map.
  */
 import { getInstanceId } from '../instance.js'
+import { describeMcpLaunch } from '../mcp-launcher.js'
 import { APP_VERSION } from '../version.js'
 import { attachmentsService } from '../services/attachments.js'
 import { commentsService } from '../services/comments.js'
@@ -148,6 +149,7 @@ const handlers: {
   [M in RpcMethod]: (params: unknown) => Promise<RpcResult<M>> | RpcResult<M>
 } = {
   'app.instance': () => describeThisInstance(),
+  'app.mcp': () => describeMcpLaunch(),
 
   // Answered by whoever is asked, and never forwarded onward - see the note on
   // these in `shared/rpc.ts`. They are in the map because a screen reaches the
@@ -199,7 +201,8 @@ const handlers: {
   'comments.remove': (params) => commentsService.remove(params, HUMAN_AUTHOR),
   'comments.setResolved': (params) => commentsService.setResolved(params, HUMAN_AUTHOR),
 
-  'attachments.ingest': (params) => attachmentsService.ingest(toIngestSource(params))
+  'attachments.ingest': (params) => attachmentsService.ingest(toIngestSource(params)),
+  'attachments.read': (params) => attachmentsService.read(params)
 }
 
 /** Derived from the map above rather than written out again next to it. */

--- a/src/core/rpc/stdio-client.ts
+++ b/src/core/rpc/stdio-client.ts
@@ -42,6 +42,7 @@
  * because this is where it would be most tempting to be clever.
  */
 import { readFrames } from './ndjson.js'
+import { frame } from '../../shared/rpc-wire.js'
 import { AppError } from '../../shared/errors.js'
 import {
   isRpcEvent,
@@ -222,7 +223,17 @@ export function createStdioClient({
           // One `write` per message: Node serialises writes on a stream, so two
           // requests issued in the same tick cannot interleave halfway through
           // a line.
-          output.write(`${JSON.stringify(request)}\n`)
+          //
+          // `frame` rather than `JSON.stringify`, and that is not a style
+          // choice: an `ArrayBuffer` is the one value `JSON.stringify` destroys
+          // silently, turning `attachments.ingest`'s image into `{}`. Until
+          // M4.4 this line was the reason a screenshot pasted onto a review on
+          // another machine came back "that file is not a PNG" about a file
+          // that was one. The encoder is `shared/rpc-wire.ts` because the
+          // WebSocket carrier had already solved this and two answers to "how
+          // does a request become bytes" is the same hazard `ndjson.ts` exists
+          // to remove.
+          output.write(`${frame(request)}\n`)
         } catch (error) {
           pending.delete(id)
           reject(

--- a/src/core/services/attachments.ts
+++ b/src/core/services/attachments.ts
@@ -31,7 +31,9 @@ import { attachments, comments, reviews } from '../db/schema.js'
 import { getDataDirectory } from '../paths.js'
 import { attachmentUrl, parseAttachmentUrl } from '../../shared/attachments.js'
 import { AppError } from '../../shared/errors.js'
-import type { Attachment } from '../../shared/schemas.js'
+import { readAttachmentInputSchema } from '../../shared/schemas.js'
+import { parseWithSchema as parse } from '../../shared/validation.js'
+import type { Attachment, AttachmentBytes } from '../../shared/schemas.js'
 
 /**
  * The ceiling on a single attachment.
@@ -326,6 +328,61 @@ export const attachmentsService = {
       height,
       originalName
     })
+  },
+
+  /**
+   * The bytes behind a token, for a reader that cannot open the file itself.
+   *
+   * Every shell served attachments straight off its own disk until M4.4, which
+   * is exactly why an image on a remote review rendered as a broken one: the
+   * store holding it is on the machine that owns the review, and the two
+   * schemes that serve it - `gitwarren://attachment/…` in the window,
+   * `/gitwarren/attachments/…` in a tab - both resolve against wherever they
+   * happen to be running. So reading becomes a method, and *which* store to
+   * read from becomes the router's question rather than the filesystem's.
+   *
+   * It stays a plain read of the store and nothing more. There is no fallback
+   * to fetching from anywhere, no cache written here, and no row invented for a
+   * file that is not on disk: a token whose bytes the sweep has collected is a
+   * `NOT_FOUND`, which is what both shells already turn into a 404.
+   *
+   * The name is matched against `ATTACHMENT_FILE_NAME` by the schema before it
+   * reaches this line, which is the whole of the traversal story - the same
+   * whitelist both servers state, now stated once more on the far side of a
+   * wire. Nothing here builds a path out of anything but a sha and an
+   * extension.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async read(input: unknown): Promise<AttachmentBytes> {
+    const { name } = parse(readAttachmentInputSchema, input)
+    const dot = name.lastIndexOf('.')
+    const sha = name.slice(0, dot)
+    const ext = name.slice(dot + 1)
+
+    // The row rather than the extension is what says what this is, for the
+    // reason `FORMATS` exists: the extension was chosen by sniffing the bytes
+    // at ingest, and the row is where that conclusion was written down.
+    const row = getDatabase().select().from(attachments).where(eq(attachments.sha, sha)).get()
+    if (!row || row.ext !== ext) {
+      throw new AppError('NOT_FOUND', `No attachment named ${name}.`)
+    }
+
+    let bytes: Buffer
+    try {
+      bytes = readFileSync(attachmentPath(sha, ext))
+    } catch {
+      // A row whose file is gone. Reported as missing rather than as a failure
+      // of this machine, because from the reader's point of view it is the same
+      // answer as a token that was never ingested.
+      throw new AppError('NOT_FOUND', `The bytes of ${name} are no longer in the store.`)
+    }
+
+    return {
+      name,
+      mimeType: row.mimeType,
+      byteSize: bytes.byteLength,
+      base64: bytes.toString('base64')
+    }
   },
 
   /**

--- a/src/core/services/hosts.ts
+++ b/src/core/services/hosts.ts
@@ -75,6 +75,29 @@ export function routeFor(row: HostRow): HostRoute {
   return { id: row.id, kind: row.kind, target: row.target }
 }
 
+/**
+ * The host a route or a link names, by the only name that survives a rename, a
+ * new address and a change of carrier.
+ *
+ * Exported because two callers outside this service resolve an instance id and
+ * must fail the same way when it is not there: `core/hosts/router.ts`, which is
+ * about to forward a request, and the editor launch in `main/ipc.ts`, which
+ * needs to know how an editor names that machine. The sentence names the id
+ * rather than saying "unknown host", because the id is what the link contained
+ * and the only thing a person can compare against their Hosts screen.
+ */
+export function requireInstance(instanceId: string): HostRow {
+  const row = getDatabase().select().from(hosts).where(eq(hosts.instanceId, instanceId)).get()
+  if (!row) {
+    throw new AppError(
+      'NOT_FOUND',
+      `This GitWarren does not know a host with id ${instanceId}. ` +
+        'It may have been removed, or the link may have come from somewhere else.'
+    )
+  }
+  return row
+}
+
 function requireRow(id: number): HostRow {
   const row = getDatabase().select().from(hosts).where(eq(hosts.id, id)).get()
   if (!row) throw new AppError('NOT_FOUND', `No host with id ${id}.`)

--- a/src/core/web/attachments.ts
+++ b/src/core/web/attachments.ts
@@ -20,6 +20,15 @@
  * reason - comment bodies are written by agents, and an agent may have just
  * read untrusted content out of the repository under review.
  *
+ * ## Which machine's store
+ *
+ * Since M4.4 a request may name a host, and then the bytes come back over the
+ * carrier instead of off this disk. The decision is `isAnsweredLocally`, the
+ * router's own, so this endpoint cannot develop a private opinion about what
+ * "no host" or "our own instance id" mean. Note what does *not* change: the
+ * name is matched before the host is looked at, so a malformed name is refused
+ * here and never travels.
+ *
  * The content type comes from the extension, which is not the usual mistake:
  * the extension was chosen at ingest by sniffing the bytes (see
  * `core/services/attachments.ts`), so it is this app's own conclusion about the
@@ -30,7 +39,9 @@
  */
 import { createReadStream, statSync } from 'node:fs'
 import type { ServerResponse } from 'node:http'
+import { isAnsweredLocally, route } from '../hosts/router.js'
 import { attachmentPath } from '../services/attachments.js'
+import { AppError } from '../../shared/errors.js'
 import { attachmentNameFromWebPath, WEB_PATHS } from '../../shared/web.js'
 
 /**
@@ -76,7 +87,8 @@ export interface AttachmentResult {
 export function serveAttachment(
   pathname: string,
   method: string,
-  response: ServerResponse
+  response: ServerResponse,
+  host?: string
 ): AttachmentResult {
   if (!pathname.startsWith(WEB_PATHS.attachments)) return { served: false }
 
@@ -90,6 +102,11 @@ export function serveAttachment(
   const contentType = CONTENT_TYPES[name.slice(dot + 1)]
   if (contentType === undefined) {
     response.writeHead(404, HEADERS).end()
+    return { served: true }
+  }
+
+  if (!isAnsweredLocally(host, 'attachments.read')) {
+    serveFromHost(host as string, name, contentType, method, response)
     return { served: true }
   }
 
@@ -123,4 +140,46 @@ export function serveAttachment(
   })
   stream.pipe(response)
   return { served: true }
+}
+
+/**
+ * The same image, out of another machine's store.
+ *
+ * Buffered whole rather than streamed, which is the one thing this endpoint
+ * does differently for a remote host and is a property of the answer rather
+ * than a shortcut: `attachments.read` returns base64 in a single response
+ * frame, because the carrier underneath it is a request/response protocol on a
+ * pipe and has no notion of a partial body. The ingest limit bounds it, and the
+ * immutable cache header above means a tab pays for it once.
+ *
+ * Fire-and-forget on purpose. The caller has already reported the path as
+ * served, exactly as it does for the local stream - by the time anything is
+ * known about the far end there is no status code left to reconsider.
+ */
+function serveFromHost(
+  host: string,
+  name: string,
+  contentType: string,
+  method: string,
+  response: ServerResponse
+): void {
+  void route(host, 'attachments.read', { name })
+    .then((image) => {
+      const bytes = Buffer.from(image.base64, 'base64')
+      response.writeHead(200, {
+        ...HEADERS,
+        'Content-Type': contentType,
+        'Content-Length': bytes.byteLength
+      })
+      response.end(method === 'HEAD' ? undefined : bytes)
+    })
+    .catch((error: unknown) => {
+      // Logged rather than described to the browser, for the reason the local
+      // 404 above is not logged: this one is not ordinary. An `<img>` has
+      // nowhere to put a sentence, and "the host is not answering" and "that
+      // token is not in its store" look identical on screen.
+      console.error(`[web] could not read ${name} from host ${host}`, error)
+      const missing = error instanceof AppError && error.code === 'NOT_FOUND'
+      response.writeHead(missing ? 404 : 502, HEADERS).end()
+    })
 }

--- a/src/core/web/handler.ts
+++ b/src/core/web/handler.ts
@@ -52,6 +52,7 @@ import { isAllowedHost, isAllowedOrigin, loopbackAuthority } from './origin.js'
 import { LINK_SERVER_PORT } from '../../shared/link-port.js'
 import { serveStatic } from './static.js'
 import { isWebToken } from './token.js'
+import { ATTACHMENT_HOST_PARAM } from '../../shared/attachments.js'
 import { SESSION_COOKIE, TOKEN_PARAM, WEB_PATHS, WEB_PREFIX } from '../../shared/web.js'
 import type { AppInfo } from '../../shared/api.js'
 
@@ -237,7 +238,14 @@ export function createWebHandler({
       // Images in comment bodies. Behind the same cookie as everything else -
       // an attachment is review content, and a port that handed screenshots out
       // to whoever asked would be a hole the token exists to close.
-      if (serveAttachment(pathname, request.method ?? 'GET', response).served) return true
+      //
+      // The host comes off the query rather than the path, so the pathname is
+      // still `<sha>.<ext>` and the whitelist is still the whole of what
+      // reaches a filesystem. See `ATTACHMENT_HOST_PARAM`.
+      const attachmentHost = url.searchParams.get(ATTACHMENT_HOST_PARAM) ?? undefined
+      if (serveAttachment(pathname, request.method ?? 'GET', response, attachmentHost).served) {
+        return true
+      }
 
       // The socket path only exists as an upgrade. A plain GET to it is a
       // mistake worth naming rather than a 404 among many.

--- a/src/daemon/listen.ts
+++ b/src/daemon/listen.ts
@@ -35,13 +35,13 @@ import {
   writeDaemonRuntime
 } from '../core/daemon-runtime.js'
 import { getInstanceId } from '../core/instance.js'
-import { getMcpLauncherPath } from '../core/mcp-launcher.js'
+import { describeMcpLaunch } from '../core/mcp-launcher.js'
 import { getDatabasePath, getDataDirectory } from '../core/paths.js'
 import { createWebHandler } from '../core/web/handler.js'
 import { clearWebToken, mintWebToken, publishWebToken } from '../core/web/token.js'
 import { LINK_SERVER_HOST, LINK_SERVER_PORT } from '../shared/link-port.js'
 import { TOKEN_PARAM } from '../shared/web.js'
-import type { AppInfo, McpLaunchInfo } from '../shared/api.js'
+import type { AppInfo } from '../shared/api.js'
 
 /** Stamped by `vite.daemon.config.ts`. Nothing reads a package.json out of a bundle. */
 declare const __APP_VERSION__: string
@@ -108,21 +108,12 @@ export function resolveWebRoot(): string | null {
  * instruction that works on one of them - hence `core/mcp-launcher.ts`.
  */
 function describeInstall(linkPort: number | null): AppInfo {
-  const launcher = getMcpLauncherPath()
-  const mcp: McpLaunchInfo = {
-    command: launcher,
-    args: [],
-    env: {},
-    available: existsSync(launcher),
-    stable: true,
-    // The daemon does not write the launcher - M3.3's `gitwarren service
-    // install` does - so it reports the same path and lets `available` say
-    // whether anything is there yet.
-    direct: { command: launcher, args: [], env: {} },
-    note: existsSync(launcher)
-      ? undefined
-      : 'No MCP launcher on this machine yet. `gitwarren service install` writes it.'
-  }
+  // `describeMcpLaunch` rather than built here, because since M4.4 the same
+  // answer goes out over `app.mcp` to a GUI on another machine looking at this
+  // one's Agent Access page. The daemon does not write the launcher - M3.3's
+  // `gitwarren service install` does - so it reports the path and lets
+  // `available` say whether anything is there yet.
+  const mcp = describeMcpLaunch()
 
   return {
     version: VERSION,

--- a/src/main/attachment-protocol.ts
+++ b/src/main/attachment-protocol.ts
@@ -16,7 +16,10 @@ import { net, protocol } from 'electron'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { ATTACHMENT_FILE_NAME } from '../core/services/attachments.js'
+import { isAnsweredLocally, route } from '../core/hosts/router.js'
 import { getDataDirectory } from '../core/paths.js'
+import { ATTACHMENT_HOST_PARAM } from '../shared/attachments.js'
+import { AppError } from '../shared/errors.js'
 
 /** The scheme, and the one host under it that resolves to anything. */
 export const ATTACHMENT_SCHEME = 'gitwarren'
@@ -46,16 +49,54 @@ export function registerAttachmentScheme(): void {
  * genuinely receive one day. A sha and a short extension is the entire
  * vocabulary of a legitimate name, so anything else is refused outright rather
  * than being resolved and then reasoned about.
+ *
+ * ## Which machine's store
+ *
+ * Since M4.4 the URL may carry `?host=<instance>`, put there by the renderer
+ * when the screen is about another machine (see `ATTACHMENT_HOST_PARAM`). The
+ * decision of what that means is not made here: `isAnsweredLocally` is the
+ * router's, so "no host", "our own instance id" and "somebody else's" mean
+ * exactly what they mean for every other request, and this scheme cannot drift
+ * from them.
+ *
+ * A remote image comes back as base64 on the answer and is turned into a
+ * `Response` here rather than streamed. It is the one place this app buffers an
+ * attachment whole, and the ingest limit is what makes that acceptable - a
+ * range request over an `ssh` pipe would be a second protocol for the sake of
+ * images that are already bounded at ten megabytes.
  */
-export function attachmentResponse(url: string): Response | Promise<Response> {
-  const { host, pathname } = new URL(url)
+export async function attachmentResponse(url: string): Promise<Response> {
+  const { host, pathname, searchParams } = new URL(url)
   if (host !== ATTACHMENT_HOST) return new Response(null, { status: 404 })
 
   const name = pathname.slice(1)
   if (!ATTACHMENT_FILE_NAME.test(name)) return new Response(null, { status: 400 })
 
-  const file = join(getDataDirectory(), 'attachments', name.slice(0, 2), name)
-  return net.fetch(pathToFileURL(file).toString())
+  const instance = searchParams.get(ATTACHMENT_HOST_PARAM) ?? undefined
+  if (isAnsweredLocally(instance, 'attachments.read')) {
+    const file = join(getDataDirectory(), 'attachments', name.slice(0, 2), name)
+    return await net.fetch(pathToFileURL(file).toString())
+  }
+
+  try {
+    const image = await route(instance, 'attachments.read', { name })
+    return new Response(Buffer.from(image.base64, 'base64'), {
+      headers: {
+        'Content-Type': image.mimeType,
+        // Content-addressed, so these bytes can never become different bytes.
+        // Worth saying on this branch in particular: without it every re-render
+        // of a comment would be another round trip over `ssh`.
+        'Cache-Control': 'private, max-age=31536000, immutable'
+      }
+    })
+  } catch (error) {
+    // An `<img>` has nowhere to put a sentence, so the code is all that can be
+    // said - and the reason is worth logging, because "the host is not
+    // answering" and "that token is not in its store" look identical on screen.
+    console.error(`[attachments] could not read ${name} from host ${instance}`, error)
+    const missing = error instanceof AppError && error.code === 'NOT_FOUND'
+    return new Response(null, { status: missing ? 404 : 502 })
+  }
 }
 
 /** Wire the handler up. Call once, after the app is ready. */

--- a/src/main/editors.ts
+++ b/src/main/editors.ts
@@ -21,7 +21,19 @@
  * a command template such as `emacsclient +{line} {file}`. It is read from the
  * environment rather than stored as a setting because this app has no settings
  * screen, and the people who need something other than the five editors below
- * are the same people who already keep `EDITOR` set.
+ * are the same people who already keep `EDITOR` set. Since M4.4 the template
+ * also takes `{host}`, for a file on another machine.
+ *
+ * ## The file may not be on this computer
+ *
+ * From M4.4 every launch takes an optional `remote` - the authority an editor's
+ * own remote extension knows a machine by. It is not a variant of this module
+ * but a property of every path through it: a URL form, a CLI form and a
+ * template each have a remote spelling or no spelling at all, and the ones with
+ * none must fail rather than fall back, because every fallback in here ends at
+ * *this* machine's filesystem. Opening the Mac's `/home/xfor/…` - which either
+ * does not exist or is somebody else's file - is the exact failure M4.3 hid the
+ * button to avoid.
  */
 import { spawn } from 'node:child_process'
 import { access, constants } from 'node:fs/promises'
@@ -41,6 +53,15 @@ interface EditorDefinition extends EditorLink {
   bin?: string
   /** Fallback launch: arguments for `bin`. */
   cliArgs?: (path: string, line: number) => string[]
+  /**
+   * The same, for a file on another machine. Absent when the CLI has no way to
+   * say "over there", which is every editor that has no `remoteUrl` either.
+   *
+   * S4 found this form honours the line where the shim *inside* the remote
+   * machine could not be spawned at all, so it is the fallback that actually
+   * works rather than the one the plan assumed.
+   */
+  remoteCliArgs?: (remote: string, path: string, line: number) => string[]
 }
 
 /**
@@ -58,18 +79,21 @@ const DETECTION: Record<EditorId, Omit<EditorDefinition, 'id' | 'label' | 'url'>
     appBundle: 'Visual Studio Code.app',
     windowsPath: 'Microsoft VS Code\\Code.exe',
     bin: 'code',
-    cliArgs: (path, line) => ['--goto', `${path}:${line}`]
+    cliArgs: (path, line) => ['--goto', `${path}:${line}`],
+    remoteCliArgs: (remote, path, line) => ['--remote', remote, '--goto', `${path}:${line}`]
   },
   cursor: {
     appBundle: 'Cursor.app',
     windowsPath: 'cursor\\Cursor.exe',
     bin: 'cursor',
-    cliArgs: (path, line) => ['--goto', `${path}:${line}`]
+    cliArgs: (path, line) => ['--goto', `${path}:${line}`],
+    remoteCliArgs: (remote, path, line) => ['--remote', remote, '--goto', `${path}:${line}`]
   },
   windsurf: {
     appBundle: 'Windsurf.app',
     bin: 'windsurf',
-    cliArgs: (path, line) => ['--goto', `${path}:${line}`]
+    cliArgs: (path, line) => ['--goto', `${path}:${line}`],
+    remoteCliArgs: (remote, path, line) => ['--remote', remote, '--goto', `${path}:${line}`]
   },
   zed: {
     appBundle: 'Zed.app',
@@ -225,18 +249,47 @@ function launchCommand(bin: string, args: string[]): void {
 /**
  * Open `path` at `line` in an editor.
  *
- * Falls back to the platform's default handler for the file when no editor was
- * detected, which is usually still the right application - just without the
- * line number.
+ * `remote` is how this machine's editors name the machine the path is on -
+ * `ssh-remote+xfor@pc-wsl`, per `editorTargetFor` - and absent means the path
+ * is on this one. That argument is the whole of M4.4's editor work, and the
+ * shape it forces is the interesting part: *every* fallback below has to be
+ * asked whether it can say "over there", because the fallbacks are where a
+ * remote path would otherwise quietly become a local one.
+ *
+ * Falls back to the platform's default handler for a local file when no editor
+ * was detected, which is usually still the right application - just without the
+ * line number. There is deliberately no such fallback for a remote file:
+ * `shell.openPath` would hand this machine's Finder a path only WSL has, which
+ * is the "something plausible to the wrong machine" M4.3 switched the whole
+ * control off to avoid. It raises instead, and the sentence names the editor
+ * and the machine.
  */
-export async function openInEditor(path: string, line: number, editorId?: string): Promise<void> {
+export async function openInEditor(
+  path: string,
+  line: number,
+  editorId?: string,
+  remote?: string
+): Promise<void> {
   const custom = customCommand()
   if (custom && (editorId === undefined || editorId === 'custom')) {
-    const args = custom.args.map((argument) =>
-      argument.replace('{file}', path).replace('{line}', String(line))
-    )
+    const args = custom.args
+      .map((argument) =>
+        argument
+          .replace('{file}', path)
+          .replace('{line}', String(line))
+          .replace('{host}', remote ?? '')
+      )
+      // An argument that became empty is dropped, which is what makes one
+      // template serve both cases: `--remote={host}` disappears on a local file
+      // instead of being passed as a flag with nothing after it. Written as one
+      // argument rather than two for exactly that reason - a `--remote {host}`
+      // pair would leave the flag behind when the value vanished.
+      .filter((argument) => argument.length > 0)
     // A template with no {file} still has to be told what to open.
-    launchCommand(custom.bin, args.some((argument) => argument.includes(path)) ? args : [...args, path])
+    launchCommand(
+      custom.bin,
+      args.some((argument) => argument.includes(path)) ? args : [...args, path]
+    )
     return
   }
 
@@ -245,23 +298,47 @@ export async function openInEditor(path: string, line: number, editorId?: string
     (editorId ? detected.find((editor) => editor.id === editorId) : undefined) ?? detected[0]
 
   if (!chosen) {
+    if (remote !== undefined) {
+      throw new AppError(
+        'INVALID_INPUT',
+        `No editor on this machine can open a file on ${remote}. VS Code, Cursor or Windsurf ` +
+          'with their remote extension can; GITWARREN_EDITOR with {host} in it can too.'
+      )
+    }
     const failure = await shell.openPath(path)
     if (failure) throw new AppError('PATH_NOT_FOUND', failure)
     return
   }
 
-  if (chosen.hasApplication && chosen.definition.url) {
+  const { definition } = chosen
+  const url = remote === undefined ? definition.url?.(path, line) : definition.remoteUrl?.(remote, path, line)
+
+  if (chosen.hasApplication && url) {
     try {
-      await shell.openExternal(chosen.definition.url(path, line))
+      await shell.openExternal(url)
       return
     } catch {
       // The scheme is not registered after all; the CLI below still might be.
     }
   }
 
-  if (chosen.binPath && chosen.definition.cliArgs) {
-    launchCommand(chosen.binPath, chosen.definition.cliArgs(path, line))
+  const cliArgs =
+    remote === undefined
+      ? definition.cliArgs?.(path, line)
+      : definition.remoteCliArgs?.(remote, path, line)
+
+  if (chosen.binPath && cliArgs) {
+    launchCommand(chosen.binPath, cliArgs)
     return
+  }
+
+  if (remote !== undefined) {
+    // Nothing left to try, and the local fallback is not a fallback here - it
+    // opens a different file, or none, on a different computer.
+    throw new AppError(
+      'INVALID_INPUT',
+      `${chosen.label} cannot open a file on ${remote} from this machine.`
+    )
   }
 
   const failure = await shell.openPath(path)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -23,13 +23,17 @@
  * in a service instead.
  */
 import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
+import { readFileSync, statSync } from 'node:fs'
+import { basename } from 'node:path'
 import { dispatch } from '../core/rpc/dispatcher.js'
 import { route } from '../core/hosts/router.js'
 import { traced } from '../core/trace.js'
-import { attachmentsService } from '../core/services/attachments.js'
+import { attachmentsService, MAX_ATTACHMENT_BYTES } from '../core/services/attachments.js'
+import { requireInstance } from '../core/services/hosts.js'
+import { editorTargetFor } from '../shared/editors.js'
 import { AppError } from '../shared/errors.js'
 import { parseWithSchema as parse } from '../shared/validation.js'
-import { openReviewFileInputSchema } from '../shared/schemas.js'
+import { openReviewFileInputSchema, pickAttachmentInputSchema } from '../shared/schemas.js'
 import { CHANNEL_METHODS, IPC_CHANNELS, type AppInfo } from '../shared/api.js'
 import type { RpcMethod, RpcOutcome, RpcParams } from '../shared/rpc.js'
 import { describeInstall } from './app-info.js'
@@ -110,15 +114,24 @@ export function registerIpcHandlers(): void {
   // host across the network - while launching an application is a capability
   // only the machine with the screen on it has.
   handleShell(IPC_CHANNELS.reviewsOpenInEditor, async (input) => {
-    const { id, path, changes, line, editorId } = parse(openReviewFileInputSchema, input)
-    const absolute = await dispatch('reviews.filePath', { id, path, changes })
-    await openInEditor(absolute, line, editorId)
+    const { id, path, changes, line, editorId, host } = parse(openReviewFileInputSchema, input)
+    // `route` rather than `dispatch`, which is the whole of M4.4 here: the
+    // review id means something on the machine that owns it, and asking this
+    // install for `reviews.filePath` of a remote id is the bug M4.3 found by
+    // pressing the button. The path that comes back is on that filesystem.
+    const absolute = await route(host, 'reviews.filePath', { id, path, changes })
+    // And this is the other half: the editor is on *this* machine and has to be
+    // told which computer the path belongs to, because to it `/home/xfor/…` is
+    // a local path that happens not to exist.
+    const remote = host === undefined ? undefined : editorTargetFor(requireInstance(host))
+    await openInEditor(absolute, line, editorId, remote)
   })
 
   // The native picker is the shell's; what it picks goes through the same
   // service an agent's file path goes through, so both produce the same row and
   // the same token. Not a dispatcher method, because it opens a window.
-  handleShell(IPC_CHANNELS.attachmentsPick, async () => {
+  handleShell(IPC_CHANNELS.attachmentsPick, async (input) => {
+    const { host } = parse(pickAttachmentInputSchema, input)
     const window = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
     const options: Electron.OpenDialogOptions = {
       title: 'Attach an image',
@@ -132,7 +145,26 @@ export function registerIpcHandlers(): void {
       ? await dialog.showOpenDialog(window, options)
       : await dialog.showOpenDialog(options)
     const path = result.canceled ? null : (result.filePaths[0] ?? null)
-    return path === null ? null : await attachmentsService.ingest({ path })
+    if (path === null) return null
+    if (host === undefined) return await attachmentsService.ingest({ path })
+
+    // A path is only a name on the machine that holds the file, so what travels
+    // is bytes - the same shape a pasted screenshot has had since M1, and the
+    // reason `AttachmentIngestParams` takes either. The size is checked from
+    // the stat rather than after reading, exactly as the store does, so a wrong
+    // file is refused without being pulled into memory on its way to a wire.
+    const { size } = statSync(path)
+    if (size > MAX_ATTACHMENT_BYTES) {
+      throw new AppError(
+        'INVALID_INPUT',
+        `That file is ${Math.round(size / 1024 / 1024)} MB. Attachments are limited to ` +
+          `${MAX_ATTACHMENT_BYTES / 1024 / 1024} MB.`
+      )
+    }
+    return await route(host, 'attachments.ingest', {
+      bytes: readFileSync(path),
+      originalName: basename(path)
+    })
   })
 
   handleShell(IPC_CHANNELS.systemPickDirectory, async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -56,6 +56,7 @@ import {
   type RpcParams,
   type RpcResult
 } from '../shared/rpc.js'
+import { attachmentSrcOnHost } from '../shared/attachments.js'
 import type { Attachment, OpenReviewFileInput } from '../shared/schemas.js'
 
 /**
@@ -142,10 +143,14 @@ const bridge: GitWarrenBridge = {
         return () => ipcRenderer.off(IPC_CHANNELS.navigationDeepLink, handler)
       }
     },
-    pickAttachment: () => invoke<Attachment | null>(IPC_CHANNELS.attachmentsPick),
-    // The token as stored. This window has a custom scheme registered for it -
-    // see `main/attachment-protocol.ts` - so there is nothing to rewrite.
-    attachmentSrc: (url: string) => url,
+    pickAttachment: (host?: string) =>
+      invoke<Attachment | null>(IPC_CHANNELS.attachmentsPick, { host }),
+    // The token as stored, for a local image: this window has a custom scheme
+    // registered for it - see `main/attachment-protocol.ts` - so there is
+    // nothing to rewrite. A remote one gains the host as a query, which is the
+    // same thing a tab does to the same token and is written once, in
+    // `shared/attachments.ts`.
+    attachmentSrc: (url: string, host?: string) => attachmentSrcOnHost(url, host),
     openInEditor: (input: OpenReviewFileInput) =>
       invoke<void>(IPC_CHANNELS.reviewsOpenInEditor, input)
   }

--- a/src/renderer/src/components/markdown.tsx
+++ b/src/renderer/src/components/markdown.tsx
@@ -43,7 +43,7 @@
 import ReactMarkdown, { defaultUrlTransform, type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { ATTACHMENT_URL_PREFIX } from '@shared/attachments'
-import { api } from '@/lib/api'
+import { useApi } from '@/lib/host-scope'
 import { cn } from '@/lib/utils'
 
 /**
@@ -190,17 +190,7 @@ const components: Components = {
       )
     }
     return (
-      <img
-        // The one place a stored token becomes something fetchable, and the
-        // only place that differs between the two shells: the window has a
-        // custom scheme registered and passes it through, a tab rewrites it to
-        // a path on its own origin. See `ShellApi.attachmentSrc`.
-        src={api.attachments.src(url)}
-        alt={alt ?? ''}
-        title={title}
-        className={cn('my-2 max-w-full rounded-md border border-border', className)}
-        {...props}
-      />
+      <AttachmentImage url={url} alt={alt} title={title} className={className} {...props} />
     )
   },
 
@@ -223,6 +213,41 @@ const components: Components = {
   ),
   td: ({ node: _node, className, ...props }) => (
     <td className={cn('border border-border px-2 py-1 align-top', className)} {...props} />
+  )
+}
+
+/**
+ * One attachment, drawn from the store that holds it.
+ *
+ * A component of its own rather than an expression inside the `img` override,
+ * because it needs `useApi()` and that is a hook. The hook is the point: the
+ * api it hands back is bound to the machine this screen is about, so the `src`
+ * is asked for on behalf of the right store without the body, the comment card
+ * or anything between them learning that hosts exist. Before M4.4 this read the
+ * module-scope `api`, which is always this install - which is precisely why an
+ * image on a remote review rendered as a broken one.
+ */
+function AttachmentImage({
+  url,
+  className,
+  ...props
+}: { url: string; className?: string } & Omit<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  'src' | 'className'
+>) {
+  const api = useApi()
+  return (
+    <img
+      // The one place a stored token becomes something fetchable, and the only
+      // place that differs between the two shells: the window has a custom
+      // scheme registered and passes it through, a tab rewrites it to a path on
+      // its own origin. Both attach the host the same way. See
+      // `ShellApi.attachmentSrc`.
+      src={api.attachments.src(url)}
+      className={cn('my-2 max-w-full rounded-md border border-border', className)}
+      {...props}
+      alt={props.alt ?? ''}
+    />
   )
 }
 

--- a/src/renderer/src/features/agent/agent-access-page.tsx
+++ b/src/renderer/src/features/agent/agent-access-page.tsx
@@ -33,6 +33,23 @@
  * same `core/mcp-launcher.ts` in both, and the clipboard is the web one either
  * way. The only thing that differs is what the install has to say for itself,
  * which arrives as `mcp.note`.
+ *
+ * ## One of these per machine
+ *
+ * `#/h/<id>/agent` is this page about a host, and what changes is where the
+ * launcher path comes from: `app.mcp` over the carrier rather than the shell's
+ * own `app-info`, because `~/.gitwarren/bin/gitwarren-mcp` has to be resolved by
+ * the machine whose `~` it is. The prompt and the snippets are then built from
+ * that command by the same `@shared/agent-setup` the host's own `gitwarren
+ * agent-setup` prints - so a person who runs the command on the host and a
+ * person who reads this page on their Mac are looking at the same sentence.
+ *
+ * The words around it change, and that is the load-bearing part. This page is
+ * an instruction, and the one way it can be harmful is by being confidently
+ * about the wrong computer - so a host's copy says "an agent running on that
+ * machine", and anything this install knows only about *itself* (its database,
+ * its version, its link port) is left out rather than repeated under another
+ * machine's heading.
  */
 import { useRef, useState, type RefObject } from 'react'
 import useSWR from 'swr'
@@ -43,7 +60,8 @@ import { Tooltip } from '@/components/ui/tooltip'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsList, TabsPanel, TabsTab } from '@/components/ui/tabs'
-import { api, CACHE_KEYS } from '@/lib/api'
+import { CACHE_KEYS } from '@/lib/api'
+import { useApi, useHost, useHostScope } from '@/lib/host-scope'
 import { navigate } from '@/lib/router'
 import { LINK_SERVER_PORT } from '@shared/link-port'
 import {
@@ -52,6 +70,7 @@ import {
   type AgentConfigSnippet
 } from '@shared/agent-setup'
 import { cn } from '@/lib/utils'
+import type { AppInfo, McpLaunchInfo } from '@shared/api'
 
 /**
  * A copy button that says it worked, and says so when it did not.
@@ -198,12 +217,52 @@ function Warning({ children }: { children: React.ReactNode }) {
   )
 }
 
+/**
+ * The one install this page is about, and what it can say for itself.
+ *
+ * Two reads rather than one, because the two questions are genuinely different.
+ * For this machine, `system.appInfo` is the shell's own answer and carries
+ * `linkPort` along with it. For a host, `app.mcp` goes over the carrier and
+ * comes back with the launcher path *as that machine resolves it* - the whole
+ * reason this is not just a string built here, since a Mac has no idea what `~`
+ * is on `pc-wsl`.
+ *
+ * `linkPort` is deliberately absent for a host. The warning it drives is about
+ * whether a `gitwarren://` link an agent hands *you* will open, which is a fact
+ * about the computer you are sitting at; a link written on the host is a local
+ * link over there, and M6 is where that grows a host segment. Saying nothing is
+ * more honest than repeating this machine's answer under another machine's
+ * heading.
+ */
+function useMcpFor(host: string | undefined): {
+  mcp: McpLaunchInfo | undefined
+  linkPort: number | null | undefined
+  /** Everything only this install can say about itself. Undefined for a host. */
+  local: AppInfo | undefined
+  isLoading: boolean
+} {
+  const api = useApi()
+  const here = useSWR(host === undefined ? CACHE_KEYS.appInfo : null, () => api.system.appInfo())
+  const there = useSWR(host === undefined ? null : CACHE_KEYS.agentMcp(host), () => api.app.mcp())
+
+  return host === undefined
+    ? {
+        mcp: here.data?.mcp,
+        linkPort: here.data?.linkPort,
+        local: here.data,
+        isLoading: here.isLoading
+      }
+    : { mcp: there.data, linkPort: undefined, local: undefined, isLoading: there.isLoading }
+}
+
 export function AgentAccessPage() {
-  const { data: info, isLoading } = useSWR(CACHE_KEYS.appInfo, () => api.system.appInfo())
+  const host = useHost()
+  const hostScope = useHostScope()
+  const { mcp, linkPort, local, isLoading } = useMcpFor(host)
   const [manual, setManual] = useState(false)
   const promptRef = useRef<HTMLParagraphElement>(null)
 
-  if (isLoading || !info) {
+  if (isLoading || !mcp) {
     return (
       <div className="flex flex-col gap-5" aria-busy="true" aria-label="Loading agent access">
         <Skeleton className="h-6 w-48" />
@@ -212,12 +271,12 @@ export function AgentAccessPage() {
     )
   }
 
-  const prompt = agentSetupPrompt(info.mcp)
-  const snippets = agentConfigSnippets(info.mcp)
+  const prompt = agentSetupPrompt(mcp)
+  const snippets = agentConfigSnippets(mcp)
   // Only worth showing when it is not the launcher again. In the app it is
   // Electron-run-as-node plus a script inside the install; in a daemon there is
   // nothing behind the launcher and repeating it would read as a second option.
-  const direct = info.mcp.direct.command === info.mcp.command ? null : info.mcp.direct
+  const direct = mcp.direct.command === mcp.command ? null : mcp.direct
 
   return (
     <div className="flex flex-col gap-5">
@@ -226,7 +285,9 @@ export function AgentAccessPage() {
           variant="ghost"
           size="sm"
           className="-ml-2 mb-2 text-muted-foreground"
-          onClick={() => navigate({ name: 'repositories' })}
+          // Carries the host, or walks the reader off the machine they are
+          // reading about - the rule every host-scoped screen follows.
+          onClick={() => navigate({ name: 'repositories', ...hostScope })}
         >
           <ArrowLeft />
           Repositories
@@ -237,14 +298,24 @@ export function AgentAccessPage() {
           <h1 className="text-xl font-semibold tracking-tight">Agent access</h1>
         </div>
         <p className="mt-1 text-sm text-muted-foreground">
-          Give an AI agent one sentence and it will configure itself to read and write these
-          reviews over MCP.
+          {host === undefined
+            ? 'Give an AI agent one sentence and it will configure itself to read and write these reviews over MCP.'
+            : // Named as a place the agent already is, because that is the thing
+              // to get right: this command is for a session running on that
+              // machine, and pasting it into an agent here would configure a
+              // server that does not exist. Which machine "there" is, the host
+              // banner above every screen already says.
+              'Paste this into an agent running on that machine, and it will configure itself to read and write its reviews over MCP.'}
         </p>
       </div>
 
       {/* The lead. Everything else on the page is a footnote to it. */}
       <Card className="p-4">
-        <p className="text-sm font-medium">Paste this into whichever agent you use</p>
+        <p className="text-sm font-medium">
+          {host === undefined
+            ? 'Paste this into whichever agent you use'
+            : 'Paste this into an agent on that machine'}
+        </p>
         <p className="mt-0.5 text-xs text-muted-foreground">
           Claude Code, Codex, Cursor, Gemini CLI — anything that speaks MCP. It will work out
           where its own configuration goes.
@@ -263,24 +334,30 @@ export function AgentAccessPage() {
         </CopyButton>
       </Card>
 
-      {(info.mcp.note || !info.mcp.available || info.linkPort === null) && (
+      {(mcp.note || !mcp.available || linkPort === null) && (
         <div className="flex flex-col gap-2">
           {/* The install's own words first. Each shell knows a different reason
               the launcher might not be there and a different way to fix it -
               `npm run build` in a checkout, `gitwarren service install` on a
-              machine with no app - and neither of them is this page's to guess. */}
-          {info.mcp.note ? (
-            <Warning>{info.mcp.note}</Warning>
+              machine with no app - and neither of them is this page's to guess.
+              A host's note comes from the host, which is the point: it is that
+              machine describing its own missing launcher. */}
+          {mcp.note ? (
+            <Warning>{mcp.note}</Warning>
           ) : (
-            !info.mcp.available && (
+            !mcp.available && (
               <Warning>
-                The MCP server is not on this machine yet, so the command above does not exist
-                until it is. The prompt itself will not change.
+                {host === undefined
+                  ? 'The MCP server is not on this machine yet, so the command above does not exist until it is. The prompt itself will not change.'
+                  : 'The MCP server is not on that machine yet, so the command above does not exist until it is. Installing the daemon from the Hosts screen writes it.'}
               </Warning>
             )
           )}
 
-          {info.linkPort === null && (
+          {/* Only ever asked about this machine - `linkPort` is undefined for a
+              host, so this is skipped rather than answered wrongly. See
+              `useMcpFor`. */}
+          {linkPort === null && (
             <Warning>
               Another program is using port {LINK_SERVER_PORT}, so links an agent hands you will
               not open GitWarren until it lets go. Everything else works, and the links themselves
@@ -358,22 +435,32 @@ export function AgentAccessPage() {
                 `/Users/somebody/.gitwar` + `ren/bin/gitwarren-mcp`, which is
                 a thing a reader has to reassemble before they can check it. */}
             <dd data-selectable className="break-words font-mono">
-              <Breakable text={info.mcp.command} />
+              <Breakable text={mcp.command} />
             </dd>
           </div>
-          <div className="flex gap-2">
-            <dt className="w-24 shrink-0 text-muted-foreground">Database</dt>
-            <dd data-selectable className="break-words font-mono">
-              <Breakable text={info.databasePath} />
-            </dd>
-          </div>
-          <div className="flex gap-2">
-            <dt className="w-24 shrink-0 text-muted-foreground">Version</dt>
-            <dd className="font-mono">
-              {info.version}
-              {!info.packaged && ' (dev)'}
-            </dd>
-          </div>
+          {/* Where the database is and which version is running are facts about
+              an install, and for a host they are already on the Hosts screen -
+              which is also the only screen that can do anything about either.
+              Left out rather than fetched again here, because the one thing
+              this card must never do is show this machine's answers under
+              another machine's heading. */}
+          {local !== undefined && (
+            <>
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">Database</dt>
+                <dd data-selectable className="break-words font-mono">
+                  <Breakable text={local.databasePath} />
+                </dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="w-24 shrink-0 text-muted-foreground">Version</dt>
+                <dd className="font-mono">
+                  {local.version}
+                  {!local.packaged && ' (dev)'}
+                </dd>
+              </div>
+            </>
+          )}
         </dl>
 
         <p className="mt-4 text-xs text-muted-foreground">

--- a/src/renderer/src/features/comments/comment-composer.tsx
+++ b/src/renderer/src/features/comments/comment-composer.tsx
@@ -24,14 +24,17 @@
  *
  * ## Images, on a review that belongs to another machine
  *
- * Attaching is off on a host, and that is a decision rather than an oversight.
- * An attachment is a file in the store of whoever owns the review, and the
- * comment body names it by a token that only that store can resolve; the
- * *displaying* half of that - `main/attachment-protocol.ts` resolving
- * `(host, id)` - is M4.4. Ingesting now would put a real image on `pc-wsl` and
- * render it here as a broken one, in a comment that cannot be fixed by
- * anything but editing markdown by hand. Refusing is the kinder failure, and
- * the text comment underneath it still works perfectly.
+ * Nothing here knows about that, and that is the design rather than a gap.
+ * `api` comes from `useApi()`, so `attachments.ingest` and `attachments.pick`
+ * are already bound to the machine the screen is about: the bytes of a pasted
+ * screenshot travel to that machine's store, the token comes back naming it,
+ * and the same token resolves when the comment is read because
+ * `main/attachment-protocol.ts` now asks the same host for the bytes.
+ *
+ * It was switched off in M4.3 for the half of that which did not exist yet -
+ * ingesting worked, displaying did not, so an image really did land on `pc-wsl`
+ * and render here as a broken one. M4.4 is that other half, and turning this
+ * back on is deleting a guard rather than adding a path.
  */
 import {
   useCallback,
@@ -60,8 +63,7 @@ import { Markdown } from '@/components/markdown'
 import { Tabs, TabsList, TabsPanel, TabsTab } from '@/components/ui/tabs'
 import { Textarea } from '@/components/ui/textarea'
 import { Tooltip } from '@/components/ui/tooltip'
-import { api } from '@/lib/api'
-import { useHost } from '@/lib/host-scope'
+import { useApi } from '@/lib/host-scope'
 import { errorMessage } from '@/lib/errors'
 import { useKeepAboveKeyboard } from '@/lib/keyboard-inset'
 import { cn } from '@/lib/utils'
@@ -101,7 +103,10 @@ export function CommentComposer({
   onCancel,
   className
 }: CommentComposerProps) {
-  const host = useHost()
+  // The app as reached on the machine this review is on. `useApi()` rather than
+  // the module-scope `api`, which is always this install - the difference being
+  // whether a pasted screenshot lands in the store that can serve it back.
+  const api = useApi()
   const [value, setValue] = useState(initialValue)
   const [tab, setTab] = useState<'write' | 'preview'>('write')
   const [dragging, setDragging] = useState(false)
@@ -248,11 +253,6 @@ export function CommentComposer({
       const images = files.filter((file) => file.type.startsWith('image/'))
       if (images.length === 0) return
 
-      if (host !== undefined) {
-        setError(new Error(REMOTE_IMAGES_UNSUPPORTED))
-        return
-      }
-
       const state = readState()
       if (!state) return
 
@@ -284,7 +284,7 @@ export function CommentComposer({
         setBusy(false)
       }
     },
-    [applyEdit, host, readState]
+    [api, applyEdit, readState]
   )
 
   /**
@@ -336,7 +336,7 @@ export function CommentComposer({
     } finally {
       setBusy(false)
     }
-  }, [applyEdit, readState])
+  }, [api, applyEdit, readState])
 
   const disabled = busy
 
@@ -382,7 +382,7 @@ export function CommentComposer({
             <Toolbar
               disabled={disabled}
               transform={transform}
-              onAttach={host === undefined ? () => void pickFile() : undefined}
+              onAttach={() => void pickFile()}
             />
             <Textarea
               ref={textareaRef}
@@ -542,16 +542,6 @@ function Toolbar({
     </div>
   )
 }
-
-/**
- * Said when someone drops a screenshot onto a review that lives elsewhere.
- *
- * Written as a fact about where the file would have to go rather than as
- * "unsupported", because that is the part a person can do something about:
- * the same picture pasted into a review on this computer works.
- */
-const REMOTE_IMAGES_UNSUPPORTED =
-  'Images cannot be attached to a review on another machine yet. The comment text works as usual.'
 
 /**
  * A default alt text, used only when nothing better is available.

--- a/src/renderer/src/features/reviews/review-files-tab.tsx
+++ b/src/renderer/src/features/reviews/review-files-tab.tsx
@@ -36,11 +36,11 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
-import { api } from '@/lib/api'
+
 import { errorMessage } from '@/lib/errors'
 import { formatStep } from '@/lib/keys'
 import { plural } from '@/lib/format'
-import { useHost } from '@/lib/host-scope'
+import { useApi, useHost } from '@/lib/host-scope'
 import { useNarrow } from '@/lib/narrow'
 import { useStoredFlag, useStoredPreference } from '@/lib/preferences'
 import { revealElement } from '@/lib/reveal'
@@ -62,6 +62,7 @@ import {
   useReviewedFiles
 } from './use-reviews'
 import { fileDiffDigest } from '@shared/diff-digest'
+import { remotelyOpenable } from '@shared/editors'
 import { findAnchorFile, isInlineAnchor, resolveAnchor } from '@shared/comment-anchors'
 import { threadSnippet } from '@shared/comment-snippets'
 import type { DiffChanges, FileDiff as FileDiffData } from '@shared/git'
@@ -340,6 +341,7 @@ function useFilesLayout(): {
 }
 
 export function ReviewFilesTab({ review, focus }: { review: Review; focus?: DiffFocus }) {
+  const api = useApi()
   const host = useHost()
   const [changes, setChanges] = useState<DiffChanges>(DEFAULT_DIFF_CHANGES)
   const [editorId, setEditorId] = useStoredPreference('editor', null)
@@ -350,17 +352,23 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
   const mutations = useCommentMutations()
   const localEditors = useEditors()
   /**
-   * No editors on a review that belongs to another machine, and therefore no
-   * open-in-editor buttons and no editor picker.
+   * The editors on *this* machine that can open a file on *that* one.
    *
-   * `reviews.filePath` answers with a path on the *host*, and `openInEditor` is
-   * this machine's shell - so the two halves that M1 deliberately kept separate
-   * would be joined across a network and hand a Mac editor a path only WSL has.
-   * The honest form of that is an editor list with nothing in it, which every
-   * control below already knows how to render: this is the same shape a browser
-   * tab has had since M3.
+   * Two different questions, and both have to be asked. Detection is local -
+   * these are the applications the person has installed - while whether an
+   * editor can be pointed at another machine at all is a property of the
+   * editor, which is why `remotelyOpenable` lives in `shared/editors.ts` and is
+   * not a second detection pass. A Mac with only Zed on it gets an empty list
+   * and therefore no button, which is the honest answer rather than a button
+   * that opens nothing.
    */
-  const editors = host === undefined ? localEditors : undefined
+  const editors = useMemo(
+    () =>
+      host === undefined || localEditors === undefined
+        ? localEditors
+        : remotelyOpenable(localEditors),
+    [host, localEditors]
+  )
 
   const threadsByFile = useMemo(
     () => anchorByFile(data?.files ?? [], threads),
@@ -445,13 +453,19 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
    *
    * `FileActions` in `diff-view.tsx` decides whether to draw the button from
    * whether it was given a *callback*, not from whether there is an editor
-   * list - so leaving the list empty for a remote host turned off the picker
-   * and left the button, and pressing it asked *this* install for
+   * list - so in M4.3, emptying the list for a remote host turned off the
+   * picker and left the button, and pressing it asked *this* install for
    * `reviews.filePath` of a review id that means something else over there.
-   * Found by pressing it against `pc-wsl`, which is the one failure shape this
+   * Found by pressing it against `pc-wsl`, which is the one failure shape that
    * slice set out to avoid: doing something plausible to the wrong file.
+   *
+   * The callback is bound to the host now rather than withheld - `useApi()`
+   * asks the owning machine for the path, and the main process tells a local
+   * editor which machine that path is on - but the two names stay, because the
+   * rule they encode still holds: when there is no editor that can do it, the
+   * *callback* has to be absent, not merely the list.
    */
-  const openLocally = useCallback(
+  const openOnItsHost = useCallback(
     (path: string, line: number) => {
       setOpenError(null)
       api.reviews
@@ -464,11 +478,24 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
         })
         .catch(setOpenError)
     },
-    [review.id, changes, editorId]
+    [api, review.id, changes, editorId]
   )
 
-  // Undefined on a review that belongs to another machine - see the note above.
-  const openInEditor = host === undefined ? openLocally : undefined
+  /**
+   * Absent when nothing installed here can open a file over *there*, which is
+   * the only thing that draws the button. See the note above.
+   *
+   * Two conditions and not one. An empty list on a *local* review is a machine
+   * with no editor detected at all, and that case has always fallen through to
+   * `shell.openPath` - the platform's own handler for the file, usually the
+   * right application and merely without the line number. Withholding the
+   * callback there would remove a working control from every machine that has
+   * no VS Code on it. A list still loading is not an empty one either.
+   */
+  const openInEditor =
+    host !== undefined && editors !== undefined && editors.editors.length === 0
+      ? undefined
+      : openOnItsHost
 
   const marked = useFocusScroll(focus, !isLoading && data !== undefined)
 

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -134,6 +134,13 @@ function buildApi(host: string | undefined): GitWarrenApi {
     fs: {
       list: (input) => ask('fs.list', input, host)
     },
+    app: {
+      // Not memoised the way `system.appInfo` is. That one is about the install
+      // behind this window and cannot change while it is open; this one is about
+      // whichever machine a route names, and a host whose daemon has just been
+      // installed has a launcher it did not have a minute ago.
+      mcp: () => ask('app.mcp', undefined, host)
+    },
     repositories: {
       list: () => ask('repositories.list', undefined, host),
       get: (input) => ask('repositories.get', input, host),
@@ -156,11 +163,12 @@ function buildApi(host: string | undefined): GitWarrenApi {
       reviewedFiles: (input) => ask('reviews.reviewedFiles', input, host),
       setFileReviewed: (input) => ask('reviews.setFileReviewed', input, host),
       // Where the file is comes from whoever owns the review; opening it is the
-      // shell's job. The two halves are joined in the main process - which is
-      // why this one is still local-only, and why the screens hide it on a
-      // remote review rather than opening the wrong machine's file. M4.4 gives
-      // it `(host, path, line)`.
-      openInEditor: (input) => shell.openInEditor(input)
+      // shell's job, on the machine the person is sitting at. The two halves
+      // are joined in the main process, which since M4.4 is handed the host so
+      // it can ask the right machine for the path and then tell a local editor
+      // that the path is over there. The host travels in the input rather than
+      // binding the shell, because the shell is not the thing that is remote.
+      openInEditor: (input) => shell.openInEditor({ ...input, ...(host === undefined ? {} : { host }) })
     },
     comments: {
       list: (input) => ask('comments.list', input, host),
@@ -172,8 +180,12 @@ function buildApi(host: string | undefined): GitWarrenApi {
     },
     attachments: {
       ingest: (input) => ask('attachments.ingest', input, host),
-      pick: () => shell.pickAttachment(),
-      src: (url) => shell.attachmentSrc(url)
+      // The picker is the shell's and the bytes are the store's, and since
+      // M4.4 those can be two different machines: a file chosen here is
+      // ingested wherever the review lives. That is why this one is bound like
+      // a read rather than left with the rest of the shell.
+      pick: () => shell.pickAttachment(host),
+      src: (url) => shell.attachmentSrc(url, host)
     },
     system: {
       pickDirectory: () => shell.system.pickDirectory(),
@@ -291,6 +303,16 @@ export const CACHE_KEYS = {
    * are memoised in `api` above and happen at most once per window.
    */
   appInfo: 'app-info',
+  /**
+   * How an agent reaches one machine's MCP server.
+   *
+   * Scoped, unlike `appInfo`, and that is the difference between the two: this
+   * is a fact about the machine a route names, and the Agent Access page for
+   * `pc-wsl` must never be handed this Mac's launcher path. It is the whole
+   * failure the page exists to avoid - an instruction that is confidently the
+   * wrong one.
+   */
+  agentMcp: (host?: string) => scoped('agent-mcp', host),
   editors: 'editors',
   /**
    * Whether GitWarren starts with the machine. Not one of the two above: it can

--- a/src/shared/__tests__/editors.test.ts
+++ b/src/shared/__tests__/editors.test.ts
@@ -11,7 +11,14 @@
  */
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { EDITOR_LINKS, editorLink, linkableEditors } from '../editors.js'
+import {
+  EDITOR_LINKS,
+  editorLink,
+  editorTargetFor,
+  linkableEditors,
+  opensRemotely,
+  remotelyOpenable
+} from '../editors.js'
 
 test('the URL forms are the ones spike S4 landed on', () => {
   const path = '/home/xfor/github.com/klarluft/gitwarren-app/README.md'
@@ -50,5 +57,105 @@ test('a shell that can only navigate is offered every editor with a scheme', () 
     offered.length,
     EDITOR_LINKS.length - 1,
     'an editor was added without deciding whether a browser can open it'
+  )
+})
+
+/* -------------------------------------------------------------------------- */
+/* Files on another machine                                                   */
+/* -------------------------------------------------------------------------- */
+
+test('the remote URL form names the machine before the path', () => {
+  const path = '/home/xfor/repos/app/README.md'
+  const remote = 'ssh-remote+xfor@pc-wsl'
+
+  assert.equal(
+    editorLink('vscode')?.remoteUrl?.(remote, path, 5),
+    `vscode://vscode-remote/${remote}${path}:5`
+  )
+  assert.equal(
+    editorLink('cursor')?.remoteUrl?.(remote, path, 5),
+    `cursor://vscode-remote/${remote}${path}:5`
+  )
+})
+
+test('the authority keeps the punctuation an ssh target is made of', () => {
+  // `@` and `+` are legal in a path segment and are what the authority is
+  // spelled with; percent-encoding them produces a machine name no remote
+  // extension recognises, and the failure is a window that opens on nothing.
+  const url = editorLink('vscode')?.remoteUrl?.('ssh-remote+xfor@pc-wsl', '/home/xfor/a.ts', 1)
+
+  assert.ok(url?.includes('ssh-remote+xfor@pc-wsl'), url ?? 'no remote URL at all')
+})
+
+test('a remote path with a space in it is escaped the same way a local one is', () => {
+  const url = editorLink('vscode')?.remoteUrl?.('wsl+Ubuntu', '/home/xfor/My Work/a.ts', 3)
+
+  assert.equal(url, 'vscode://vscode-remote/wsl+Ubuntu/home/xfor/My%20Work/a.ts:3')
+})
+
+test('an editor with no way to reach another machine says so', () => {
+  // Zed, Sublime and the JetBrains IDEs have no remote form here. Offering one
+  // of them for a remote review is how a Mac editor is handed a path only WSL
+  // has, which is the failure M4.3 hid the whole control to avoid.
+  assert.equal(opensRemotely('vscode'), true)
+  assert.equal(opensRemotely('cursor'), true)
+  assert.equal(opensRemotely('windsurf'), true)
+  assert.equal(opensRemotely('zed'), false)
+  assert.equal(opensRemotely('sublime'), false)
+  assert.equal(opensRemotely('jetbrains'), false)
+})
+
+test('GITWARREN_EDITOR is trusted to know what it is doing', () => {
+  // `{host}` exists in the template precisely so that somebody can say what
+  // "over there" means for their own command. Whether it works is theirs to
+  // find out; refusing to offer it would remove the only way to try.
+  assert.equal(opensRemotely('custom'), true)
+})
+
+test('a remote picker offers only what can actually open a remote file', () => {
+  const filtered = remotelyOpenable({
+    editors: [
+      { id: 'zed', label: 'Zed' },
+      { id: 'vscode', label: 'VS Code' }
+    ],
+    defaultId: 'zed'
+  })
+
+  // The default moves too. Leaving it pointing at Zed would produce a picker
+  // whose selected entry is not in it.
+  assert.deepEqual(filtered.editors, [{ id: 'vscode', label: 'VS Code' }])
+  assert.equal(filtered.defaultId, 'vscode')
+})
+
+test('a machine with nothing that can reach a host gets an empty list', () => {
+  const filtered = remotelyOpenable({ editors: [{ id: 'zed', label: 'Zed' }], defaultId: 'zed' })
+
+  // Which is what makes the button disappear rather than open the wrong file.
+  assert.deepEqual(filtered.editors, [])
+  assert.equal(filtered.defaultId, null)
+})
+
+test('a chosen default that can reach a host is kept', () => {
+  const filtered = remotelyOpenable({
+    editors: [
+      { id: 'vscode', label: 'VS Code' },
+      { id: 'cursor', label: 'Cursor' }
+    ],
+    defaultId: 'cursor'
+  })
+
+  assert.equal(filtered.defaultId, 'cursor')
+})
+
+test('the editor target is derived from the ssh target, and overridden when set', () => {
+  assert.equal(
+    editorTargetFor({ kind: 'ssh', target: 'xfor@pc-wsl', editorTarget: null }),
+    'ssh-remote+xfor@pc-wsl'
+  )
+  // NULL means derive; a value means somebody's SSH config and their editor
+  // disagree, and theirs wins. M5 is where the two stop coinciding by default.
+  assert.equal(
+    editorTargetFor({ kind: 'ssh', target: 'xfor@pc-wsl', editorTarget: 'wsl+Ubuntu' }),
+    'wsl+Ubuntu'
   )
 })

--- a/src/shared/__tests__/rpc-wire.test.ts
+++ b/src/shared/__tests__/rpc-wire.test.ts
@@ -1,6 +1,6 @@
 /**
- * Coverage for the encoding that makes pasting a screenshot into a browser tab
- * work at all.
+ * Coverage for the encoding that makes pasting a screenshot work at all - in a
+ * browser tab, and since M4.4 onto a review on another machine.
  *
  * `JSON.stringify` turns an `ArrayBuffer` into `{}` and says nothing about it.
  * The image then reaches the dispatcher as an empty object, fails the format
@@ -11,12 +11,12 @@
  *
  * The decode side is the dispatcher's `toIngestSource`, which has taken base64
  * since M2 for the stdio carrier. Nothing new is being agreed here; this is the
- * browser end learning to speak what the daemon already listened for.
+ * asking ends learning to speak what the daemon already listened for.
  */
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { frame } from '../wire.js'
-import type { RpcRequest } from '../../shared/rpc.js'
+import { frame } from '../rpc-wire.js'
+import type { RpcRequest } from '../rpc.js'
 
 /** What the dispatcher does with what arrives, in one line. */
 function bytesOf(text: string): Buffer {

--- a/src/shared/__tests__/web.test.ts
+++ b/src/shared/__tests__/web.test.ts
@@ -15,7 +15,7 @@
  */
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { attachmentUrl } from '../attachments.js'
+import { attachmentSrcOnHost, attachmentUrl } from '../attachments.js'
 import { attachmentNameFromWebPath, webAttachmentSrc, WEB_PATHS } from '../web.js'
 
 const SHA = 'a'.repeat(64)
@@ -65,4 +65,40 @@ test('a path under the prefix that is not a legitimate name is not a name', () =
 test('a path outside the prefix is not an attachment request at all', () => {
   assert.equal(attachmentNameFromWebPath(`/attachments/${SHA}.png`), null)
   assert.equal(attachmentNameFromWebPath(WEB_PATHS.appInfo), null)
+})
+
+/* -------------------------------------------------------------------------- */
+/* Which machine's store                                                      */
+/* -------------------------------------------------------------------------- */
+
+test('a local image is the same string it was before hosts existed', () => {
+  // The case that must not change. Every comment ever written names its images
+  // this way, and the local `src` is still exactly the token in both shells.
+  assert.equal(attachmentSrcOnHost(attachmentUrl(SHA, 'png'), undefined), attachmentUrl(SHA, 'png'))
+  assert.equal(webAttachmentSrc(attachmentUrl(SHA, 'png')), `${WEB_PATHS.attachments}${SHA}.png`)
+})
+
+test('a remote image names the machine in the query, never in the token', () => {
+  const token = attachmentUrl(SHA, 'png')
+
+  // The pathname is what a server resolves against a filesystem, and it is
+  // untouched - which is why the whitelist is still the whole of the story.
+  assert.equal(attachmentSrcOnHost(token, 'inst-abc'), `${token}?host=inst-abc`)
+  assert.equal(
+    webAttachmentSrc(token, 'inst-abc'),
+    `${WEB_PATHS.attachments}${SHA}.png?host=inst-abc`
+  )
+  assert.equal(attachmentNameFromWebPath(`${WEB_PATHS.attachments}${SHA}.png`), `${SHA}.png`)
+})
+
+test('an instance id is escaped on its way into the query', () => {
+  const withHost = attachmentSrcOnHost(attachmentUrl(SHA, 'png'), 'a&b=c')
+
+  assert.equal(new URL(withHost).searchParams.get('host'), 'a&b=c')
+})
+
+test('a URL that is not one of our tokens gains nothing', () => {
+  // A foreign image URL renders as a link rather than an `<img>`, and appending
+  // a host to it would be writing into somebody else's URL.
+  assert.equal(attachmentSrcOnHost('https://example.com/a.png', 'inst-abc'), 'https://example.com/a.png')
 })

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -311,6 +311,22 @@ export interface GitWarrenApi {
   fs: {
     list(input: ListDirectoryInput): Promise<DirectoryListing>
   }
+  /**
+   * Facts about the install this api is pointed at.
+   *
+   * `system.appInfo` is the shell's answer about the install *behind this
+   * window or tab*, and stays that. This one is about whichever machine the
+   * screen is showing, which is what the Agent Access page needs when it is
+   * showing a host: the command to paste is `~/.gitwarren/bin/gitwarren-mcp`
+   * *over there*, and only that machine knows what `~` is.
+   *
+   * A fact and not a capability, which is the line `shared/web.ts` draws and
+   * the reason this may travel at all: it says where a launcher is, it does not
+   * start one.
+   */
+  app: {
+    mcp(): Promise<McpLaunchInfo>
+  }
   repositories: {
     list(): Promise<RepositoryWithGitState[]>
     get(input: GetRepositoryInput): Promise<RepositoryWithGitState>
@@ -505,8 +521,16 @@ export interface ShellApi {
   system: GitWarrenApi['system']
   updates: GitWarrenApi['updates']
   navigation: GitWarrenApi['navigation']
-  /** A picker, then straight into `attachments.ingest`. */
-  pickAttachment(): Promise<Attachment | null>
+  /**
+   * A picker, then straight into `attachments.ingest`.
+   *
+   * `host` is where the image has to end up - the machine that owns the review
+   * being commented on - and absent means this one. The picker itself is always
+   * this machine's, because the file being attached is a file the person can
+   * see; what travels is the bytes, which is the one shape that works for a
+   * screenshot with no path at all.
+   */
+  pickAttachment(host?: string): Promise<Attachment | null>
   /**
    * The `src` this shell can actually draw an attachment token from.
    *
@@ -516,15 +540,26 @@ export interface ShellApi {
    * the `<img>` and nowhere else: the window passes it through to its custom
    * scheme, and a tab rewrites it to a path on its own origin.
    *
+   * `host` is the instance id of the machine whose store holds the file, and
+   * absent means this one. It is not in the token for the same reason a review
+   * id is not: the body is text on one machine and has no business naming
+   * another. Both shells attach it as a query, and the local case is therefore
+   * the token unchanged - see `ATTACHMENT_HOST_PARAM`.
+   *
    * Synchronous, and it has to be: it is called during render, once per image.
    */
-  attachmentSrc(url: string): string
+  attachmentSrc(url: string, host?: string): string
   /**
    * Ask the owning host where the file is, then open it here.
    *
    * Two halves that must not be merged: *which* file on disk is review
    * knowledge and belongs to whoever owns the review, while launching an
    * application is a capability of the machine the person is sitting at.
+   *
+   * `input.host` says which machine the path is on, and it travels with the
+   * path rather than binding the shell to a host: this shell is the one the
+   * person is sitting at whatever the screen is showing, and what it needs to
+   * know is which filesystem the file it is about to open lives on.
    */
   openInEditor(input: OpenReviewFileInput): Promise<void>
 }

--- a/src/shared/attachments.ts
+++ b/src/shared/attachments.ts
@@ -63,3 +63,37 @@ export function parseAttachmentUrl(url: string): { sha: string; ext: string } | 
   const dot = name.lastIndexOf('.')
   return { sha: name.slice(0, dot), ext: name.slice(dot + 1) }
 }
+
+/**
+ * The query parameter that says which machine's store to read from.
+ *
+ * A body holds `gitwarren://attachment/<name>` whoever wrote it and whoever
+ * reads it - that is the point of the token, and M4.3 kept it true for remote
+ * reviews by simply not rendering their images. The host cannot go in the token
+ * for the same reason a review id cannot: the body is stored text on one
+ * machine, and the machine it is stored on is not something the text should
+ * have an opinion about. A comment copied from one review to another, or read
+ * by an agent over its own local MCP, would carry a stale instance id.
+ *
+ * So the host is attached at the `<img src>` and nowhere else - the one place
+ * that already differs between the two shells, and the one place that knows
+ * which screen the image is being drawn on. A local image is the token
+ * unchanged, byte for byte, which is what makes every comment written before
+ * M4.4 render exactly as it did.
+ *
+ * A query rather than a path segment, so the pathname of a scheme URL is still
+ * `/<sha>.<ext>` and the whitelist above is still the whole of what is
+ * resolved against the filesystem.
+ */
+export const ATTACHMENT_HOST_PARAM = 'host'
+
+/**
+ * The token, addressed to the machine whose store holds it.
+ *
+ * `undefined` gives the token back unchanged, which is the local case and is
+ * therefore the case that must not be touched.
+ */
+export function attachmentSrcOnHost(url: string, host: string | undefined): string {
+  if (host === undefined || attachmentName(url) === null) return url
+  return `${url}?${ATTACHMENT_HOST_PARAM}=${encodeURIComponent(host)}`
+}

--- a/src/shared/editors.ts
+++ b/src/shared/editors.ts
@@ -16,6 +16,16 @@
  * `PATH` lookups and `cliArgs` are Node's business. This file is the half both
  * shells need, and it is the half a browser bundle can import.
  *
+ * ## Files on another machine
+ *
+ * M4.4 adds a second URL per editor, for a file that is not on this computer:
+ * `vscode://vscode-remote/ssh-remote+xfor@pc-wsl/home/xfor/…:42`. It is a
+ * different URL rather than the same one with a prefix, and only three of the
+ * six editors below have one - which is the useful half of putting it here,
+ * because "can this editor even do that" becomes a question the picker can ask
+ * before it offers a button. See spike S4 in docs/across-hosts.md for what was
+ * verified and on which machines.
+ *
  * Plain JS only. No Node, no Electron.
  */
 import type { EditorInfo } from './api.js'
@@ -26,6 +36,41 @@ export interface EditorLink extends EditorInfo {
    * scheme worth using and can only be launched from a command line.
    */
   url?: (path: string, line: number) => string
+  /**
+   * The same, for a file on another machine - `remote` being the authority that
+   * editor's own remote extension knows the machine by, such as
+   * `ssh-remote+xfor@pc-wsl` or `wsl+Ubuntu`. Absent when the editor has no way
+   * to open a file it cannot see, which is most of them.
+   *
+   * A separate function rather than an optional argument to `url`, because the
+   * two produce different URLs rather than the same URL with something extra
+   * on it, and because "this editor cannot do that" has to be a thing a caller
+   * can ask. An editor with no `remoteUrl` is left out of the picker on a remote
+   * review entirely - the M4.3 rule about a control that would do something
+   * plausible to the wrong machine, applied one level down.
+   */
+  remoteUrl?: (remote: string, path: string, line: number) => string
+}
+
+/**
+ * How an editor on this machine names a file on another one.
+ *
+ * The stored `editor_target` wins when there is one, and NULL means derive it -
+ * which is the common case and the reason the column is nullable rather than
+ * filled in at Add time with a guess nobody has checked. It is kept apart from
+ * `target` because the two coincide today and stop coinciding at M5, where the
+ * carrier is `wsl.exe -d Ubuntu` and the editor form is `wsl+Ubuntu`.
+ *
+ * Here rather than in the hosts service because both shells need it and only
+ * one of them can read a database: a browser tab opens the same URLs and works
+ * out the same authority from the host row it already has.
+ */
+export function editorTargetFor(host: {
+  kind: string
+  target: string
+  editorTarget: string | null
+}): string {
+  return host.editorTarget ?? `ssh-remote+${host.target}`
 }
 
 /**
@@ -37,17 +82,23 @@ export const EDITOR_LINKS = [
   {
     id: 'vscode',
     label: 'VS Code',
-    url: (path, line) => `vscode://file${encodeURI(path)}:${line}`
+    url: (path, line) => `vscode://file${encodeURI(path)}:${line}`,
+    remoteUrl: (remote, path, line) =>
+      `vscode://vscode-remote/${encodeURI(remote)}${encodeURI(path)}:${line}`
   },
   {
     id: 'cursor',
     label: 'Cursor',
-    url: (path, line) => `cursor://file${encodeURI(path)}:${line}`
+    url: (path, line) => `cursor://file${encodeURI(path)}:${line}`,
+    remoteUrl: (remote, path, line) =>
+      `cursor://vscode-remote/${encodeURI(remote)}${encodeURI(path)}:${line}`
   },
   {
     id: 'windsurf',
     label: 'Windsurf',
-    url: (path, line) => `windsurf://file${encodeURI(path)}:${line}`
+    url: (path, line) => `windsurf://file${encodeURI(path)}:${line}`,
+    remoteUrl: (remote, path, line) =>
+      `windsurf://vscode-remote/${encodeURI(remote)}${encodeURI(path)}:${line}`
   },
   {
     id: 'zed',
@@ -96,4 +147,41 @@ export function linkableEditors(): EditorInfo[] {
   return (EDITOR_LINKS as readonly EditorLink[])
     .filter((editor) => editor.url !== undefined)
     .map(({ id, label }) => ({ id, label }))
+}
+
+/**
+ * Whether this editor can be pointed at a file on another machine at all.
+ *
+ * `custom` is true and is the one id here that is not in the table. It stands
+ * for whatever `GITWARREN_EDITOR` holds, and the template gained `{host}` in
+ * M4.4 precisely so that somebody with `emacsclient` or a wrapper script can
+ * say what "over there" means for them. Whether it works is theirs to know;
+ * offering it is the only way they can find out.
+ */
+export function opensRemotely(id: string): boolean {
+  if (id === 'custom') return true
+  return EDITOR_LINKS.some((editor) => editor.id === id && 'remoteUrl' in editor)
+}
+
+/**
+ * The subset of an editor list that can open a file on another machine, and
+ * which of them to use when the caller does not name one.
+ *
+ * The filtering is here rather than in either shell because the list being
+ * filtered is *detection* - what this machine has installed, which only the
+ * Electron shell can know - while whether an editor has a remote form is a
+ * property of the editor and the same everywhere. An empty result is the honest
+ * answer for a machine with only Zed on it, and is what makes the button
+ * disappear rather than open the wrong file.
+ */
+export function remotelyOpenable(list: {
+  editors: EditorInfo[]
+  defaultId: string | null
+}): { editors: EditorInfo[]; defaultId: string | null } {
+  const editors = list.editors.filter((editor) => opensRemotely(editor.id))
+  const defaultId =
+    list.defaultId !== null && editors.some((editor) => editor.id === list.defaultId)
+      ? list.defaultId
+      : (editors[0]?.id ?? null)
+  return { editors, defaultId }
 }

--- a/src/shared/rpc-wire.ts
+++ b/src/shared/rpc-wire.ts
@@ -17,10 +17,25 @@
  * alongside an array of byte values and an `ArrayBuffer` - so this is a choice
  * among the encodings that end is known to take, not a new one.
  *
+ * ## Why this is in `shared/` and not next to a carrier
+ *
+ * It was `web/wire.ts` until M4.4, when the second carrier over a byte stream
+ * arrived: `core/rpc/stdio-client.ts` was still writing `JSON.stringify`, so an
+ * image attached to a review on another machine crossed the `ssh` pipe as `{}`
+ * and was refused on the far side for not being an image. That is the same
+ * argument `core/rpc/ndjson.ts` makes about framing, one layer up: two answers
+ * to "how does a request become bytes" is a disagreement nobody can see, and
+ * the failure it produces names the wrong thing. So there is one encoder, and
+ * the WebSocket carrier and the stdio client are both users of it.
+ *
+ * `shared/` is where it can be: one of those two readers is compiled into a
+ * browser bundle and the other runs in Node, and this file has to be importable
+ * by both.
+ *
  * Plain JS and no DOM: `btoa` is the one global it needs, and it is a global in
  * Node too.
  */
-import type { RpcRequest } from '../shared/rpc.js'
+import type { RpcRequest } from './rpc.js'
 
 /**
  * `btoa` wants a string of char codes, and a call stack to build it with.

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -19,11 +19,13 @@
  * and a second opinion about what a valid review is.
  */
 import { AppError, deserializeAppError, type SerializedAppError } from './errors.js'
+import type { McpLaunchInfo } from './api.js'
 import type { FileContent, FileImage, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
 import type {
   AddHostInput,
   AddRepositoryInput,
   Attachment,
+  AttachmentBytes,
   GetHostInput,
   HostWithState,
   InstallOnHostInput,
@@ -44,6 +46,7 @@ import type {
   RemoveCommentInput,
   RemoveRepositoryInput,
   RemoveReviewInput,
+  ReadAttachmentInput,
   ReplyToThreadInput,
   Repository,
   RepositoryRefsInput,
@@ -185,6 +188,22 @@ export interface RpcMethods {
   'app.instance': { params: void; result: HostIdentity }
 
   /**
+   * How an agent starts *this* install's MCP server.
+   *
+   * A fact about the machine, which is the line that decides whether something
+   * may travel at all - see the note on `appInfo` in `shared/web.ts`. It says
+   * where a launcher is; it does not start one, and nothing here opens a window
+   * or reads a clipboard.
+   *
+   * It exists because the Agent Access page is per host: `#/h/<id>/agent` has to
+   * print `~/.gitwarren/bin/gitwarren-mcp` as that machine resolves it, since a
+   * Mac has no way to know what `~` is on `pc-wsl`. `gitwarren agent-setup` on
+   * the host prints the same command from the same function, which is what
+   * `shared/agent-setup.ts` exists to guarantee.
+   */
+  'app.mcp': { params: void; result: McpLaunchInfo }
+
+  /**
    * Managing the list of *other* machines this install knows about.
    *
    * In the map because both shells need them - the Hosts screen exists in a
@@ -272,6 +291,17 @@ export interface RpcMethods {
   'comments.setResolved': { params: SetThreadResolvedInput; result: CommentThread }
 
   'attachments.ingest': { params: AttachmentIngestParams; result: Attachment }
+  /**
+   * The bytes behind a token, from the store that holds them.
+   *
+   * A method rather than a file read because of who has to ask. An image lives
+   * in the store of the machine that owns the review, and both shells serve it
+   * off their own disk - so until M4.4 an image on a remote review was a broken
+   * one, resolved against a store that has never heard of that sha. Making it a
+   * method puts the question through the router, and `(host, name)` is then
+   * answered by the machine the name means something on.
+   */
+  'attachments.read': { params: ReadAttachmentInput; result: AttachmentBytes }
 }
 
 export type RpcMethod = keyof RpcMethods
@@ -340,6 +370,7 @@ export interface AttachmentIngestParams {
  */
 export const READ_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   'app.instance',
+  'app.mcp',
   'hosts.list',
   'hosts.get',
   // `hosts.probe` is deliberately absent. It reads in the sense that it changes
@@ -359,7 +390,12 @@ export const READ_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   'reviews.image',
   'reviews.filePath',
   'reviews.reviewedFiles',
-  'comments.list'
+  'comments.list',
+  // Two `<img>` elements on one screen naming the same token is ordinary - a
+  // screenshot quoted in a reply, the same picture in a description and a
+  // comment - and the answer is a few hundred kilobytes over a pipe. This is
+  // the entry in this list that most earns its place.
+  'attachments.read'
 ])
 
 export function isReadMethod(method: string): boolean {

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -11,6 +11,7 @@
  * UI and the agent surface from drifting apart.
  */
 import { z } from 'zod'
+import { ATTACHMENT_FILE_NAME } from './attachments.js'
 import { DIGEST_MAX_LENGTH } from './diff-digest.js'
 import type { DiffChanges, DiffLine } from './git.js'
 
@@ -385,7 +386,20 @@ export const reviewImageInputSchema = reviewFileInputSchema.extend({
  */
 export const openReviewFileInputSchema = reviewFileInputSchema.extend({
   line: z.number().int().min(1).optional().default(1),
-  editorId: z.string().max(64).optional()
+  editorId: z.string().max(64).optional(),
+  /**
+   * Which machine the review - and therefore the file - is on. Absent means
+   * this one.
+   *
+   * The one place in this file a host appears in params rather than on the
+   * envelope, and it is not an exception to `RpcRequest.host` but a consequence
+   * of it: this input never goes on a wire. It is a shell channel, answered by
+   * the main process of the machine with the screen on it, which has to do two
+   * different things with the host - ask *that* machine for the path, and then
+   * tell a local editor that the path is over there. `ssh-remote+<target>` is
+   * part of the URL it opens, so the host is part of what is being opened.
+   */
+  host: z.string().max(200).optional()
 })
 
 export const repositoryRefsInputSchema = z.object({ id: repositoryIdSchema })
@@ -680,8 +694,59 @@ export const agentLabelSchema = z
   .min(1, 'A label cannot be empty.')
   .max(MAX_AGENT_LABEL_LENGTH, 'That label is too long.')
 
+/**
+ * Which image to read out of the store, by the name a body already names it by.
+ *
+ * A name rather than a sha and an extension, because that is what the callers
+ * have: both shells are serving a URL whose last segment is `<sha>.<ext>`, and
+ * splitting it only to join it again is where a dot goes missing. The pattern
+ * is the security boundary and is checked here as well as by whoever is doing
+ * the serving - see `ATTACHMENT_FILE_NAME`, and note that this is a method a
+ * comment body written by an agent can reach through a rendered image.
+ */
+export const readAttachmentInputSchema = z.object({
+  name: z.string().regex(ATTACHMENT_FILE_NAME, 'That is not an attachment name.')
+})
+
+/**
+ * An image, small enough to have crossed a wire.
+ *
+ * base64 rather than bytes, because this answer is `JSON.stringify`d onto an
+ * ndjson frame by whoever serves it - the same encoding `attachments.ingest`
+ * takes on the way in, going the other way. It is a third larger than the file,
+ * and that is the price of the store being on a different computer: the ingest
+ * limit is what bounds it, and the browser cache is what stops it being paid
+ * twice, since the name is the hash of the bytes and can therefore be cached
+ * for ever.
+ *
+ * `mimeType` is the store's own conclusion from sniffing the bytes at ingest,
+ * never a claim made by a filename - see `core/services/attachments.ts`.
+ */
+export const attachmentBytesSchema = z.object({
+  name: z.string(),
+  mimeType: z.string(),
+  byteSize: z.number().int(),
+  /** The file itself, base64-encoded. */
+  base64: z.string()
+})
+
 export type AnchorSnapshot = z.infer<typeof anchorSnapshotSchema>
 export type Attachment = z.infer<typeof attachmentSchema>
+/**
+ * Which machine a picked image is being attached to. Absent means this one.
+ *
+ * A shell channel rather than a method, for the same reason the picker itself
+ * is: it opens a window. What crosses the wire afterwards is `attachments.ingest`
+ * with bytes on it, because a path picked here is a name only this machine
+ * knows - see the note on `pickAttachment` in `shared/api.ts`.
+ */
+export const pickAttachmentInputSchema = z.object({
+  host: z.string().max(200).optional()
+})
+
+export type ReadAttachmentInput = z.input<typeof readAttachmentInputSchema>
+export type AttachmentBytes = z.infer<typeof attachmentBytesSchema>
+export type PickAttachmentInput = z.input<typeof pickAttachmentInputSchema>
 export type CommentAttachment = z.infer<typeof commentAttachmentSchema>
 export type CommentAuthorData = z.infer<typeof commentAuthorSchema>
 export type Comment = z.infer<typeof commentSchema>

--- a/src/shared/web.ts
+++ b/src/shared/web.ts
@@ -20,7 +20,7 @@
  * `WEB_PATHS.appInfo` below.
  */
 
-import { ATTACHMENT_FILE_NAME, attachmentName } from './attachments.js'
+import { ATTACHMENT_FILE_NAME, ATTACHMENT_HOST_PARAM, attachmentName } from './attachments.js'
 
 /** Everything the browser shell talks to, under one reserved prefix. */
 export const WEB_PREFIX = '/gitwarren'
@@ -76,10 +76,18 @@ export const WEB_PATHS = {
  * Anything that is not one of our tokens comes back unchanged, so the caller's
  * own decision about what to do with a foreign URL - render it as a link, per
  * `components/markdown.tsx` - is still the caller's to make.
+ *
+ * Since M4.4 it also carries which machine's store to read from, because a tab
+ * can be looking at a review on another computer. Absent means this one.
  */
-export function webAttachmentSrc(url: string): string {
+export function webAttachmentSrc(url: string, host?: string): string {
   const name = attachmentName(url)
-  return name === null ? url : `${WEB_PATHS.attachments}${name}`
+  if (name === null) return url
+  const path = `${WEB_PATHS.attachments}${name}`
+  // The host goes on as a query, exactly as it does on the custom scheme, so
+  // that one rule in `shared/attachments.ts` describes both shells. See
+  // `ATTACHMENT_HOST_PARAM` for why it is not in the token itself.
+  return host === undefined ? path : `${path}?${ATTACHMENT_HOST_PARAM}=${encodeURIComponent(host)}`
 }
 
 /**

--- a/src/web/carrier.ts
+++ b/src/web/carrier.ts
@@ -27,8 +27,9 @@
  * here: two components asking the same question in the same tick is one frame
  * on the wire instead of two.
  *
- * A request is turned into text by `wire.ts` rather than by `JSON.stringify`,
- * because one of them holds an image. See the note there.
+ * A request is turned into text by `shared/rpc-wire.ts` rather than by
+ * `JSON.stringify`, because one of them holds an image. See the note there -
+ * since M4.4 the stdio client reads the same encoder, for the same reason.
  */
 import { AppError } from '@shared/errors'
 import {
@@ -43,7 +44,7 @@ import {
   type RpcResult
 } from '@shared/rpc'
 import { WEB_PATHS } from '@shared/web'
-import { frame } from './wire'
+import { frame } from '@shared/rpc-wire'
 
 /** Backoff between reconnects: quick at first, then out of the way. */
 const RETRY_MS = [250, 500, 1000, 2000, 5000] as const

--- a/src/web/shell.ts
+++ b/src/web/shell.ts
@@ -34,7 +34,7 @@
  * backstop for a caller that did not look.
  */
 import { AppError } from '@shared/errors'
-import { editorLink, linkableEditors } from '@shared/editors'
+import { editorLink, editorTargetFor, linkableEditors } from '@shared/editors'
 import { WEB_PATHS, webAttachmentSrc } from '@shared/web'
 import type { AppInfo, EditorList, ShellApi, UpdateStatus } from '@shared/api'
 import type { Attachment, OpenReviewFileInput } from '@shared/schemas'
@@ -55,6 +55,31 @@ function unsupported<T>(what: string, instead: string): Promise<T> {
   return Promise.reject(
     new AppError('FORBIDDEN', `${what} is not available in a browser tab. ${instead}`)
   )
+}
+
+/**
+ * The row for one instance id, out of a list this tab has just asked for.
+ *
+ * A list rather than a `hosts.get`, because `hosts.get` takes the local numeric
+ * id and what a route carries is the instance id - the only name that survives
+ * a machine being renamed or readdressed. It is one local SQLite read behind
+ * the socket and happens on a button press, so there is nothing to save by
+ * caching it and something to lose: the target is the field someone edits when
+ * their editor and their SSH config disagree.
+ */
+function requireHostRow(
+  list: { instanceId: string | null; kind: string; target: string; editorTarget: string | null }[],
+  instanceId: string
+): { kind: string; target: string; editorTarget: string | null } {
+  const row = list.find((candidate) => candidate.instanceId === instanceId)
+  if (!row) {
+    throw new AppError(
+      'NOT_FOUND',
+      `This GitWarren does not know a host with id ${instanceId}. ` +
+        'It may have been removed, or the link may have come from somewhere else.'
+    )
+  }
+  return row
 }
 
 async function readAppInfo(): Promise<AppInfo> {
@@ -151,14 +176,18 @@ export function createWebShell(carrier: Carrier): ShellApi {
    *
    * `reviews.filePath` is a read on the dispatcher - it answers *which* file,
    * which is review knowledge - and the navigation is this shell's own. The
-   * path is an absolute path on the machine the daemon is on, which today is
-   * always the machine the browser is on too: the handler binds loopback and
-   * checks `Host`, so there is no way to be looking at this page from
-   * elsewhere. When M6 makes that untrue, this is one of the places that has to
-   * learn the difference, and the editor URL grows a remote authority per S4.
+   * path is an absolute path on the machine that owns the review, which since
+   * M4.3 may not be the machine the daemon is on; `input.host` is which, and
+   * the request carries it so that the *path* comes from there.
+   *
+   * The URL then needs the other half, and it is a different question: the
+   * browser is on the machine the person is sitting at, the loopback handler
+   * having made sure of that, so the editor it hands the URL to is a local one
+   * being told where the file is. That is the remote authority from S4, and it
+   * comes from the host row rather than from the path.
    */
   const openInEditor = async (input: OpenReviewFileInput): Promise<void> => {
-    const { id, path, changes, line, editorId } = input
+    const { id, path, changes, line, editorId, host } = input
     const editor = editorLink(editorId) ?? editorLink(editorChoices().defaultId ?? undefined)
     if (!editor?.url) {
       return unsupported(
@@ -166,8 +195,22 @@ export function createWebShell(carrier: Carrier): ShellApi {
         'No editor with a URL scheme was chosen for this tab.'
       )
     }
+    if (host !== undefined && !editor.remoteUrl) {
+      return unsupported(
+        'Opening a file on another machine',
+        `${editor.label} has no way to open a file it cannot see. VS Code, Cursor and Windsurf do.`
+      )
+    }
 
-    const absolute = await carrier.request('reviews.filePath', { id, path, changes })
+    const absolute = await carrier.request('reviews.filePath', { id, path, changes }, host)
+
+    // A host's own list of hosts is answered by whoever is asked, so this is
+    // this install's row for that machine - which is the right one: it is the
+    // row the person filled in, on the computer their editor is on.
+    const remote =
+      host === undefined
+        ? undefined
+        : editorTargetFor(requireHostRow(await carrier.request('hosts.list', undefined), host))
 
     // `location.href` rather than `window.open`: a scheme the browser hands to
     // the OS does not open a document, so a popup would be an empty tab left
@@ -177,7 +220,12 @@ export function createWebShell(carrier: Carrier): ShellApi {
     // could invent.
     // `line` is optional on the way in and defaulted by the schema on the way
     // through the dispatcher, which this call does not go through.
-    window.location.href = editor.url(absolute, line ?? 1)
+    window.location.href =
+      remote === undefined
+        ? editor.url(absolute, line ?? 1)
+        : // Non-null because the guard above refused an editor without one, and
+          // nothing between here and there can have changed which editor it is.
+          editor.remoteUrl!(remote, absolute, line ?? 1)
   }
 
   /**
@@ -189,13 +237,17 @@ export function createWebShell(carrier: Carrier): ShellApi {
    * tab knows that the Electron picker does not is that it never learns a path,
    * which is fine: a path was never what got stored.
    */
-  const pickAttachment = async (): Promise<Attachment | null> => {
+  const pickAttachment = async (host?: string): Promise<Attachment | null> => {
     const file = await pickImageFile()
     if (file === null) return null
-    return await carrier.request('attachments.ingest', {
-      bytes: await file.arrayBuffer(),
-      originalName: file.name
-    })
+    return await carrier.request(
+      'attachments.ingest',
+      { bytes: await file.arrayBuffer(), originalName: file.name },
+      // The store that has to end up holding it is the one that owns the
+      // review. This tab has bytes and no path, which is exactly the shape that
+      // travels, so nothing else about the call changes.
+      host
+    )
   }
 
   return {


### PR DESCRIPTION
M4 slice four: the three controls M4.3 switched off rather than half-built,
because each would have done something plausible to the wrong machine. Each
turned out to be the same shape — something that meant "this computer"
implicitly, made to say which computer it means.

## What is in it

**Bytes over the carrier.** `attachments.ingest` routed to a host correctly in
M4.3 and still could not work: `core/rpc/stdio-client.ts` wrote
`JSON.stringify`, and that is the one function an `ArrayBuffer` does not
survive. The image arrived as `{}` and was refused for not being a PNG — a
sentence about the *file* for a fault in the *wire*. The web carrier had already
solved this, so the encoder moved rather than being written again:
`shared/rpc-wire.ts` is now read by both carriers over a byte stream. Same
argument `core/rpc/ndjson.ts` makes about framing, one layer up; the two
failures differ only in how loud they are — two framings hang, two encodings
lie.

**Attachments.** `attachments.read` answers with the file, so the store can be
on another machine. `main/attachment-protocol.ts` and `core/web/attachments.ts`
both resolve `(host, name)` through the router's own `isAnsweredLocally`, so
neither can develop a private opinion about what "no host" means. The host rides
on the `<img src>` as a query and never enters the token — a comment body is
stored text on one machine and must not name another — which makes the local
`src` the token byte for byte, and every comment written before this milestone
render exactly as it did. Attaching is back on, and the picker sends bytes
rather than a path, because a path is the one form that cannot travel.

**Editors.** `main/editors.ts` takes a remote authority, and the shape that
forces is the interesting part: every fallback in it ends at *this* machine's
filesystem, so the ones with no remote spelling now fail rather than fall
through. Three editors have an `ssh-remote+<target>` form;
`hosts.editor_target` overrides the derived one; the `GITWARREN_EDITOR` template
gains `{host}`, and an argument that becomes empty is dropped so
`--remote={host}` disappears on a local file. The button and the picker are back
in `review-files-tab.tsx`, drawn from the *callback* the way that file has said
since M4.3.

**Agent access per host.** `app.mcp` reports the launcher path as the host
resolves it, because a Mac cannot know what `~` is on `pc-wsl`. A fact about a
machine rather than a capability of one, which is the line that lets it travel
at all. `gitwarren agent-setup` on the host prints the same sentence from the
same `shared/agent-setup.ts` — checked by running both.

Two files were reading the wrong machine by construction and now use `useApi()`:
the Agent Access page and the markdown renderer's images.

## Spike S4 gained the half it was missing

S4 verified `wsl+Ubuntu` from Windows. The form this slice actually ships — a
Mac opening `ssh-remote+xfor@pc-wsl` — was unverified, and is now checked by
hand and recorded: the URL lands on the line, proved from VS Code's own
per-window memento rather than from looking at a screen. **It does nothing at
all without the Remote-SSH extension, and does it silently**;
`ms-vscode-remote.remote-ssh` was installed on the Mac to run the check.

## Verified against `pc-wsl`, through the shipping code

Every call over `window.gitwarren.carrier` in the real window, so the preload,
the router, the pool and the `ssh` carrier were all in the path. The daemon was
reinstalled from this build first and answered `Unknown method "app.mcp"` before
it — version skew behaving as designed.

A 5,035-byte PNG made in the renderer crossed the pipe and landed in the host's
store with its dimensions read correctly on the far side; `attachments.read`
fetched it back in 11 ms warm while the same name asked of this machine answered
`NOT_FOUND`. The token in a comment body on the host rendered in the window as a
320×200 image, and again after a cold reload, and came back over the loopback
HTTP endpoint as `image/png` behind the session cookie. An unknown host and a
percent-encoded traversal were both refused. `shell.openInEditor` opened line 3
of a file on `pc-wsl` in a window whose authority is `ssh-remote+xfor@pc-wsl`.
`#/h/<instance>/agent` showed the WSL launcher path and no trace of the Mac's.
No console errors, no horizontal scroll at 390 px.

Three things bit, and what they were is in `docs/across-hosts.md` under M4.4.

## Next

M4.5 — the disconnection banner, stale content kept visible, silent refetch on
reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QhSNn1mw5KTCStKPomF5H
