### PR TITLE
M4.5: disconnection

### DIFF
--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -1586,7 +1586,8 @@ them verifiable against the real `pc-wsl` node rather than against a mock:
    listed under their host, clones grouped by root commit across hosts.
    *(done — see below.)*
 4. **Attachments, editors and agent access per host.** *(done — see below.)*
-5. **Disconnection.** The stale banner and the silent refetch.
+5. **Disconnection.** The stale banner and the silent refetch. *(done — see
+   below. M4 is complete.)*
 
 **M4.1, done on the Mac against the WSL node, 10 September.** The novelty is
 one file and an argument vector. Everything else M4 needs had already been
@@ -2199,6 +2200,236 @@ tests and not by the machine. A browser tab was checked at the HTTP endpoint and
 not with a browser open in front of it. And deep links still carry no host, so a
 `gitwarren://` link written on `pc-wsl` opens the Mac's review of that number —
 unchanged from M4.3, and still M6's.
+
+**M4.5, done on the Mac against the WSL node, 11 September.** A machine can now
+go away in the middle of being reviewed. The banner is the visible half and was
+the easy one; what the slice is actually about is the two halves either side of
+it — knowing, and coming back:
+
+    lib/host-reachability.ts    which machines have stopped answering
+    onErrorRetry                something has to go on asking
+    use-reconnect.ts            one read coming back brings the rest with it
+    ShellConnection             the *other* disconnection
+
+**The push nobody built, and why that is the same argument as M4.2's.**
+`core/hosts/pool.ts` has carried an `onStateChange` hook since M4.1 with a
+comment saying this slice would render it. Nothing passes it, and it is still
+nothing. A push from the pool has nowhere to travel: `RpcEvent` in
+`shared/rpc.ts` is reserved for M6 and nothing emits on it, so the state would
+have had to reach a screen down an Electron IPC channel for the window *and*
+down the WebSocket for a tab — two half-built event channels, in a
+request/response protocol, for one banner. That is exactly what M4.2 refused to
+invent for a progress bar, and the refusal is easier here, because in this case
+the signal already exists.
+
+The signal is the reads the screen is making anyway. An open review polls
+`reviews.open` every fifteen seconds; when the machine goes away that read fails
+with `HOST_OFFLINE`, and when it comes back the same read succeeds. Both halves
+of "disconnection" are already arriving, on the one path that also knows whether
+there is anything on screen to mark stale. `lib/api.ts`'s `ask` is where every
+question this window asks of another computer passes with the host still in
+scope, so it is the one place that can notice, and it is four lines.
+
+What the pool knows and this does not is the state of hosts *nobody is looking
+at* — which is precisely the set with no screen to put a banner on. That is
+M6's `host.state` event, where a machine going away is news whether or not
+anything is open on it, and the hook's comment now says so.
+
+Polling `hosts.list` was the other candidate and is worse than either. It is
+cheap — `hostsService.list` reads the pool rather than connecting — but the
+pool's state only *changes* when something connects, so the poll would report
+the past for ever unless some other read were doing the real work. Two
+questions, one answer, and a standing chance of the two disagreeing on one
+screen. Which they did, and see below.
+
+**Two disconnections, two sentences, and neither can see the other's evidence.**
+A host that is asleep and a browser tab whose socket has dropped both end in a
+stale screen, and they are different in all three of the ways that matter, so
+they are two components rather than one with a branch in it.
+
+*Different evidence.* A machine that has gone away is learned from requests that
+fail. A dropped socket fails nothing: `web/carrier.ts` queues whatever is asked
+while it is down, so nothing settles, no error is thrown, and an outcome-based
+signal is blind to it by construction. Only the socket knows —
+`createWebCarrier` has exposed `connected()` and `onConnectionChange()` since
+M3 with nothing subscribing, and `ShellConnection` is what finally does. In the
+Electron window it is a constant `true`, because the other end of that carrier
+is the main process of the same application and cannot go away without taking
+the window with it.
+
+*Different reach.* A sleeping host makes that machine's screens stale; a dropped
+socket makes every screen stale, this computer's included, and while it is down
+nothing can be claimed about any host. So `ConnectionBanner` sits above
+`HostBanner` in `App.tsx` and its sentence wins.
+
+*Different remedy.* A host gets "Try again", because somebody pressing it knows
+something the backoff timer does not — it is `hosts.probe`, the one call that
+ignores backoff, and the reason that method exists. The tab gets no button, and
+that is honest rather than missing: the carrier is already reconnecting on its
+own ladder, and a reload would need the very server that is not answering.
+
+**Stale is content you keep, and that turned out to be six screens rather than
+one.** The rule is one sentence — a disconnection is the only error that says
+nothing *about* the data, because it means the question could not be asked,
+while every other error is an answer that contradicts what is on screen — and
+`isDisconnection` in `lib/errors.ts` is the whole of it. Applying it was the
+work: the review header, the files tab, the commits tab, the repository list,
+the review list and the repository detail each had their own replace-on-error,
+and the conversation tab said it a second time in red under a banner that had
+just said it. A card is now for having *nothing* to show; `repository-list.tsx`
+keeps M4.3's "This host is not answering" for exactly that case, which is what
+arriving cold at a machine that is already asleep looks like.
+
+Nothing is dimmed, nothing is disabled and there is no per-row marker. A diff
+that was readable a second ago is still readable, a reviewer mid-file keeps
+their place, and one strip saying so out loud is the whole of the marking.
+Writes are not blocked either: a comment typed against a machine that has gone
+fails on submit with `ssh`'s own sentence, in the composer, with the text still
+in the box — which is better than a disabled button that loses what somebody was
+in the middle of writing.
+
+**One read is the machine's heartbeat, and the rest come back with it.** A
+review screen holds half a dozen keys, and most of them are `LIVE_READ_OPTIONS`
+reads that deliberately never retry, because a diff is expensive and re-running
+it behind somebody's back is not a favour. So recovery is not each key finding
+its own way back: the one read that *is* retrying announces the machine, and
+`use-reconnect.ts` revalidates everything scoped to it at once, so the screen
+redraws whole rather than in pieces over the following minutes. Revalidating by
+key suffix is what makes that a single line, and it is not a trick — `scoped()`
+in `lib/api.ts` puts the instance id on the end of every key that names
+something a host owns, for the sake of the family-wide `startsWith`
+invalidation at the front; asking from the other end gives "everything about
+that machine".
+
+**Verified end to end against `pc-wsl` through the shipping code**, with the
+cable pulled four different ways. No reinstall was needed and that is worth
+noting: M4.5 adds no method and changes no frame, so the daemon M4.4 left on
+that box answered it unchanged — the first slice of M4 for which version skew
+had nothing to say.
+
+The host added and reachable in 224 ms, its instance id learned, and review 2
+opened at `#/h/<instance>/reviews/2/files` with its diff. Then, with the
+launcher moved aside *and* the running daemon killed — moving it is not enough,
+the pool is holding a pipe into a process that is already up — the strip became
+*pc-wsl stopped answering*, with *GitWarren is not installed on xfor@pc-wsl:
+~/.gitwarren/bin/gitwarren was not found*, *Showing what was loaded at 07:41*,
+and a Try again; the 287 lines of review and diff underneath were the same 287
+lines. Putting the launcher back, the screen came back **on its own after 32
+seconds** — no click, no focus, no navigation.
+
+Mid-request, which is what M4's verify line actually asks for: killing the
+`ssh` the pool was holding while a request was travelling on it failed that
+request in 13 ms with *The connection to xfor@pc-wsl was terminated (SIGKILL)*,
+nothing retried, and the diff stayed. Driven through a real *Refresh* press so
+the request in flight was one the app made, the banner rose and the files tab
+kept its diff; the review poll noticed the machine again **5 seconds** later and
+pulled the diff back with it. Try again, pressed while the machine was still
+away, failed honestly and left the screen alone; pressed a moment after the
+launcher was restored it had the review back in **0.5 seconds**, which is the
+backoff being ignored on purpose.
+
+Arriving cold at a sleeping host is the other shape: `#/h/<instance>/` after a
+reload said *pc-wsl · Unreachable* in the strip and carried M4.3's card in the
+content, once rather than twice. A comment typed while the machine was away kept
+its draft and showed `ssh`'s sentence under the composer — and it was the failed
+*write* that raised the banner, which is the whole design in one gesture.
+
+In a Chrome tab on the loopback view: stopping the app under it produced
+*GitWarren is not answering*, the home screen still on screen behind it, and
+`shell.connection.connected()` false; fifteen seconds later the second sentence
+about a restarted GitWarren appeared. No console errors or warnings in any of
+it, and no horizontal scroll at 390 px.
+
+**Five things bit.**
+
+*The poll stops at the exact moment there is something to notice.* SWR's
+`refreshInterval` looks like it is already the heartbeat and it is not: the poll
+is skipped for as long as the cached error is set — `if (!getCache().error && …)`
+in `use-swr` — and this app has set `shouldRetryOnError: false` globally since
+M1. So the fifteen-second revalidation that would have seen the machine come
+back stopped the first time it failed, and an open review stayed offline until
+somebody focused the window. The banner was perfect and permanent. The fix is an
+`onErrorRetry` that says no to everything except a disconnection and retries
+that at a steady fifteen seconds, only while the document is visible; what it
+costs is bounded a layer down, because a host in backoff refuses in
+microseconds and at most one `ssh` a minute per machine actually happens. Worth
+noticing that the flag's original reasoning was right and is now written out in
+prose rather than expressed by being off: an error is normally an *answer*, and
+a `NOT_FOUND` will not become found by being asked again.
+
+*A healthy start was being offered as a cause of death.* The first failure
+message to reach a screen read *The connection to xfor@pc-wsl was terminated
+(SIGKILL). [gitwarren-serve] ready (instance …, protocol v1, database: …)* —
+because `describeExit` appends the tail of stderr, and stderr is where M4.1 put
+the daemon's start-up banner precisely so it could not hurt the framing on
+stdout. Two kinds of line on one stream, and only one of them is ever an
+explanation: proof that the daemon started is the one thing that cannot be why
+it stopped. The banner's prefix now lives in `shared/rpc.ts` because the two
+ends of the pipe both need it — one to write it, one to leave it out — and every
+other line is still kept, because any of them might be the reason. M4.1 and M4.2
+never saw this: their failures were all *before* a start, where stderr holds
+only what `ssh` said.
+
+*Keeping the content meant finding every screen that throws it away.* The review
+header was the obvious one. The files tab was not, and it is the one that
+mattered — killing the `ssh` under a *Refresh* left the banner correct and the
+diff gone, which is the exact failure the slice exists to prevent, found by
+pressing the button rather than by reading the code. Six screens in the end, and
+the reason it was six is that "could not load" and "is momentarily out of touch"
+had never needed telling apart before there was a network in the middle.
+
+*The badge over the diff disagreed with the diff, in both directions.* Opening a
+review on a host in a freshly started window showed *Not tried yet* over a diff
+that machine had just served, because `hosts.list` was answered before anything
+had connected and nothing re-asked. So `reachabilityOf` now takes what the
+asking side has observed, and that wins over the row. The first attempt at it
+still said *Not tried yet*, which is the more interesting half: the store
+announced a change of state and treated "answered" as no change, so the badge
+was never told. Never heard from is a state, and leaving it is news — one extra
+announcement per machine per window, and the sentence is right.
+
+*It passed the no-horizontal-scroll check and was unreadable anyway.* At 390 px
+the buttons beside the message are `shrink-0` and the text column had `min-w-0`,
+so `ssh`'s sentence came out one word per line down the left of the screen
+inside a box that measured exactly 390 px wide. A floor on the text column makes
+the row wrap and gives the buttons a line of their own. Worth writing down
+because the check that M3.5 established — `scrollWidth === clientWidth` — is
+necessary and says nothing at all about whether anybody can read the result.
+
+**What M4.5 found next door.** A browser tab cannot get itself back after the
+app it was served by is restarted, and this is by design rather than a bug:
+`core/web/token.ts` mints its token per *launch* and gives three reasons for it,
+the first of which is that revoking it should be `quit`. The consequence had
+simply never been looked at from the tab's side — the socket retries for ever
+against a server that answers 401, which is a spinner pretending to be progress.
+Nothing here changes the token, because persisting it would trade away the
+property that module was built for. What changed is that the banner stops
+pretending: after fifteen seconds it says that a restarted GitWarren means an
+expired link and a new one has to be opened from the app. Conditional on
+purpose — a page cannot tell a restart from a blip, both being a socket that
+will not open, and the confident version of that sentence would send somebody to
+re-open an app that is fine.
+
+**Not done in M4.5, and why.** There are still no events: the fifteen-second
+poll is the whole of how this app learns anything, and a machine that goes away
+while nothing is open on it is noticed the next time somebody looks. That is
+M6, and `onStateChange` is the hook it will use. Nothing marks individual rows
+as stale, deliberately — one strip is the whole of the marking, and a screen
+covered in little clocks would be worse at saying the one thing that is true.
+`ConnectionBanner` is only ever seen in a tab, since the window's carrier cannot
+lose its other end; the Electron half is a constant and two lines. And a review
+open on a machine that comes back does not learn what *changed* while it was
+away beyond what a refetch shows — comments an agent wrote in the meantime
+appear, because the whole review is one read, but nothing points at them.
+
+**M4 is complete.** From the Mac, a WSL node is added by SSH target, has
+GitWarren installed onto it over the pipe, and is then a machine whose
+repositories, reviews, diffs, comments, attachments and editor links all work
+from here; the agent inside WSL reads the same reviews over its own local MCP;
+and when the machine goes away the screen says so, keeps what it had, and comes
+back by itself. The gap table below still reads true as written — disconnection
+was always split between M4 and M6, and what M6 owns is the heartbeat, not the
+banner.
 
 ### M5 — WSL from Windows
 

--- a/src/core/hosts/__tests__/ssh.test.ts
+++ b/src/core/hosts/__tests__/ssh.test.ts
@@ -13,8 +13,16 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { connectOverSsh, isLocalOnly, sshArgs, REMOTE_LAUNCHER, SSH_OPTIONS } from '../ssh.js'
+import {
+  connectOverSsh,
+  describeExit,
+  isLocalOnly,
+  sshArgs,
+  REMOTE_LAUNCHER,
+  SSH_OPTIONS
+} from '../ssh.js'
 import { rpcMethodNames } from '../../rpc/dispatcher.js'
+import { DAEMON_READY_PREFIX } from '../../../shared/rpc.js'
 
 test('the command starts the launcher, not a versioned path', () => {
   const args = sshArgs('xfor@pc-wsl')
@@ -55,6 +63,29 @@ test('a host that cannot be resolved says what ssh said, not that a stream ended
   assert.match(reason, /ssh could not connect/i)
   assert.match(reason, /no-such-host/i)
   connection.close()
+})
+
+test('a healthy start is never offered as the reason a connection died', () => {
+  // Found in M4.5 by killing the `ssh` under an open review: the daemon had
+  // started perfectly and said so on stderr, and the banner came back stuck to
+  // the end of the failure - "The connection to xfor@pc-wsl was terminated
+  // (SIGKILL). [gitwarren-serve] ready (instance …, protocol v1, database: …)".
+  // Both halves true; the second one the opposite of an explanation.
+  const banner = `${DAEMON_READY_PREFIX} (instance 4e0b0adb, protocol v1, database: /home/xfor/db)`
+
+  const killed = describeExit('xfor@pc-wsl', null, 'SIGKILL', banner)
+  assert.equal(killed, 'The connection to xfor@pc-wsl was terminated (SIGKILL).')
+
+  // Anything else on that stream might genuinely be why, so it is kept - even
+  // when the banner is sitting above it.
+  const withReason = describeExit(
+    'xfor@pc-wsl',
+    1,
+    null,
+    `${banner}\nsqlite: database is locked`
+  )
+  assert.match(withReason, /sqlite: database is locked/)
+  assert.doesNotMatch(withReason, /ready \(instance/)
 })
 
 test('host management is answered here and never sent to a host', () => {

--- a/src/core/hosts/pool.ts
+++ b/src/core/hosts/pool.ts
@@ -37,6 +37,11 @@
  * kinder than hopeful here: the UI can say "not reachable" now, and M4.5's
  * banner has something to render.
  *
+ * It is also what bounds M4.5's retry. A screen that has gone stale asks again
+ * every fifteen seconds for as long as somebody is looking at it, and four out
+ * of five of those cost a rejected promise and no process. Whatever the UI
+ * asks for, at most one `ssh` a minute per host actually happens.
+ *
  * One deliberate exception: an explicit probe from the Hosts screen ignores the
  * backoff, because a person pressing a button has information the timer does
  * not - they just turned the machine on.
@@ -78,7 +83,23 @@ export interface HostPoolOptions {
   /** Swappable for tests; the default opens a real `ssh`. */
   connect?: (route: HostRoute, onClose: (error: AppError) => void) => SshConnection
   now?: () => number
-  /** Notified whenever a host's reachability changes. M4.5 renders this. */
+  /**
+   * Notified whenever a host's reachability changes. Nothing passes it yet.
+   *
+   * It was written for M4.5's banner and M4.5 did not use it, which is worth
+   * recording rather than deleting. A push from here has nowhere to go: the
+   * event channel in `shared/rpc.ts` is reserved for M6 and nothing emits on
+   * it, so reaching a screen would have meant an Electron IPC channel for the
+   * window *and* a WebSocket message for a tab - two half-built event channels
+   * for one banner, which is the thing M4.2 refused to build for a progress
+   * bar. And it was not needed: a screen already asks this machine questions,
+   * so the answers it gets are the disconnection, and
+   * `renderer/lib/host-reachability.ts` reads them there.
+   *
+   * What this hook can see that a screen cannot is a host nobody is looking at,
+   * which is why it belongs to M6's `host.state` event - where a machine going
+   * away is news whether or not anything is open on it.
+   */
   onStateChange?: (hostId: number, state: HostState) => void
 }
 

--- a/src/core/hosts/ssh.ts
+++ b/src/core/hosts/ssh.ts
@@ -62,6 +62,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import type { Readable } from 'node:stream'
 import { createStdioClient, type StdioClient } from '../rpc/stdio-client.js'
 import { AppError } from '../../shared/errors.js'
+import { DAEMON_READY_PREFIX } from '../../shared/rpc.js'
 import type { RpcMethod, RpcParams, RpcResult } from '../../shared/rpc.js'
 
 /** The launcher M2 promised would stay put. */
@@ -370,14 +371,33 @@ export function isLocalOnly(method: string): boolean {
  * launcher is not there - which before M4.2 is the single most likely outcome
  * of adding a host, and deserves to say what to do about it rather than
  * "exited with code 127".
+ *
+ * Exported for its own test. Everything else about a connection needs a real
+ * `ssh` to say anything about, and this is the one part that is a pure function
+ * of an exit status and a stream - which is also where M4.5 found it quoting
+ * the daemon's start-up banner as if it were a cause of death.
  */
-function describeExit(
+export function describeExit(
   target: string,
   code: number | null,
   signal: NodeJS.Signals | null,
   stderr: string
 ): string {
-  const tail = stderr.trim().split('\n').slice(-3).join(' ').trim()
+  // Two different kinds of line arrive on that stream, and only one of them is
+  // an explanation. A daemon that started announces itself there (M4.1 put the
+  // banner on stderr precisely so it could not hurt the framing on stdout), and
+  // quoting it back at somebody whose connection has just died reads as though
+  // it were the cause: "The connection to xfor@pc-wsl was terminated (SIGKILL).
+  // [gitwarren-serve] ready (instance …)". Proof of a healthy start is the one
+  // thing that cannot be why it stopped. Every other line the daemon or `ssh`
+  // wrote is kept, because any of them might be.
+  const tail = stderr
+    .trim()
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith(DAEMON_READY_PREFIX))
+    .slice(-3)
+    .join(' ')
+    .trim()
   const detail = tail ? ` ${tail}` : ''
 
   if (code === 127) {

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -44,7 +44,7 @@ import { closeDatabase, getDatabase } from '../core/db/client.js'
 import { getInstanceId } from '../core/instance.js'
 import { getDatabasePath } from '../core/paths.js'
 import { serveStdio } from '../core/rpc/stdio.js'
-import { RPC_PROTOCOL_VERSION } from '../shared/rpc.js'
+import { DAEMON_READY_PREFIX, RPC_PROTOCOL_VERSION } from '../shared/rpc.js'
 import { runListen } from './listen.js'
 
 const USAGE = `gitwarren serve --stdio
@@ -85,8 +85,10 @@ export function runDaemon(argv: readonly string[]): boolean {
   // start debugging a missing database.
   getDatabase()
 
+  // The prefix is shared with `core/hosts/ssh.ts`, which has to recognise this
+  // line to keep it out of a failure message. See `DAEMON_READY_PREFIX`.
   console.error(
-    `[gitwarren-serve] ready (instance ${getInstanceId()}, protocol v${RPC_PROTOCOL_VERSION}, ` +
+    `${DAEMON_READY_PREFIX} (instance ${getInstanceId()}, protocol v${RPC_PROTOCOL_VERSION}, ` +
       `database: ${getDatabasePath()})`
   )
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -136,6 +136,21 @@ const bridge: GitWarrenBridge = {
         return () => ipcRenderer.off(IPC_CHANNELS.updatesChanged, handler)
       }
     },
+    /**
+     * Always up, and not as a simplification.
+     *
+     * The other end of this carrier is the main process of the same
+     * application: it cannot go away without taking this window with it, and
+     * `ipcRenderer.invoke` pairs every request with its answer over a channel
+     * with nothing between the two. There is no state here to report and
+     * nothing that could ever change it, so the subscription is a no-op rather
+     * than a listener that would never fire. `web/shell.ts` is where this
+     * question has a real answer.
+     */
+    connection: {
+      connected: () => true,
+      subscribe: () => () => {}
+    },
     navigation: {
       onDeepLink: (listener: (hash: string) => void) => {
         const handler = (_event: Electron.IpcRendererEvent, hash: string): void => listener(hash)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import { useRef } from 'react'
 // sibling file. A data: URI is allowed by that same policy, and at this size
 // costs less than the exception would.
 import logo from './assets/logo.png?inline'
+import { ConnectionBanner } from './components/connection-banner'
 import { ScrollToTop } from './components/scroll-to-top'
 import { Kbd } from './components/ui/kbd'
 import { TooltipProvider } from './components/ui/tooltip'
@@ -29,6 +30,7 @@ import { CommandRegistryProvider } from './features/commands/command-registry'
 import { HostBanner } from './features/hosts/host-banner'
 import { HostsCard } from './features/hosts/hosts-card'
 import { HostsPage } from './features/hosts/hosts-page'
+import { useRefetchOnReconnect } from './features/hosts/use-reconnect'
 import { SettingsPanel } from './features/settings/settings-panel'
 import { RepositoryDetail } from './features/repositories/repository-detail'
 import { RepositoryList } from './features/repositories/repository-list'
@@ -56,6 +58,11 @@ export function App() {
   // The app scrolls inside <main>, not the window, so anything that wants to
   // know or change the scroll position needs a handle on that element.
   const scroller = useRef<HTMLElement>(null)
+  // Here rather than in the banner that shows the disconnection, because
+  // bringing a screen back is not the banner's job and a machine can come back
+  // while nothing about it is on screen. Once, at the top, for the same reason
+  // the host scope is read once: two subscribers would refetch twice.
+  useRefetchOnReconnect()
 
   return (
     // One provider for the whole app: Base UI groups tooltips through it, so
@@ -83,7 +90,13 @@ export function App() {
                 route.name === 'review' ? reviewWidth(route.tab) : 'max-w-3xl'
               )}
             >
-              <div className="mb-6">
+              {/* `gap-3` so the two can be on screen at once; an empty box is
+                  still zero high, so the spacing below is unchanged. */}
+              <div className="mb-6 flex flex-col gap-3">
+                {/* Above the host strip deliberately: a page that cannot reach
+                    its own core has nothing to say about anybody else's
+                    machine. See `connection-banner.tsx`. */}
+                <ConnectionBanner />
                 <UpdateBanner />
               </div>
 

--- a/src/renderer/src/components/connection-banner.tsx
+++ b/src/renderer/src/components/connection-banner.tsx
@@ -1,0 +1,113 @@
+/**
+ * The other disconnection: this page has lost its own core.
+ *
+ * Deliberately not `features/hosts/host-banner.tsx`, and the separation is the
+ * decision rather than a filing choice. A host that is asleep and a browser tab
+ * whose socket has dropped look adjacent - both end with a stale screen - and
+ * they are different in all three of the ways that matter.
+ *
+ * *Different evidence.* A machine that has gone away is learned from requests
+ * that fail, which is all `lib/host-reachability.ts` reads. A dropped socket
+ * fails nothing: `web/carrier.ts` queues whatever is asked while it is down, so
+ * nothing settles, no error is thrown, and the outcome-based signal is blind to
+ * it by construction. Only the socket knows, through `ShellConnection`.
+ *
+ * *Different reach.* A sleeping host makes that machine's screens stale. A
+ * dropped socket makes every screen stale, this computer's included - the tab
+ * is not talking to anything - so while it is down nothing can be claimed about
+ * any host, and this sentence is the one that wins. Hence the order in
+ * `App.tsx`: this above, and the host strip below it saying whatever it last
+ * knew.
+ *
+ * *Different remedy.* A host has "Try again", because a person pressing it
+ * knows something the backoff timer does not. There is no button here, and that
+ * is honest rather than an omission: the carrier is already reconnecting on its
+ * own timer, a reload would need the very server that is not answering, and the
+ * one thing a person can usefully do - start GitWarren again on that machine -
+ * is not something a page in a browser can offer to do for them.
+ *
+ * In the Electron window this renders nothing, ever. The window's carrier
+ * reaches the main process of its own application, which cannot go away without
+ * taking the window with it, so `connected()` is a constant `true` there and
+ * the subscription is a no-op. One component, two shells, no branch on which.
+ */
+import { useEffect, useState, useSyncExternalStore } from 'react'
+import { Unplug } from 'lucide-react'
+import { api } from '@/lib/api'
+
+/**
+ * How long to let the carrier try before saying what a person can do.
+ *
+ * An ordinary blip - a sleeping laptop, a wifi handover - is back inside the
+ * carrier's own ladder, which tops out at five seconds. Still down after this
+ * long and the likely explanation is the other one, and it is the one a page
+ * cannot fix for itself: `core/web/token.ts` mints its token per *launch* and
+ * says why, so a GitWarren that has been restarted will refuse this tab's
+ * session for ever, however patiently it reconnects. Verified in M4.5 by
+ * stopping the app under an open tab - the socket retried against a 401 with
+ * no end in sight, which is a spinner pretending to be progress.
+ *
+ * The sentence is deliberately conditional. This page cannot tell a restart
+ * from a blip - both are a socket that will not open - and guessing wrong in
+ * the confident direction would send somebody to re-open an app that is fine.
+ */
+const LIKELY_GONE_MS = 15_000
+
+// Module scope on purpose, and it is the exception the M4.4 lesson allows: the
+// two files that were caught importing the module-scope `api` were asking about
+// a *machine*, where `useApi()` is the only correct reader. This asks about the
+// shell the person is using, which no route can change.
+const subscribe = (onChange: () => void): (() => void) =>
+  api.connection.subscribe(() => onChange())
+
+export function ConnectionBanner() {
+  const connected = useSyncExternalStore(
+    subscribe,
+    () => api.connection.connected(),
+    // Nothing renders this on a server, but `getServerSnapshot` is also what
+    // React uses for hydration, and "connected" is the state that shows nothing.
+    () => true
+  )
+
+  if (connected) return null
+  return <Lost />
+}
+
+/**
+ * Mounted only while the socket is down, and that is what resets the clock.
+ *
+ * The alternative - one component holding a timer and clearing it when the
+ * connection comes back - has to remember to undo its own state on the way out,
+ * which is a thing to forget. A component that only exists while the condition
+ * does starts fresh every time by construction.
+ */
+function Lost() {
+  const [awhile, setAwhile] = useState(false)
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setAwhile(true), LIKELY_GONE_MS)
+    return () => window.clearTimeout(timer)
+  }, [])
+
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-3 rounded-lg border border-warning/40 bg-warning/10 px-4 py-2.5 text-sm"
+    >
+      <Unplug className="mt-0.5 size-4 shrink-0 text-warning" />
+      <div className="min-w-0 flex-1">
+        <p className="font-medium">GitWarren is not answering</p>
+        <p className="text-muted-foreground">
+          This page lost its connection and is trying to reconnect. What is on screen is what was
+          loaded before, and nothing has been sent.
+        </p>
+        {awhile && (
+          <p className="mt-1 text-muted-foreground">
+            If GitWarren has been restarted since this page was opened, its link has expired and
+            this page cannot get itself back. Open GitWarren again for a new one.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/features/hosts/host-banner.tsx
+++ b/src/renderer/src/features/hosts/host-banner.tsx
@@ -1,7 +1,8 @@
 /**
- * "You are looking at another machine", and the way back.
+ * "You are looking at another machine", and the way back - and since M4.5, "and
+ * it has stopped answering".
  *
- * The one piece of chrome M4.3 adds, and it is deliberately a strip above every
+ * The one piece of chrome M4.3 added, and it is deliberately a strip above every
  * screen rather than a badge on each of them. Once a repository list, a review
  * and a diff can all belong to a different computer, *which* computer is the
  * thing a person has to be able to check without thinking - and a component
@@ -19,6 +20,25 @@
  * written has no label to show, and saying so here is better than a screen full
  * of `NOT_FOUND` with no explanation of which machine failed to be found.
  *
+ * ## The disconnection lives here because it is the same sentence
+ *
+ * M4.5 needed to say "this machine stopped answering" on an open review, and
+ * the first sketch was a banner of its own on the review screen. It would have
+ * been wrong twice. Once for the reason above - a diff, a repository list and a
+ * conversation tab all go stale together, and three copies of one notice is two
+ * chances to forget it. And once because it would have sat next to *this*
+ * strip, which is already naming the machine and already showing a badge about
+ * whether it is reachable: two components, one about a host, in the same two
+ * centimetres of screen, free to disagree.
+ *
+ * So the strip has two states rather than a neighbour. What it says comes from
+ * `lib/host-reachability.ts` - the requests this window is actually making -
+ * and not from the `hosts.list` row underneath it, which is a read like any
+ * other and is exactly as old as the last time something refreshed it. The
+ * badge is dropped while the strip is saying the machine is away, because
+ * "Reachable" underneath "pc-wsl stopped answering" is the disagreement in one
+ * line.
+ *
  * ## Not loaded yet is not the same as not known
  *
  * The host list is a read like any other, and for the first frames of a cold
@@ -30,13 +50,22 @@
  * alarming answer. So the sentence is only reached once the list has actually
  * arrived, and until then the banner says what it does know - that this is
  * somewhere else - and shows the id.
+ *
+ * The same mistake has a third face here, and it is the one M4.5 could have
+ * made: a request in flight is not a disconnection. Nothing on this strip reads
+ * `isRefreshing`, and the store it does read only ever moves on an outcome.
  */
-import { Server } from 'lucide-react'
+import { useCallback, useState, useSyncExternalStore } from 'react'
+import { useSWRConfig } from 'swr'
+import { PlugZap, RefreshCw, Server } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { timeOfDay } from '@/lib/format'
 import { useHost } from '@/lib/host-scope'
+import { hostReachability, subscribeToHostChanges } from '@/lib/host-reachability'
 import { navigate } from '@/lib/router'
-import { useHosts } from './use-hosts'
-import { ReachabilityBadge } from './host-status'
+import { useHosts, useHostMutations } from './use-hosts'
+import { ReachabilityBadge, type Reachability } from './host-status'
+import type { HostWithState } from '@shared/schemas'
 
 export function HostBanner() {
   const host = useHost()
@@ -44,12 +73,72 @@ export function HostBanner() {
   // SQLite read that the home screen has already made and SWR has already
   // cached. The early return is below.
   const { hosts } = useHosts()
-
-  if (host === undefined) return null
+  // Subscribed to rather than polled: the store announces a change of state and
+  // nothing else, so this redraws when the machine goes and when it comes back
+  // and not once per request. See `lib/host-reachability.ts`.
+  const reachability = useSyncExternalStore(subscribeToHostChanges, () => hostReachability(host))
+  const { probeHost } = useHostMutations()
+  const { mutate } = useSWRConfig()
+  const [retrying, setRetrying] = useState(false)
 
   // Undefined while the list is still on its way; null once it has arrived and
   // this host is genuinely not in it. See the note above.
-  const row = hosts === undefined ? undefined : (hosts.find((c) => c.instanceId === host) ?? null)
+  const row =
+    host === undefined || hosts === undefined
+      ? undefined
+      : (hosts.find((candidate) => candidate.instanceId === host) ?? null)
+
+  /**
+   * Try now, and then look again.
+   *
+   * A plain revalidation would be refused before it reached the network: the
+   * pool is holding a backoff timer, and while it runs every request fails fast
+   * rather than hopefully. `hosts.probe` is the one call that ignores it, and
+   * it exists for precisely this - somebody pressing a button knows something
+   * the timer does not, usually that they have just woken the machine.
+   *
+   * Then every key scoped to that machine, because a screen is half a dozen of
+   * them and the person pressed one button. The suffix is `scoped()` in
+   * `lib/api.ts` read from the other end; see `use-reconnect.ts`, which does
+   * the same thing without being asked.
+   */
+  const retry = useCallback(async (): Promise<void> => {
+    if (!row) return
+    setRetrying(true)
+    try {
+      await probeHost(row.id)
+      await mutate((key) => typeof key === 'string' && key.endsWith(`@${host}`))
+    } finally {
+      setRetrying(false)
+    }
+  }, [host, mutate, probeHost, row])
+
+  if (host === undefined) return null
+
+  const observed: Reachability | undefined =
+    reachability.offlineSince !== null ? 'down' : reachability.lastSeenAt !== null ? 'up' : undefined
+
+  // The loud form is for content that has gone stale, which means there has to
+  // be content. Arriving cold at a machine that is already asleep loads
+  // nothing, and "stopped answering" is then the wrong tense - it never
+  // started. That case belongs to the screen, which has the room to say what
+  // happened and the same Try again: `repository-list.tsx` has had exactly that
+  // card since M4.3. Two notices one above the other, in the same words, is the
+  // duplication this file exists to avoid - so up here it stays one word, in
+  // the badge, and the badge now says "Unreachable" because this window has
+  // just watched it fail.
+  if (reachability.offlineSince !== null && reachability.lastSeenAt !== null) {
+    return (
+      <Disconnected
+        row={row}
+        host={host}
+        message={reachability.message}
+        lastSeenAt={reachability.lastSeenAt}
+        onRetry={row ? () => void retry() : undefined}
+        retrying={retrying}
+      />
+    )
+  }
 
   return (
     <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-md border border-dashed px-3 py-2">
@@ -63,7 +152,10 @@ export function HostBanner() {
               : 'Another machine'}
         </p>
         {row ? (
-          <ReachabilityBadge host={row} />
+          // This window's own evidence, which beats the row's - see
+          // `reachabilityOf`. Undefined when it has none, which leaves the row
+          // to answer as it did before M4.5.
+          <ReachabilityBadge host={row} observed={observed} />
         ) : (
           // The id, while there is no label to show - and because it is what
           // the person can compare against the Hosts screen to work out which
@@ -73,14 +165,101 @@ export function HostBanner() {
           </span>
         )}
       </div>
-      <Button
-        variant="ghost"
-        size="sm"
-        className="shrink-0 text-muted-foreground"
-        onClick={() => navigate({ name: 'repositories' })}
-      >
-        Back to this computer
-      </Button>
+      <BackToThisComputer />
     </div>
+  )
+}
+
+/**
+ * The machine went away, and what is on screen is what it last said.
+ *
+ * Three sentences and a button, in the order somebody reads them: which machine
+ * and that it is gone, what the attempt actually said, and how old the thing
+ * they are looking at is. The middle one is `ssh`'s own words carried up
+ * through the pool - "Permission denied (publickey)", "Could not resolve
+ * hostname", "GitWarren is not installed on xfor@pc-wsl" - and it is the only
+ * line on the screen that says what to go and fix. Everything M4.1 did to make
+ * sure that sentence was the useful one rather than "the connection closed"
+ * ends here.
+ *
+ * The content behind it is left alone: no overlay, no dimming, nothing
+ * disabled. A diff that was readable a second ago is still readable, and a
+ * reviewer mid-file should not lose their place because a laptop shut its lid.
+ * What a stale screen must not do is pretend, and one strip saying so out loud
+ * is enough - which is also why there is no per-card marker anywhere below.
+ *
+ * Writes are deliberately not blocked either. A comment typed against a machine
+ * that is away fails on submit with the same sentence, in the composer, where
+ * the text still is - and that is a better answer than a disabled button that
+ * loses what somebody was in the middle of writing.
+ */
+function Disconnected({
+  row,
+  host,
+  message,
+  lastSeenAt,
+  onRetry,
+  retrying
+}: {
+  row: HostWithState | null | undefined
+  host: string
+  message: string | null
+  lastSeenAt: number
+  onRetry: (() => void) | undefined
+  retrying: boolean
+}) {
+  return (
+    <div
+      role="status"
+      className="mb-4 flex flex-wrap items-start gap-x-3 gap-y-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2"
+    >
+      <PlugZap className="mt-0.5 size-4 shrink-0 text-warning" />
+      {/* A floor rather than `min-w-0`, and it is what makes this readable on a
+          phone. The buttons beside it are `shrink-0`, so a text column allowed
+          to shrink to nothing does: at 390 px `ssh`'s sentence came out one word
+          per line down the left of the screen, which passes a no-horizontal-
+          scroll check and is unreadable. Below this width the row wraps and the
+          buttons take a line of their own. */}
+      <div className="flex min-w-[14rem] flex-1 flex-col gap-0.5">
+        <p className="text-sm font-medium">
+          {row ? `${row.label} stopped answering` : 'That machine stopped answering'}
+        </p>
+        {message && <p className="text-sm text-muted-foreground">{message}</p>}
+        <p className="text-xs text-muted-foreground">
+          Showing what was loaded at {timeOfDay(lastSeenAt)}. GitWarren keeps trying.
+        </p>
+        {!row && (
+          <span data-selectable className="font-mono text-xs text-muted-foreground">
+            {host}
+          </span>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        {/* Absent rather than disabled while the host list is still loading,
+            which is the rule M3 set for a control a shell cannot honour: this
+            one needs the row's numeric id to probe with, and a button that
+            explains itself when pressed is worse than one that was not there. */}
+        {onRetry && (
+          <Button variant="outline" size="sm" onClick={onRetry} disabled={retrying}>
+            <RefreshCw className={retrying ? 'animate-spin' : undefined} />
+            Try again
+          </Button>
+        )}
+        <BackToThisComputer />
+      </div>
+    </div>
+  )
+}
+
+function BackToThisComputer() {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="shrink-0 text-muted-foreground"
+      onClick={() => navigate({ name: 'repositories' })}
+    >
+      Back to this computer
+    </Button>
   )
 }

--- a/src/renderer/src/features/hosts/host-status.tsx
+++ b/src/renderer/src/features/hosts/host-status.tsx
@@ -21,15 +21,37 @@ import type { HostWithState } from '@shared/schemas'
 
 export type Reachability = 'up' | 'down' | 'unknown'
 
-export function reachabilityOf(host: HostWithState): Reachability {
+/**
+ * `observed` is the asking side's own evidence, and it wins.
+ *
+ * A row's `state` comes from the pool, but the *row* is a read like any other
+ * and is exactly as old as the last time the list was fetched. M4.5 found the
+ * two saying different things out loud: open a review on a host in a window
+ * that has just started, and the strip above the diff said "Not tried yet"
+ * about the machine that had this moment served it - because `hosts.list` was
+ * answered before anything had connected and nothing re-asked. Whoever has had
+ * an answer out of the machine knows better than a cached list, in exactly the
+ * way `lib/host-reachability.ts` argues about the disconnection itself.
+ *
+ * Undefined when the caller has observed nothing, which is not the same as
+ * having observed nothing good - see the paragraph above about never tried.
+ */
+export function reachabilityOf(host: HostWithState, observed?: Reachability): Reachability {
+  if (observed !== undefined) return observed
   if (host.state.connected) return 'up'
   // A host with a failure behind it is down even while its backoff is running;
   // a host with none has simply not been asked.
   return host.state.failures > 0 || host.state.lastError ? 'down' : 'unknown'
 }
 
-export function ReachabilityBadge({ host }: { host: HostWithState }) {
-  switch (reachabilityOf(host)) {
+export function ReachabilityBadge({
+  host,
+  observed
+}: {
+  host: HostWithState
+  observed?: Reachability
+}) {
+  switch (reachabilityOf(host, observed)) {
     case 'up':
       return (
         <Badge variant="success">

--- a/src/renderer/src/features/hosts/use-reconnect.ts
+++ b/src/renderer/src/features/hosts/use-reconnect.ts
@@ -1,0 +1,68 @@
+/**
+ * The silent half of M4.5: what happens when the machine answers again.
+ *
+ * A banner is the visible half and the easy one. The part a person actually
+ * notices is that the screen they left open comes back by itself when the
+ * laptop wakes - without a refresh button, without a navigation, and without
+ * their place in a diff being lost.
+ *
+ * Two things have to be true for that, and only one of them was.
+ *
+ * **Something has to keep asking.** That is the retry in `main.tsx`, because
+ * SWR's own fifteen-second poll stops at the exact moment there is something to
+ * notice - see the note there.
+ *
+ * **One read coming back has to bring the rest with it.** This file. A review
+ * screen holds half a dozen keys - the review, the diff, the commits, each
+ * expanded file - and most of them are `LIVE_READ_OPTIONS` reads that
+ * deliberately never retry, because a diff is expensive and re-running it
+ * behind someone's back is not a favour. So the one read that *is* retrying is
+ * the whole machine's heartbeat: when it succeeds, everything scoped to that
+ * machine is revalidated at once, and the screen redraws whole rather than in
+ * pieces over the following minutes.
+ *
+ * Revalidating by key suffix is what makes that a single line, and it is not a
+ * trick - `scoped()` in `lib/api.ts` puts the instance id on the end of every
+ * key that names something a host owns, for the sake of the family-wide
+ * `startsWith` invalidation at the front. Asking from the other end gives
+ * "everything about that machine", which is the unit that just changed.
+ *
+ * The carrier's own reconnection is the same idea with a wider blast radius: a
+ * tab that lost its socket lost every screen's freshness, this computer's
+ * included, so everything is revalidated. It costs a handful of local SQLite
+ * reads on a page that has just been offline.
+ */
+import { useEffect } from 'react'
+import { useSWRConfig } from 'swr'
+import { api, CACHE_KEYS } from '@/lib/api'
+import { subscribeToHosts } from '@/lib/host-reachability'
+
+export function useRefetchOnReconnect(): void {
+  const { mutate } = useSWRConfig()
+
+  useEffect(
+    () =>
+      subscribeToHosts((host, state) => {
+        // Only the moment it comes back. The store announces a change of state
+        // rather than every outcome, so this fires once per reconnection.
+        if (state.offlineSince !== null) return
+        void mutate(
+          (key) =>
+            typeof key === 'string' &&
+            // The host list carries live reachability, so it is stale too - and
+            // it is the one key about a machine that is deliberately not scoped
+            // by one. See `CACHE_KEYS.hosts`.
+            (key === CACHE_KEYS.hosts || key.endsWith(`@${host}`))
+        )
+      }),
+    [mutate]
+  )
+
+  useEffect(
+    () =>
+      api.connection.subscribe((connected) => {
+        if (connected) void mutate(() => true)
+      }),
+    [mutate]
+  )
+}

--- a/src/renderer/src/features/repositories/repository-detail.tsx
+++ b/src/renderer/src/features/repositories/repository-detail.tsx
@@ -20,7 +20,7 @@ import { Tooltip } from '@/components/ui/tooltip'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { CACHE_KEYS } from '@/lib/api'
-import { errorMessage } from '@/lib/errors'
+import { errorMessage, isDisconnection } from '@/lib/errors'
 import { useApi, useHost, useHostScope } from '@/lib/host-scope'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
 import { navigate } from '@/lib/router'
@@ -95,7 +95,12 @@ export function RepositoryDetail({ repositoryId }: { repositoryId: number }) {
     )
   }
 
-  if (error !== undefined || !repository) {
+  // A disconnection over a repository we already have is staleness, not
+  // failure - see the same guard in `review-detail.tsx` and `isDisconnection`
+  // in `lib/errors.ts`. `HostBanner` is what says so.
+  const stale = repository !== undefined && isDisconnection(error)
+
+  if (!repository || (error !== undefined && !stale)) {
     return (
       <Card className="flex flex-col items-center gap-3 border-destructive/40 px-6 py-12 text-center">
         <div className="rounded-full bg-destructive/10 p-3 text-destructive">

--- a/src/renderer/src/features/repositories/repository-list.tsx
+++ b/src/renderer/src/features/repositories/repository-list.tsx
@@ -15,9 +15,14 @@
  * stops being a broken app and becomes an ordinary answer: the machine is
  * asleep. `HOST_OFFLINE` therefore gets its own state with the sentence `ssh`
  * produced and a Try again, rather than the generic failure a missing git would
- * give - the two need completely different things done about them. What that
- * state currently depends on, and where it therefore does and does not render,
- * is written down next to it in `ErrorState`.
+ * give - the two need completely different things done about them.
+ *
+ * Since M4.5 that card is for having *nothing* to show, and only that. A
+ * disconnection with rows already on screen leaves them exactly where they are:
+ * they are the last true answer that machine gave, nothing has contradicted
+ * them, and `HostBanner` says above them that they are old. Replacing a list
+ * somebody was reading with a notice about a laptop is the one thing a stale
+ * screen is not allowed to cost.
  *
  * ## Clones, and which direction the comparison runs
  *
@@ -41,7 +46,7 @@ import { Tooltip } from '@/components/ui/tooltip'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { api, CACHE_KEYS } from '@/lib/api'
-import { errorCode, errorMessage } from '@/lib/errors'
+import { errorCode, errorMessage, isDisconnection } from '@/lib/errors'
 import { useHost } from '@/lib/host-scope'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
 import { RepositoryCard, type Elsewhere } from './repository-card'
@@ -96,6 +101,11 @@ export function RepositoryList() {
     () => localClonesByRoot(host, localRepositories),
     [host, localRepositories]
   )
+
+  // The rows stay when the machine that served them goes away; `ErrorState`
+  // below is for having nothing to show, not for having something old. See the
+  // note at the top of this file.
+  const stale = repositories !== undefined && isDisconnection(error)
 
   const [formOpen, setFormOpen] = useState(false)
   const [editing, setEditing] = useState<RepositoryWithGitState | undefined>(undefined)
@@ -169,15 +179,15 @@ export function RepositoryList() {
 
       {isLoading && <LoadingState />}
 
-      {!isLoading && error !== undefined && (
+      {!isLoading && error !== undefined && !stale && (
         <ErrorState error={error} onRetry={() => void refresh()} />
       )}
 
-      {!isLoading && error === undefined && repositories?.length === 0 && (
+      {!isLoading && (error === undefined || stale) && repositories?.length === 0 && (
         <EmptyState onAdd={openAdd} />
       )}
 
-      {!isLoading && error === undefined && repositories && repositories.length > 0 && (
+      {!isLoading && (error === undefined || stale) && repositories && repositories.length > 0 && (
         <ul className="flex flex-col gap-2">
           {repositories.map((repository) => (
             <li key={repository.id}>
@@ -256,16 +266,12 @@ function ErrorState({ error, onRetry }: { error: unknown; onRetry: () => void })
   // produced ("Could not resolve hostname", "Permission denied (publickey)")
   // is the only thing on the screen that says what to go and fix.
   //
-  // This branch reaches a browser tab today and not the Electron window, and
-  // the reason is older than this slice: `contextBridge` strips everything but
-  // `message` off a rejection, so `AppError.code` and `fieldErrors` do not
-  // survive the preload - which is also why the add-repository form has been
-  // showing duplicate-path errors in its general slot rather than under the
-  // field. M4.3 found it and deliberately did not fix it here; see "What
-  // M4.3 found and left alone" in docs/across-hosts.md. In the window the
-  // generic state below still renders `errorMessage(error)`, which is the same
-  // sentence - it just arrives under a heading about git rather than about a
-  // sleeping machine.
+  // It reaches both shells. It did not when M4.3 wrote it: `contextBridge`
+  // strips everything but `message` off a rejection, so `AppError.code` did not
+  // survive the preload and this branch was unreachable in the window. The
+  // `BridgeCarrier` change that landed straight after M4.3 fixed that at the
+  // boundary, which is what M4.5 is built on - every "is this a disconnection?"
+  // in the renderer is a question about a code.
   if (code === 'HOST_OFFLINE') {
     return (
       <Card className="flex flex-col items-center gap-3 border-dashed px-6 py-12 text-center">

--- a/src/renderer/src/features/reviews/review-commits-tab.tsx
+++ b/src/renderer/src/features/reviews/review-commits-tab.tsx
@@ -10,7 +10,7 @@ import { AlertCircle, GitCommitHorizontal, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { errorMessage } from '@/lib/errors'
+import { errorMessage, isDisconnection } from '@/lib/errors'
 import { absoluteTime, plural, relativeTime } from '@/lib/format'
 import { CompareErrorCard, NoWorktreeNotice, WorkingTreeBanner } from './compare-notices'
 import { useReviewCommits } from './use-reviews'
@@ -23,7 +23,9 @@ export function ReviewCommitsTab({ review }: { review: Review }) {
 
   if (isLoading) return <LoadingState />
 
-  if (error !== undefined) {
+  // Kept when the machine goes away, for the reason `review-files-tab.tsx`
+  // spells out: a disconnection contradicts nothing already on screen.
+  if (error !== undefined && !(data !== undefined && isDisconnection(error))) {
     return (
       <Card className="flex flex-col items-center gap-3 border-destructive/40 px-6 py-10 text-center">
         <div className="rounded-full bg-destructive/10 p-3 text-destructive">

--- a/src/renderer/src/features/reviews/review-conversation-tab.tsx
+++ b/src/renderer/src/features/reviews/review-conversation-tab.tsx
@@ -22,7 +22,7 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Markdown } from '@/components/markdown'
-import { errorMessage } from '@/lib/errors'
+import { errorMessage, isDisconnection } from '@/lib/errors'
 import { absoluteTime, relativeTime } from '@/lib/format'
 import { replace } from '@/lib/router'
 import { CommentComposer } from '../comments/comment-composer'
@@ -108,7 +108,10 @@ export function ReviewConversationTab({ review, onEdit }: ReviewConversationTabP
 
       {isLoading && <Skeleton className="h-24 w-full" />}
 
-      {error !== undefined && error !== null && (
+      {/* Not for a disconnection: this tab already keeps its threads when a
+          read fails, and `HostBanner` has said the machine is away in as many
+          words. A second red line under it would be the same news twice. */}
+      {error !== undefined && error !== null && !isDisconnection(error) && (
         <p role="alert" className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
           {errorMessage(error)}
         </p>

--- a/src/renderer/src/features/reviews/review-detail.tsx
+++ b/src/renderer/src/features/reviews/review-detail.tsx
@@ -35,7 +35,7 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsCount, TabsList, TabsPanel, TabsTab } from '@/components/ui/tabs'
-import { errorMessage } from '@/lib/errors'
+import { errorMessage, isDisconnection } from '@/lib/errors'
 import { plural } from '@/lib/format'
 import { useHostScope } from '@/lib/host-scope'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
@@ -179,7 +179,15 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
 
   if (isLoading) return <LoadingState />
 
-  if (error !== undefined || !review) {
+  // A disconnection with a review already in hand is staleness, not failure:
+  // nothing has contradicted what is on screen, the question simply could not
+  // be asked. So the review stays exactly as it was - scroll position, open
+  // thread, expanded file and all - and `HostBanner` says so above it. Every
+  // other error still replaces the screen, because every other error is an
+  // answer *about* this review. See `isDisconnection` in `lib/errors.ts`.
+  const stale = review !== undefined && isDisconnection(error)
+
+  if (!review || (error !== undefined && !stale)) {
     return (
       <Card className="flex flex-col items-center gap-3 border-destructive/40 px-6 py-12 text-center">
         <div className="rounded-full bg-destructive/10 p-3 text-destructive">

--- a/src/renderer/src/features/reviews/review-files-tab.tsx
+++ b/src/renderer/src/features/reviews/review-files-tab.tsx
@@ -37,7 +37,7 @@ import {
 } from '@/components/ui/select'
 import { Skeleton } from '@/components/ui/skeleton'
 
-import { errorMessage } from '@/lib/errors'
+import { errorMessage, isDisconnection } from '@/lib/errors'
 import { formatStep } from '@/lib/keys'
 import { plural } from '@/lib/format'
 import { useApi, useHost } from '@/lib/host-scope'
@@ -697,7 +697,13 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
 
   if (isLoading) return <LoadingState />
 
-  if (error !== undefined) {
+  // The diff outlives the machine that produced it. This is the tab M4.5 was
+  // written for - somebody halfway down a file, with a thread open - and
+  // replacing it with a card about a laptop would cost them their place to tell
+  // them something `HostBanner` is already saying above the tab strip. Every
+  // other error still replaces it, because every other error contradicts what
+  // is on screen. See `isDisconnection` in `lib/errors.ts`.
+  if (error !== undefined && !(data !== undefined && isDisconnection(error))) {
     return (
       <Card className="flex flex-col items-center gap-3 border-destructive/40 px-6 py-10 text-center">
         <div className="rounded-full bg-destructive/10 p-3 text-destructive">

--- a/src/renderer/src/features/reviews/review-list.tsx
+++ b/src/renderer/src/features/reviews/review-list.tsx
@@ -10,7 +10,7 @@ import { Tooltip } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { errorMessage } from '@/lib/errors'
+import { errorMessage, isDisconnection } from '@/lib/errors'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
 import { absoluteTime, relativeTime } from '@/lib/format'
 import { useHostScope } from '@/lib/host-scope'
@@ -38,6 +38,10 @@ export function ReviewList({ repositoryId }: { repositoryId: number }) {
     repositoryId,
     filter === 'all' ? undefined : filter
   )
+
+  // The list we already have outlives the machine that served it going away -
+  // see `review-detail.tsx` for the argument, and `HostBanner` for the notice.
+  const stale = reviews !== undefined && isDisconnection(error)
 
   useRegisterCommands(
     useMemo<Command[]>(
@@ -121,7 +125,7 @@ export function ReviewList({ repositoryId }: { repositoryId: number }) {
 
       {isLoading && <LoadingState />}
 
-      {!isLoading && error !== undefined && (
+      {!isLoading && error !== undefined && !stale && (
         <Card className="flex flex-col items-center gap-3 border-destructive/40 px-6 py-10 text-center">
           <div className="rounded-full bg-destructive/10 p-3 text-destructive">
             <AlertCircle className="size-6" />
@@ -134,11 +138,11 @@ export function ReviewList({ repositoryId }: { repositoryId: number }) {
         </Card>
       )}
 
-      {!isLoading && error === undefined && reviews?.length === 0 && (
+      {!isLoading && (error === undefined || stale) && reviews?.length === 0 && (
         <EmptyState filter={filter} onCreate={() => setFormOpen(true)} />
       )}
 
-      {!isLoading && error === undefined && reviews && reviews.length > 0 && (
+      {!isLoading && (error === undefined || stale) && reviews && reviews.length > 0 && (
         <ul className="flex flex-col gap-2">
           {reviews.map((review) => (
             <li key={review.id}>

--- a/src/renderer/src/lib/__tests__/host-reachability.test.ts
+++ b/src/renderer/src/lib/__tests__/host-reachability.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The rules a banner is drawn from, without a banner.
+ *
+ * Everything here is about telling three states apart that a screen is very
+ * likely to blur: never asked, answering, and gone. The first two look the same
+ * in a naive store - both are "no error" - and getting that wrong is how a host
+ * that is perfectly fine announces itself as unreachable for the first frames
+ * of a load, which `host-banner.tsx` has a paragraph about.
+ */
+import { strict as assert } from 'node:assert'
+import { afterEach, test } from 'node:test'
+import {
+  hostReachability,
+  reportHostAnswered,
+  reportHostUnreachable,
+  resetHostReachability,
+  subscribeToHosts
+} from '../host-reachability'
+
+const HOST = 'a4f0c5f0-0000-4000-8000-000000000001'
+
+afterEach(() => resetHostReachability())
+
+test('a machine nothing has asked about is not reported as gone', () => {
+  const state = hostReachability(HOST)
+  assert.equal(state.offlineSince, null)
+  assert.equal(state.message, null)
+  assert.equal(state.lastSeenAt, null)
+})
+
+test('this install is never a disconnection', () => {
+  assert.equal(hostReachability(undefined).offlineSince, null)
+})
+
+test('a failure carries the sentence the attempt produced', () => {
+  reportHostUnreachable(HOST, 'ssh could not connect to xfor@pc-wsl.')
+  const state = hostReachability(HOST)
+  assert.ok(state.offlineSince !== null)
+  assert.equal(state.message, 'ssh could not connect to xfor@pc-wsl.')
+})
+
+test('a run of failures is one going away, and takes the later explanation', () => {
+  reportHostUnreachable(HOST, 'The connection to the host closed.')
+  const first = hostReachability(HOST).offlineSince
+  reportHostUnreachable(HOST, 'GitWarren is not installed on xfor@pc-wsl.')
+
+  const state = hostReachability(HOST)
+  // The moment it went away, not the moment of the latest attempt: a machine
+  // that is off for the evening fails every fifteen seconds without going away
+  // again. The message is the opposite - the useful half of a failure arrives
+  // after the failure, which is what M4.1 built `diagnostics()` for.
+  assert.equal(state.offlineSince, first)
+  assert.equal(state.message, 'GitWarren is not installed on xfor@pc-wsl.')
+})
+
+test('an answer clears it, and is what a screen is woken for', () => {
+  const seen: (number | null)[] = []
+  const unsubscribe = subscribeToHosts((_host, state) => seen.push(state.offlineSince))
+
+  reportHostUnreachable(HOST, 'ssh could not connect to xfor@pc-wsl.')
+  reportHostAnswered(HOST)
+
+  assert.equal(hostReachability(HOST).offlineSince, null)
+  assert.equal(hostReachability(HOST).message, null)
+  // Once for going, once for coming back. Anything else would be a refetch per
+  // request; see `use-reconnect.ts`, which revalidates a whole machine on this.
+  assert.equal(seen.length, 2)
+  assert.equal(seen[1], null)
+  unsubscribe()
+})
+
+test('coming back after a first answer is still one announcement', () => {
+  reportHostAnswered(HOST)
+
+  let woken = 0
+  const unsubscribe = subscribeToHosts(() => {
+    woken += 1
+  })
+  reportHostUnreachable(HOST, 'ssh could not connect to xfor@pc-wsl.')
+  reportHostAnswered(HOST)
+  reportHostAnswered(HOST)
+
+  assert.equal(woken, 2)
+  unsubscribe()
+})
+
+test('the first answer is news, and every one after it is not', () => {
+  let woken = 0
+  const unsubscribe = subscribeToHosts(() => {
+    woken += 1
+  })
+
+  reportHostAnswered(HOST)
+  reportHostAnswered(HOST)
+  reportHostAnswered(HOST)
+
+  // Once: leaving "never heard from" is a state change, and the badge above a
+  // review depends on hearing about it. The two after it are not - a screen
+  // that redrew on every successful read would redraw on every read.
+  assert.equal(woken, 1)
+  assert.ok(hostReachability(HOST).lastSeenAt !== null)
+  unsubscribe()
+})
+
+test('when the machine last answered survives it going away', () => {
+  reportHostAnswered(HOST)
+  const seen = hostReachability(HOST).lastSeenAt
+  reportHostUnreachable(HOST, 'ssh could not connect to xfor@pc-wsl.')
+
+  // This is the number the banner names - "showing what was loaded at 14:32" -
+  // so it has to be the last time the machine spoke, not the last time it was
+  // asked.
+  assert.equal(hostReachability(HOST).lastSeenAt, seen)
+})
+
+test('machines are kept apart', () => {
+  const other = 'a4f0c5f0-0000-4000-8000-000000000002'
+  reportHostUnreachable(HOST, 'ssh could not connect to xfor@pc-wsl.')
+
+  assert.ok(hostReachability(HOST).offlineSince !== null)
+  assert.equal(hostReachability(other).offlineSince, null)
+})

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -38,6 +38,8 @@
  * repository path can appear under the path input again.
  */
 import { resultOf, type RpcMethod, type RpcParams, type RpcResult } from '@shared/rpc'
+import { errorMessage, isDisconnection } from './errors'
+import { reportHostAnswered, reportHostUnreachable } from './host-reachability'
 import type { GitWarrenApi, GitWarrenBridge } from '@shared/api'
 import type { DiffChanges } from '@shared/git'
 
@@ -58,13 +60,38 @@ const { carrier, shell } = bridge
  * throw. `resultOf` is the shared unwrapper every carrier uses, which is what
  * makes a `NOT_FOUND` from a daemon over `ssh` reach a component as the same
  * `AppError` a local call would have thrown.
+ *
+ * It is also where M4.5 learns which machines are still answering. Every
+ * question this window asks of another computer passes through here with the
+ * host still in scope, which makes it the one place that can notice a machine
+ * going away without anybody having to push anything - see
+ * `lib/host-reachability.ts` for why that is the signal rather than the pool's
+ * own `onStateChange`.
  */
 function ask<M extends RpcMethod>(
   method: M,
   params: RpcParams<M>,
   host?: string
 ): Promise<RpcResult<M>> {
-  return carrier.request(method, params, host).then(resultOf)
+  const answered = carrier.request(method, params, host).then(resultOf)
+  // Nothing to observe about this install. A local call cannot be a
+  // disconnection, and there is no banner for one to raise.
+  if (host === undefined) return answered
+
+  return answered.then(
+    (result) => {
+      reportHostAnswered(host)
+      return result
+    },
+    (error: unknown) => {
+      // Only a transport failure says anything about the machine - the rule the
+      // pool applies before touching its backoff ladder, arriving at the other
+      // end of the same wire. A `NOT_FOUND` is proof the far end is there.
+      if (isDisconnection(error)) reportHostUnreachable(host, errorMessage(error))
+      else reportHostAnswered(host)
+      throw error
+    }
+  )
 }
 
 /**
@@ -199,7 +226,11 @@ function buildApi(host: string | undefined): GitWarrenApi {
       setOpenAtLogin: (openAtLogin) => shell.system.setOpenAtLogin(openAtLogin)
     },
     navigation: shell.navigation,
-    updates: shell.updates
+    updates: shell.updates,
+    // Unbound like the two above, and for the same reason: it is about the
+    // shell the person is using, not about any machine a route names. A tab
+    // that has lost its socket has lost it for every screen at once.
+    connection: shell.connection
   }
 }
 

--- a/src/renderer/src/lib/errors.ts
+++ b/src/renderer/src/lib/errors.ts
@@ -17,6 +17,18 @@ export function errorCode(error: unknown): AppErrorCode | null {
   return error instanceof AppError ? error.code : null
 }
 
+/**
+ * A failure that says nothing about the data - the question could not be asked.
+ *
+ * The distinction M4.5 turns on. Every other error is an *answer* about what
+ * was asked for, and replaces what is on screen because it contradicts it; a
+ * disconnection contradicts nothing, so the screen keeps what it had and the
+ * banner says it is stale. See `features/hosts/host-banner.tsx`.
+ */
+export function isDisconnection(error: unknown): boolean {
+  return errorCode(error) === 'HOST_OFFLINE'
+}
+
 /** Field-level messages keyed by form field, ready to render inline. */
 export function fieldErrors(error: unknown): Record<string, string[]> {
   return error instanceof AppError && error.fieldErrors ? error.fieldErrors : {}

--- a/src/renderer/src/lib/format.ts
+++ b/src/renderer/src/lib/format.ts
@@ -37,6 +37,21 @@ export function absoluteTime(iso: string | null): string {
   return Number.isNaN(timestamp) ? iso : ABSOLUTE.format(timestamp)
 }
 
+const CLOCK = new Intl.DateTimeFormat(undefined, { timeStyle: 'short' })
+
+/**
+ * "14:32", for something that happened while the window was open.
+ *
+ * A clock time rather than `relativeTime`, and the difference matters for the
+ * one caller: the disconnection banner says when what is on screen was loaded,
+ * and it is only redrawn when the machine's state changes. A relative phrase
+ * would freeze at "just now" and stay there for the rest of the outage, while
+ * a clock time is as true an hour later as it was at the time.
+ */
+export function timeOfDay(timestamp: number): string {
+  return CLOCK.format(timestamp)
+}
+
 /**
  * "412 KB". Powers of two with the units people expect next to a file, which
  * is what every git host prints beside an image.

--- a/src/renderer/src/lib/host-reachability.ts
+++ b/src/renderer/src/lib/host-reachability.ts
@@ -1,0 +1,159 @@
+/**
+ * Which machines have stopped answering, learned from the requests this window
+ * is already making to them.
+ *
+ * M4.5 needed a banner on an open review whose host has gone away, and the
+ * obvious place to read that from is `core/hosts/pool.ts`, which has carried an
+ * `onStateChange` hook since M4.1 with a comment saying this slice would render
+ * it. Nothing here reads it, and the reason is worth the paragraph.
+ *
+ * ## A push from the pool has nowhere to travel
+ *
+ * `RpcEvent` in `shared/rpc.ts` is reserved for M6 and nothing emits on it. So
+ * the pool's state would have to reach a screen down an Electron IPC channel
+ * for the window *and* down the WebSocket for a tab - two half-built event
+ * channels, in a request/response protocol, for one banner. That is the
+ * argument M4.2 made when it refused to invent one for a progress bar, and it
+ * is stronger here, because in this case there is already a signal.
+ *
+ * The signal is the reads the screen is doing anyway. An open review polls
+ * `reviews.open` every fifteen seconds; when the machine goes away that read
+ * fails with `HOST_OFFLINE`, and when it comes back the same read succeeds.
+ * Both halves of "disconnection" are already arriving, on the one path that
+ * also knows whether there is anything on screen to mark stale. What the pool
+ * knows and this does not is the state of hosts nobody is looking at - which is
+ * exactly the set with no screen to put a banner on.
+ *
+ * Polling `hosts.list` was the other candidate and is worse than either. It is
+ * cheap - `hostsService.list` reads the pool rather than connecting - but the
+ * pool's state only *changes* when something connects, so the poll would report
+ * the past forever unless some other read were doing the real work. Two
+ * questions, one answer, and a standing chance of the two disagreeing on one
+ * screen.
+ *
+ * This is deliberately *not* where a browser tab's own dropped socket is
+ * recorded, and they are not the same fact. A dead socket does not fail
+ * requests - `web/carrier.ts` queues them until it reconnects - so nothing
+ * settles and this file, which only ever learns from an outcome, is blind to it
+ * by construction. `ShellApi.connection` is that one, and
+ * `components/connection-banner.tsx` is its sentence.
+ *
+ * ## A request in flight is not a disconnection
+ *
+ * Only a settled failure marks a machine down, and only `HOST_OFFLINE` does: a
+ * `NOT_FOUND` travelled the wire perfectly and is the host working correctly,
+ * which is the same rule the pool applies before touching its backoff ladder.
+ * The mistake in the other direction is the one `host-banner.tsx` already
+ * records about a host list that has not loaded yet - the honest rendering of
+ * an unanswered question is not the alarming answer.
+ *
+ * There is no React in this file, and that is deliberate rather than
+ * incidental: the rules above are the part worth testing, and a test of them is
+ * a node program (see the note about renderer tests in `tsconfig.node.json`).
+ * `useSyncExternalStore` over `subscribeToHosts` is four lines at the one
+ * component that needs it, which is what `connection-banner.tsx` does with the
+ * other disconnection.
+ */
+
+export interface HostReachability {
+  /**
+   * When the current run of failures started, or null while the machine is
+   * answering.
+   *
+   * The *first* failure of the run rather than the latest, because what a
+   * banner is about is when the machine went away, and a machine that is off
+   * for the evening fails every fifteen seconds without going away again.
+   */
+  offlineSince: number | null
+  /** What the last failure said - `ssh`'s own sentence, by way of the pool. */
+  message: string | null
+  /**
+   * When this machine last answered anything, in this window.
+   *
+   * Null means it has not answered since the page loaded, which is not the same
+   * as never: the banner says "what was loaded" only when it has a time to name.
+   */
+  lastSeenAt: number | null
+}
+
+/** A machine nothing has asked anything of yet. Shared, so the snapshot is stable. */
+const UNKNOWN: HostReachability = { offlineSince: null, message: null, lastSeenAt: null }
+
+type Listener = (host: string, state: HostReachability) => void
+
+const byHost = new Map<string, HostReachability>()
+const listeners = new Set<Listener>()
+
+function announce(host: string, state: HostReachability): void {
+  for (const listener of listeners) listener(host, state)
+}
+
+/** Notified when a machine changes state. Returns an unsubscribe function. */
+export function subscribeToHosts(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/**
+ * That machine answered.
+ *
+ * Called for a failure that is not a transport failure too: an error that
+ * travelled the wire is proof the far end is there.
+ */
+export function reportHostAnswered(host: string): void {
+  const current = byHost.get(host) ?? UNKNOWN
+  const next: HostReachability = { offlineSince: null, message: null, lastSeenAt: Date.now() }
+  byHost.set(host, next)
+
+  // Only a change of *state* is worth waking a screen for. `lastSeenAt` moves
+  // on every successful read - four times a minute on an open review, more
+  // while someone is clicking - and nothing on screen shows it while the
+  // machine is answering. The value is read at the moment it stops.
+  //
+  // The two states that *are* a change are coming back, and the very first
+  // answer. The second is easy to leave out and M4.5 did, which cost the badge
+  // above a freshly opened review: this window had just been served a diff by
+  // the machine and went on saying "Not tried yet" about it, because the only
+  // thing that would have corrected the sentence was a re-render nothing asked
+  // for. Never heard from is a state, and leaving it is news.
+  if (current.offlineSince !== null || current.lastSeenAt === null) announce(host, next)
+}
+
+/** That machine could not be reached, and this is what the attempt said. */
+export function reportHostUnreachable(host: string, message: string): void {
+  const current = byHost.get(host) ?? UNKNOWN
+  const next: HostReachability = {
+    offlineSince: current.offlineSince ?? Date.now(),
+    message,
+    lastSeenAt: current.lastSeenAt
+  }
+  byHost.set(host, next)
+  // The message changing matters as much as the state changing, and for the
+  // reason M4.1 recorded in the pool: the first thing known about a dying
+  // connection is "it closed", and the sentence worth reading - "GitWarren is
+  // not installed on xfor@pc-wsl" - arrives a moment later.
+  if (current.offlineSince === null || current.message !== message) announce(host, next)
+}
+
+/** Forget everything. For tests; nothing in the app has any reason to. */
+export function resetHostReachability(): void {
+  byHost.clear()
+}
+
+/**
+ * What is known about one machine.
+ *
+ * `UNKNOWN` for this install, which is right rather than a fallback: a local
+ * call cannot be a disconnection, so there is never anything to say. The
+ * returned object is the one held in the map, so it is a stable snapshot for
+ * `useSyncExternalStore` between one announcement and the next.
+ */
+export function hostReachability(host: string | undefined): HostReachability {
+  return host === undefined ? UNKNOWN : (byHost.get(host) ?? UNKNOWN)
+}
+
+/** `subscribeToHosts`, in the shape `useSyncExternalStore` wants. */
+export const subscribeToHostChanges = (onStoreChange: () => void): (() => void) =>
+  subscribeToHosts(() => onStoreChange())

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,7 +3,19 @@ import { createRoot } from 'react-dom/client'
 import { SWRConfig } from 'swr'
 import { App } from './App'
 import { api } from './lib/api'
+import { isDisconnection } from './lib/errors'
 import './index.css'
+
+/**
+ * How often to ask a machine that has stopped answering whether it is back.
+ *
+ * The same fifteen seconds an open review already polls at, because it is the
+ * same question. What it costs is bounded by the pool rather than by this
+ * number: `core/hosts/pool.ts` refuses immediately while its backoff is
+ * running, so four out of five of these are a rejected promise and no process,
+ * and at most one connection a minute per machine actually reaches `ssh`.
+ */
+const OFFLINE_RETRY_MS = 15_000
 
 /** Follow the OS appearance, and keep following it if the user switches. */
 function applyColourScheme(): void {
@@ -41,7 +53,43 @@ createRoot(container).render(
         // it - a branch may well have changed while you were in the terminal.
         revalidateOnFocus: true,
         revalidateOnReconnect: false,
-        shouldRetryOnError: false
+        /**
+         * On, so that `onErrorRetry` below is consulted at all - and it is what
+         * still says no to everything except a disconnection.
+         *
+         * The flag was `false` because an error is normally an *answer*: a
+         * `NOT_FOUND` will not become found by being asked again, and a broken
+         * git will not mend itself between two revalidations. A machine that is
+         * asleep is the one error that is about the question not having been
+         * asked, and it is expected to stop being true - which is why it is the
+         * one case that retries, and why leaving the refusal expressed here in
+         * code is better than turning a flag back on.
+         */
+        shouldRetryOnError: true,
+        /**
+         * A machine that stopped answering is asked again, at a steady interval.
+         *
+         * SWR's `refreshInterval` looks like it should already do this and does
+         * not: the poll is skipped for as long as the cached error is set (in
+         * `use-swr`: `if (!getCache().error && …)`), so the fifteen-second
+         * revalidation that would notice a machine coming back stops at the
+         * exact moment there is something to notice. With retries off, an open
+         * review against a sleeping host stayed offline until somebody focused
+         * the window. Found by unplugging `pc-wsl` and waiting; see M4.5 in
+         * docs/across-hosts.md.
+         *
+         * Steady rather than exponential, because what is being waited for is a
+         * laptop opening its lid, and the backoff that protects `ssh` from a
+         * machine that is switched off already exists one layer down. Only
+         * while the document is visible: a window in the background has
+         * `revalidateOnFocus` to bring it up to date the moment it is looked at,
+         * and nothing to show in the meantime.
+         */
+        onErrorRetry: (error, _key, _config, revalidate, { retryCount }) => {
+          if (!isDisconnection(error)) return
+          if (document.visibilityState !== 'visible') return
+          setTimeout(() => revalidate({ retryCount }), OFFLINE_RETRY_MS)
+        }
       }}
     >
       <App />

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -447,6 +447,33 @@ export interface GitWarrenApi {
     /** Returns an unsubscribe function. */
     subscribe(listener: (status: UpdateStatus) => void): () => void
   }
+  /** Whether this window or tab can still reach its own core. See `ShellConnection`. */
+  connection: ShellConnection
+}
+
+/**
+ * Whether this shell can still reach the core it was handed.
+ *
+ * Not the same question as whether a *host* is answering, and M4.5 kept the two
+ * apart deliberately. A host that has gone away is learned from requests that
+ * fail (`renderer/lib/host-reachability.ts`); this one cannot be, because a
+ * browser tab whose socket has dropped does not fail its requests at all -
+ * `web/carrier.ts` queues them until it reconnects, so nothing settles and
+ * there is no outcome to read. Only the socket knows.
+ *
+ * They also have different blast radii, which is why they are two banners and
+ * not one component with a branch in it. A machine that is asleep makes *that*
+ * machine's screens stale; a socket that has dropped makes every screen stale,
+ * this computer's included, and while it is down nothing can be claimed about
+ * any host - so its sentence is the one that wins.
+ *
+ * Constant `true` in the Electron window, where the other end of the carrier is
+ * a process that cannot go away without taking this one with it.
+ */
+export interface ShellConnection {
+  connected(): boolean
+  /** Returns an unsubscribe function. */
+  subscribe(listener: (connected: boolean) => void): () => void
 }
 
 /**
@@ -521,6 +548,16 @@ export interface ShellApi {
   system: GitWarrenApi['system']
   updates: GitWarrenApi['updates']
   navigation: GitWarrenApi['navigation']
+  /**
+   * Whether the carrier underneath this shell is up.
+   *
+   * On this side of the line because it is a fact about the transport this
+   * shell built, and the transports differ: the preload has an IPC channel to
+   * its own main process, a tab has a socket that can drop. Not on the
+   * dispatcher for the obvious reason - asking a machine whether it can be
+   * reached only works when it can.
+   */
+  connection: ShellConnection
   /**
    * A picker, then straight into `attachments.ingest`.
    *

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -76,6 +76,20 @@ import type {
 export const RPC_PROTOCOL_VERSION = 1
 
 /**
+ * The first thing a `serve --stdio` daemon writes, and it writes it on stderr.
+ *
+ * Here rather than in `daemon/daemon.ts` because two files need it and they are
+ * on opposite ends of a pipe. The daemon prints it; `core/hosts/ssh.ts` has to
+ * recognise it in order to *leave it out* of what it tells a person went wrong.
+ * That stream carries two completely different kinds of line - a healthy start,
+ * and why the far end died - and M4.5 found the first being quoted as if it
+ * were the second: "The connection to xfor@pc-wsl was terminated (SIGKILL).
+ * [gitwarren-serve] ready (instance …, protocol v1, database: …)". Both halves
+ * true, the second one no help at all.
+ */
+export const DAEMON_READY_PREFIX = '[gitwarren-serve] ready'
+
+/**
  * Who just answered.
  *
  * `instanceId` is the durable identity of the install (`core/instance.ts`) and

--- a/src/web/shell.ts
+++ b/src/web/shell.ts
@@ -38,7 +38,7 @@ import { editorLink, editorTargetFor, linkableEditors } from '@shared/editors'
 import { WEB_PATHS, webAttachmentSrc } from '@shared/web'
 import type { AppInfo, EditorList, ShellApi, UpdateStatus } from '@shared/api'
 import type { Attachment, OpenReviewFileInput } from '@shared/schemas'
-import type { Carrier } from '@shared/rpc'
+import type { WebCarrier } from './carrier'
 
 /** Nothing to unsubscribe from. Returned by the subscriptions a tab cannot have. */
 const NO_SUBSCRIPTION = (): void => {}
@@ -170,7 +170,15 @@ function pickImageFile(): Promise<File | null> {
   })
 }
 
-export function createWebShell(carrier: Carrier): ShellApi {
+/**
+ * `WebCarrier` rather than `Carrier`, since M4.5.
+ *
+ * The extra two methods are `connected` and `onConnectionChange`, and they are
+ * the whole reason this shell can answer a question the preload's cannot: a tab
+ * is the one shell whose link to its own core can go away while the page stays
+ * on screen. See `ShellConnection`.
+ */
+export function createWebShell(carrier: WebCarrier): ShellApi {
   /**
    * Ask the host where the file is, then hand the URL to this machine.
    *
@@ -278,6 +286,22 @@ export function createWebShell(carrier: Carrier): ShellApi {
       installNow: () =>
         unsupported('Installing an update', 'Update GitWarren the way you installed it.'),
       subscribe: () => NO_SUBSCRIPTION
+    },
+    /**
+     * The socket, as the one thing on this page that can quietly stop being
+     * there.
+     *
+     * Passed straight through from the carrier, which has had both halves since
+     * M3 with nothing subscribing to either. What makes it worth surfacing now
+     * is what a drop actually does: in-flight requests are rejected, and
+     * everything after that is *queued* rather than failed - so a tab whose
+     * server has gone away shows the last thing it loaded, forever, with no
+     * spinner and no error. It is the quietest failure in the app and the only
+     * one nothing can infer from an outcome.
+     */
+    connection: {
+      connected: () => carrier.connected(),
+      subscribe: (listener) => carrier.onConnectionChange(listener)
     },
     navigation: {
       // Deep links need no channel here. The route is in the hash, the router

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -33,6 +33,8 @@
     "src/renderer/src/lib/fuzzy.ts",
     "src/renderer/src/lib/__tests__/keys.test.ts",
     "src/renderer/src/lib/__tests__/fuzzy.test.ts",
+    "src/renderer/src/lib/host-reachability.ts",
+    "src/renderer/src/lib/__tests__/host-reachability.test.ts",
     "src/renderer/src/features/reviews/diff-search.ts",
     "src/renderer/src/features/reviews/__tests__/diff-search.test.ts",
     "src/web/loopback-fragment.ts",


### PR DESCRIPTION
The last slice of M4. A host can go away in the middle of being reviewed: the
strip above the screen says so in `ssh`'s own words, the content stays exactly
where it was, and the screen comes back by itself when the machine answers
again. The write-up is under "How it is being built" in `docs/across-hosts.md`.

## The decision the slice turned on

`core/hosts/pool.ts` has carried `onStateChange` since M4.1 with a comment
saying M4.5 would render it. **It is still unwired**, and that is the answer
rather than an omission. A push from the pool has nowhere to travel — `RpcEvent`
is reserved for M6 and nothing emits on it — so it would have meant an Electron
IPC channel for the window *and* a WebSocket message for a tab: two half-built
event channels, in a request/response protocol, for one banner. M4.2 refused
exactly that for a progress bar.

The signal already exists. An open review polls `reviews.open` every fifteen
seconds; that read fails with `HOST_OFFLINE` when the machine goes and succeeds
when it comes back, and `lib/api.ts`'s `ask` is the one place every question to
another computer passes with the host still in scope. What the pool knows and
this does not is the state of hosts *nobody is looking at* — which is the set
with no screen to put a banner on, and is M6's `host.state`. The hook's comment
now says so.

Polling `hosts.list` was the other candidate and is worse than either: the
pool's state only changes when something connects, so the poll would report the
past for ever unless some other read were doing the real work.

## The other disconnection

A tab whose socket drops and a Mac whose `pc-wsl` is asleep are two facts and
two sentences, because neither can see the other's evidence: `web/carrier.ts`
*queues* requests while the socket is down rather than failing them, so nothing
settles and an outcome-based signal is blind to it. `ShellConnection` surfaces
`connected()` / `onConnectionChange()`, which the carrier has had since M3 with
nothing subscribing. It is a constant `true` in the window, whose carrier cannot
lose its other end. `ConnectionBanner` sits above `HostBanner`, because a page
that cannot reach its own core has nothing to say about anybody else's machine.

## What changed

- `lib/host-reachability.ts` — which machines have stopped answering, learned
  from the requests this window is already making. React-free, so its rules have
  a test.
- `onErrorRetry` in `main.tsx` — the heartbeat, for disconnections only.
- `features/hosts/use-reconnect.ts` — one read coming back revalidates
  everything scoped to that machine, by key suffix.
- `HostBanner` gains a disconnection state; `isDisconnection` in `lib/errors.ts`
  is the rule, applied to the six screens that were replacing content.
- `shared/api.ts` `ShellConnection`, implemented in the preload and `web/shell.ts`.

## Verified against pc-wsl, four ways

No reinstall needed — M4.5 adds no method and changes no frame, the first slice
of M4 for which version skew had nothing to say.

- Launcher moved aside **and** the running daemon killed under an open review:
  banner up with *GitWarren is not installed on xfor@pc-wsl…*, 287 lines of
  review and diff unchanged, back **on its own after 32 s** once restored.
- `ssh` killed mid-request: failed in 13 ms with *terminated (SIGKILL)*, nothing
  retried; driven through a real Refresh press the diff stayed and the review
  poll pulled it back **5 s** later.
- Try again: honest failure while away, review back in **0.5 s** when pressed
  after the machine returned (backoff ignored on purpose).
- Cold arrival at a sleeping host: *pc-wsl · Unreachable* in the strip and
  M4.3's card in the content, once rather than twice.
- A comment typed while the machine was away kept its draft, showed `ssh`'s
  sentence in the composer, and the failed **write** is what raised the banner.
- A Chrome tab on the loopback view: app stopped underneath it, banner up,
  content behind it, second sentence after 15 s.
- No console errors or warnings; no horizontal scroll at 390 px.

## Five things bit

1. **SWR's poll stops at the moment there is something to notice** —
   `refreshInterval` is skipped while the cached error is set, and this app has
   had `shouldRetryOnError: false` since M1. The banner was perfect and
   permanent.
2. **A healthy start was quoted as a cause of death** — `describeExit` appends
   the tail of stderr, which is where the daemon's `ready` banner lives. The
   prefix moved to `shared/rpc.ts` so both ends of the pipe agree.
3. **The files tab threw the diff away** — the exact failure the slice exists to
   prevent, found by pressing Refresh rather than by reading.
4. **The badge disagreed with the diff, in both directions** — *Not tried yet*
   over a review that machine had just served, and then again after the first
   fix, because the store treated a first answer as no change.
5. **390 px passed the scroll check and was unreadable** — one word per line
   inside a box measuring exactly 390 px.

## Found next door

A tab cannot reconnect after the app restarts: `core/web/token.ts` mints its
token per launch on purpose, so the socket retries for ever against a 401.
Nothing here changes the token; the banner stops pretending and says a restarted
GitWarren needs a fresh link.

---

**M4 is complete.** The gap table still reads as written — disconnection was
always split between M4 and M6, and what M6 owns is the heartbeat, not the
banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JU34FAZmT9hGLeLnGtwjwm
