### PR TITLE
M6: tailnet and live updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ brew install klarluft/tap/gitwarren-cli   # macOS and Linux, brings its own Node
 
 See [The `gitwarren` command line](#the-gitwarren-command-line).
 
-A cross-platform desktop app for doing local code reviews of your own git
-repositories. Single user, single machine, no server, no account.
+A cross-platform desktop app for doing code reviews of your own git
+repositories, on your own machines. Your machines, your agents, no one else's
+server — and no account.
+
+Reviews live on the machine the code is on. GitWarren reaches your other
+machines over SSH, over `wsl.exe`, or over your own tailnet, and nothing is
+replicated, relayed or stored anywhere but the computers you already own.
 
 Built for the moment a coding agent — Claude Code, Codex, or anything else that
 edits files on your disk — has just finished, and its work is sitting in your
@@ -1645,8 +1650,24 @@ these two are unrelated and both need updating if the branding moves.
 - **Agent names are only as consistent as the client's `clientInfo`.** A client
   that changes the name it sends between versions will appear as two
   participants, and there is no way to merge them after the fact.
-- **Nothing is pushed to the UI.** An agent's comment appears when the window
-  polls (every 15s) or regains focus, not the moment it is written.
+- **Live updates need a machine that is listening.** An agent's comment appears
+  the moment it is written when GitWarren is running on the machine that owns
+  the review — locally, or on a host reached over the tailnet. A host reached
+  over SSH or `wsl.exe` has no process of its own to push from, so there the
+  window still finds out on its next poll (every 15s) or when it regains focus.
+  The poll is the floor everywhere: a lost update costs seconds, never
+  correctness.
+- **A host is only greyed if something has asked it something recently.** The
+  connection pool hangs up after ten idle minutes, so a machine that goes away
+  having been untouched for longer is noticed the next time you look at it
+  rather than the moment it goes. Keeping a socket open to every host would mean
+  connecting to every machine you own, which is the thing the pool exists to
+  avoid.
+- **`tailscale serve` needs to be allowed to run.** On Linux it refuses without
+  root unless `sudo tailscale set --operator=$USER` has been run once; GitWarren
+  reports what Tailscale said rather than silently failing to turn the switch on.
+  HTTPS is a tailnet-wide setting: with it off, your machines are reachable over
+  plain HTTP inside the tailnet, which WireGuard is encrypting either way.
 - **Repo-relative images are not rendered.** `![](docs/arch.png)` in a comment
   stays as written rather than resolving against the repository — it needs a
   second protocol host and repository context threaded into the renderer. Such a

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -3119,7 +3119,7 @@ Before them, one spike that had to happen first, because it decides whether the
 3. **Tailnet exposure, identity, and `webUrl`.** `tailscale serve` behind a
    settings toggle, the gate learning a second way to be satisfied, and the URL
    that goes into an MCP result once a host listens. The phone works at the end
-   of this one.
+   of this one. *(done — see below.)*
 4. **The listening carrier.** The third `HostConnection`: a WebSocket client in
    the app, reaching a machine that listens rather than one it spawns.
 5. **Events across a host, and `host.state`.** `RpcEvent` on a wire in the one
@@ -3494,6 +3494,102 @@ M4.5 and M5 were the only slices with nothing to say about version skew, and
 this is the cheapest possible version of it — two processes from the same
 checkout, one of them stale. Every slice from here needs the app rebuilt and
 restarted before it is asked anything, and a host reinstalled before it is.
+
+**M6.3, done on the Mac against the real tailnet, 11 September.** The biggest
+slice, and the one where the plan's own wording turned out to need checking
+against the machine.
+
+    core/tailnet.ts        what Tailscale knows, asked rather than assumed
+    core/web/exposure.ts   one answer, for three layers that need the same one
+    core/web/origin.ts     a second authority, and a different question on it
+    core/web/handler.ts    the gate, satisfied two ways and never one for the other
+    mcp/gui-link.ts        `webUrl`, when there is one
+    features/settings/tailnet-panel.tsx   the switch
+
+**A second authority, not a second server.** `tailscale serve` proxies from the
+tailnet *to loopback*, so a request from a phone arrives on 127.0.0.1 with
+`Host: mac.tail688c0c.ts.net:41427`. There is no socket to tell the two apart
+by; the header is the whole difference. That makes this a change to
+`isAllowedHost` rather than a listener beside it, and everything `origin.ts`
+already said stays true - a browser cannot change `Host`, so requiring it to be
+one of the two we hand out forecloses rebinding on both.
+
+**The token and the identity header answer different questions, and a request
+satisfies one or the other.** Written into `isTailnetOwner` rather than only
+into this document, because it is the thing most likely to be undone by somebody
+being helpful. `token.ts` asks *did the user point something at GitWarren, or
+does this merely know the port* - about intent, on a machine where every process
+is already the user. The header asks *is the person at the other end the owner* -
+about principal, on a network where intent cannot be checked at all. So a token
+presented on the tailnet authority is **ignored rather than honoured**: a token
+minted on the Mac is not evidence about the person holding a phone. `token.ts`
+is untouched, and M4.5's finding about per-launch minting still stands exactly
+as it did.
+
+The honest bound is in the module rather than implied: a *local* process can set
+the header itself with a tailnet `Host` and get in without the token. It gains
+nothing - it can already read the 0600 token file and open the database - and it
+is the same principal `token.ts` says loopback has. The door that matters stays
+shut, because a web page can set neither `Host` nor `Tailscale-User-Login`,
+both being forbidden header names.
+
+**`webUrl` is derived from what happened, not from the plan's spelling.** The
+plan writes it `https://<host>.<tailnet>.ts.net/review/4/…`. M6.0 found that
+this tailnet has no HTTPS at all, so a URL assembled by convention would have
+been handed to an agent, handed to a person, and refused to open, with nothing
+anywhere having warned. `serveTailnet` asks for HTTPS, falls back to HTTP, and
+reports which it got; the panel and the MCP result both show what the machine
+said. A tailnet that enables certificates later gets `https` on the next toggle
+with no code change.
+
+It also carries the *mount*, which is not cosmetic: the app serves the web build
+at `/app/` and the daemon at `/`, so a URL naming only the origin would land a
+phone on the Electron link page rather than in the app.
+
+**The route in a `webUrl` is an ordinary app hash, and that is M2's two
+notations finally paying off.** A loopback link's fragment is `h=<id>/review/4`
+- a *deep link waiting to be assembled*, handed by the page to a local
+GitWarren which then decides whose review it is. A tailnet URL is not waiting
+for anything: the server answering it is the machine that owns the review, so
+the fragment is `#/reviews/4/conversation` with no host segment, because there
+is no other machine in the story. `deep-link.ts` predicted in M2 that those two
+"stop being the same machine in M4"; this is where they stop.
+
+**The switch is `hosts.setTailnetExposure`, and the prefix is the point.**
+Turning exposure on is genuinely an *act* on a machine, which is the thing the
+dispatcher may never let travel - and it does not, because `isLocalOnly` refuses
+the whole `hosts.` prefix. So a browser tab can expose the install that served
+it, which is exactly what the person running `gitwarren serve` on a headless box
+needs, and a GUI on the Mac cannot reach across and start `tailscale serve` on
+the PC. M5.2 made the same argument for `hosts.distros` and this is the harder
+case it was rehearsing for.
+
+**Verified two ways, and the second one is the one that mattered.**
+`scripts/verify/m6-3.mjs` forges headers against the running app and checks the
+refusals: exposure off is `403` on the tailnet authority; the owner is `200`
+with no token; another login is `401`; no header is `401`; a token on the
+tailnet authority mints no session; an identity header on *loopback* grants
+nothing; the poke endpoint is `404` there; and turning the switch off takes the
+authority and the published `webRoot` away again.
+
+Then the same thing from a machine whose header was stamped by a real
+`tailscaled` rather than by the test: from `pc-wsl`, `GET
+http://mac.tail688c0c.ts.net:41427/app/` answered **200**, and
+`/gitwarren/app-info` came back with the Mac's instance id - a second computer,
+through the proxy, through the gate, with no configuration on either side beyond
+the switch. And the half that could have failed silently: the same request with
+upgrade headers answered **101 Switching Protocols**, which is M6.4's carrier
+proved before a line of it was written.
+
+**One thing bit, and a test found it rather than a machine.** `isAllowedOrigin`
+accepted *either* authority's origin on *either* authority, so a page on
+loopback could act on the tailnet authority. Nothing escalated - both pages are
+ours, and both had already got through the gate - but the shape was wrong, and
+what makes it worth recording is that the comment above the function already
+said the right thing ("what neither may be is *the other one*") while the code
+did not. A page acts on the server that served it; the origin check now takes
+which authority the request arrived at and accepts exactly one value. The next
+authority added would have been wrong the same way.
 
 ## Agent setup
 

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -3126,7 +3126,7 @@ Before them, one spike that had to happen first, because it decides whether the
    direction nothing has exercised, and the pool's `onStateChange` finally
    rendered — which is what greys a machine nobody is looking at. *(done — see below.)*
 6. **Discovery.** Peers from `tailscale status --json`, proposed rather than
-   added.
+   added. *(done — see below.)*
 7. **Links across installs, and the words.** What a `gitwarren://<other-id>/…`
    link does now that there is somewhere for it to go, and the README, the
    tagline and Known limitations catching up with the thing that shipped.
@@ -3255,17 +3255,24 @@ to every machine on the list, which is what `core/hosts/pool.ts` exists to avoid
 and what M4.3 refused to do to render a home screen — and it would be worse
 here, because the list includes machines that are not this user's problem.
 
-So it is a screen-triggered read with a bounded cost, and the cost is worth
-computing rather than hand-waving. The candidate set is peers from `tailscale
-status --json` that are `Online` and carry the same `UserID` as `Self` — an
-ownership check from the same file the identity check reads, not a guess. Each
-candidate gets one HTTP `GET` with a one-second timeout. A phone is not
-filtered out by its `OS` field, because a blocklist of operating systems is the
-same shape as M5.2's blocklist of distribution names and goes stale the same
-way; it is filtered out by *answering nothing*, which costs a refused TCP
-connect in single-digit milliseconds. Nine phones and one PC is ten parallel
-connects, nine of them refused, once, when a screen is opened. That is the
-whole bill.
+So it is a screen-triggered read with a bounded cost. The candidate set is
+peers from `tailscale status --json` that are `Online` and carry the same
+`UserID` as `Self` — an ownership check from the same file the identity check
+reads, not a guess. Each candidate gets one HTTP `GET` with a one-second
+timeout, all of them in parallel. A phone is not filtered out by its `OS`
+field, because a blocklist of operating systems is the same shape as M5.2's
+blocklist of distribution names and goes stale the same way; it is filtered out
+by *answering nothing*.
+
+*(This paragraph originally said that answering nothing "costs a refused TCP
+connect in single-digit milliseconds", and M6.6 measured otherwise: on a real
+tailnet a peer with nothing on the port takes about 800 ms to refuse, because
+reaching it means NAT traversal or a relay first. The bill is therefore not
+"nine cheap refusals" but **one probe timeout, once, however many peers there
+are** — measured at 1046 ms for this four-node tailnet. The estimate was wrong
+in a way that does not change the design and does change what the number means,
+which is exactly the sort of thing worth leaving visible rather than quietly
+editing.)*
 
 *Discovery proposes; it never adds.* `isLocalOnly` refuses the whole `hosts.`
 prefix so that a hub cannot be talked into becoming a mesh, and a discovery that
@@ -3766,6 +3773,73 @@ local shell, `ssh`'s own concatenation of its arguments, and the remote *zsh*
 that M4.2 found is the login shell on that box. A script file crosses once and
 is read by `sh`. It is the same lesson M5.1 learned about `wsl.exe --`, in a
 place where it cost a confusing half hour rather than a bug.
+
+**M6.6, done on the Mac against the real tailnet, 11 September.** "The PC
+appears on the Mac with no configuration", and the design work was all in the
+second half of that sentence rather than the first.
+
+**What "no configuration" constrains is what the *user* types, not what the app
+does while nobody is watching.** So discovery runs when somebody opens the Hosts
+screen, or presses "Look again", and at no other time - no timer, no startup
+scan, no revalidation on focus. Probing every peer on a schedule would be a
+connection to every machine you own, which is what `core/hosts/pool.ts` exists
+to avoid and what M4.3 refused to do to render a home screen.
+
+The SWR options on `CACHE_KEYS.discovered` say so explicitly rather than by
+omission - `revalidateOnFocus: false`, `revalidateIfStale: false`,
+`refreshInterval: 0` - because this is the one read in the application that
+costs a connection attempt per peer, and a default that is right everywhere else
+is wrong here.
+
+**The probe is a `GET`, not `app.instance` over a carrier.** A method needs the
+socket, the socket needs an upgrade, and that is a lot of ceremony to ask of
+peers that will not answer - but the better reason is what it *means*: a probe
+is asked of machines this install has no relationship with, and opening a
+carrier to one is a stronger act than asking whether anybody is home. It is
+`WEB_PATHS.discover`, behind the same gate as everything else, so on the tailnet
+authority it requires the owner's login and only the owner's own devices can
+learn that a machine runs GitWarren. What it answers is `HostIdentity` - the
+same shape `app.instance` returns, shared rather than rebuilt, because it is the
+same question asked before there is a connection rather than after.
+
+**It proposes; it never adds.** `isLocalOnly` refuses the whole `hosts.` prefix
+so a hub cannot be talked into becoming a mesh, and a discovery that inserted
+rows would have walked around that from the other side.
+
+**And a machine you already have is shown rather than hidden, naming the row.**
+This is the case the brief asked to be checked and it is not hypothetical:
+`pc-wsl` is already an `ssh` row on this Mac from M4 and it is the same box.
+Dropping it from the list would be M5.2's rejected blocklist all over again - a
+listing that silently omits rows is one you cannot trust when what you wanted is
+missing. So it appears with *Already added as pc-wsl* where the button would be.
+M4.1's collision report says the same thing on connect, after an insert; here
+the instance id arrived with the probe, so it can be said before anybody presses
+anything.
+
+**Verified with an empty host list.** `scripts/verify/m6-6.mjs`: nothing
+configured, `hosts.discover` found `pc-wsl.tail688c0c.ts.net` running
+0.1.7-beta.1 and reporting `4e0b0adb…`; this Mac was not proposed to itself;
+adding the proposal produced a working host on the first probe with the instance
+id discovery already knew; a second scan reported it as *Already added as
+pc-wsl*; and with the row replaced by an `ssh` row for the same machine, it was
+still reported as already added rather than offered as new.
+
+**The estimate in the plan was wrong, and it is left visible.** That paragraph
+said a peer with nothing on the port costs "a refused TCP connect in single-digit
+milliseconds", so the bill would be "nine cheap refusals". Measured: the phone
+on this tailnet takes **768 ms** to refuse, and a full scan of four nodes takes
+**1046 ms**. Refusing means being *reached* first, and on a tailnet that is NAT
+traversal or a relay before there is anything to refuse with.
+
+So the honest description of the cost is the opposite shape: not many small
+things, but **one probe timeout, once, however many peers there are**, because
+they run in parallel. Nothing about the design changes - it was already
+parallel, already bounded, already screen-triggered - but what
+`PROBE_TIMEOUT_MS` is choosing turns out to be the duration of the whole scan
+rather than a safety net on a fast case, and the comment on it now says that.
+The guess was wrong in a way that would have been invisible on a LAN and is the
+first thing anybody notices on a tailnet, which is the argument for measuring
+against the real one in one sentence.
 
 ## Agent setup
 

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -3952,6 +3952,89 @@ that have to precede it; the lesson is the M6.2 one again, one layer down - a
 protocol change is a protocol change even when both ends came from the same
 checkout.
 
+**M6 is complete, with one part of the verify line left for a person.** From the
+Mac, a machine on the tailnet is *found* rather than typed in; it is reached
+over a socket rather than a process started on it; a comment an agent writes
+over there appears here in a quarter of a second; switching it off greys it in
+about the same, with nothing open on it and nothing having asked it anything;
+and a review on it has a URL that opens in a browser on any device the owner is
+signed in on.
+
+The verify line, run end to end on 11 September:
+
+| | |
+| --- | --- |
+| PC appears on the Mac with no configuration | `hosts.discover` found `pc-wsl.tail688c0c.ts.net` with an empty host list and nothing typed; adding the proposal worked on the first probe. |
+| An agent comment shows on the Mac within a second | **261 ms**, four hops, tagged `4e0b0adb…`, and on the open review with nobody touching the window. |
+| Turn the PC off: greyed within seconds, no stale data | **173 ms**, from the pool noticing its own socket rather than from a failed request. The host list said *The connection to pc-wsl.tail688c0c.ts.net:41427 was lost.* |
+| Phone on the tailnet opens a `webUrl`, leaves a comment, the agent reads it | The PC's own agent emits `webUrl: http://pc-wsl.tail688c0c.ts.net:41427/#/reviews/2/conversation`, and that URL serves the web build and its bundle to a *different device* with no token. **Opening it in a phone's browser is the one step nothing here could drive**, and is recorded as unverified rather than claimed. |
+
+**What M6 did not change, and that is most of the point.** The fifteen-second
+poll, `onErrorRetry`, `revalidateOnFocus`, M4.5's banner and
+`renderer/lib/host-reachability.ts` are all exactly as M5 left them. Delete
+`core/events.ts` and this application is M5: slower, never wrong. That is what
+"additive" had to mean, and it is checked rather than asserted - `mutate` on a
+key with no subscriber does nothing at all, so an event about a review nobody
+has open costs one map lookup.
+
+**Three carriers now, and the contract held.** `core/hosts/carrier.ts` was
+extracted in M5 with the guess that a third implementation would be a *user* of
+it rather than a parallel one, and that turned out to be true in the place it
+mattered least and the place it mattered most: the pool gained a `case`, and
+`createStdioClient` - written for a pipe, reused for `wsl.exe` - was reused
+again for something that is not a pipe at all. The one thing the new carrier
+could not inherit was `diagnostics()`'s *source*, there being no stderr; it has
+an HTTP status and a close code instead, which are better, and which arrive
+after the failure in exactly the way M4.1 discovered an exit status does.
+
+**Four things are worth keeping separately from the slices.**
+
+*The two questions that must not be collapsed stayed uncollapsed, and the code
+says which is which.* `core/web/token.ts` asks about *intent* on a machine where
+every process is already the user; `isTailnetOwner` asks about *principal* on a
+network where intent cannot be checked. A request satisfies one or the other,
+a token on the tailnet authority is ignored rather than honoured, and an
+identity header on loopback grants nothing. `token.ts` is untouched, so M4.5's
+finding about per-launch minting still stands exactly as written.
+
+*Two of the four things that bit were already written down in this repository.*
+The WebSocket carrier refused the very request that caused it to exist -
+`web/carrier.ts` names that as the first of the three things a socket has that
+an IPC channel does not, and has since M3. And `isAllowedOrigin` accepted either
+authority's origin on either authority, while the comment directly above it said
+"what neither may be is *the other one*". Both were found by running the thing.
+The lesson is not "read more carefully"; it is that a prose invariant and a
+predicate drift apart silently, and only an execution notices.
+
+*Version skew is a mechanism problem now rather than a design one.* M4.1–M4.4
+each needed a reinstall and each knew it. M6 needs one too - it adds four
+methods, an endpoint and an event - but `hosts.install` compares *version
+strings*, and a pre-release that changes its protocol without changing its
+version answers `already-current` and does nothing. `force` is the way out and
+was needed twice. Recorded in the gap table rather than fixed here, because the
+fix is a question about what identifies a build and that is a decision rather
+than a patch.
+
+*One estimate in this document was wrong and is left visible.* The discovery
+section predicted that a peer with nothing on the port would refuse "in
+single-digit milliseconds"; measured on the real tailnet it takes about 800 ms,
+because refusing means being reached first. Nothing about the design changed -
+it was already parallel, bounded and screen-triggered - but the *shape* of the
+cost did, from "many cheap refusals" to "one probe timeout, once, however many
+peers there are". Wrong in a way that would be invisible on a LAN and is the
+first thing anyone notices on a tailnet, which is the argument for verifying
+against the real one in a sentence.
+
+**And the thing that is still owed, again.** `ci.yml` runs ubuntu only. M5
+recorded that every Windows-shaped failure in this repository had been found by
+a person sitting at a Windows machine; M6 adds a Linux-shaped one to the pile -
+`tailscale serve` needs `--operator` there and succeeds silently as the user on
+macOS, so the switch works on the machine most likely to be *developed* on and
+fails on the machine most likely to be a *host*. A CI job that runs on more than
+one platform is the honest fix, it is a change to how this project is tested
+rather than to what it does, and it is still deliberately not part of a
+milestone.
+
 ## Agent setup
 
 One sentence instead of a snippet per harness. Agents know their own

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -3097,6 +3097,327 @@ server" to "your machines, your agents, no one else's server". Update Known
 limitations as each milestone retires one ("nothing is pushed to the UI" goes
 at M6).
 
+#### How it is being built, and where it has got to
+
+Seven changes. M6 is the only milestone with five bullets in its own
+description, and the reason it needs more slices than M4's five or M5's four is
+that three of the five are only testable with a second machine awake and one of
+them only with a phone — so the cut has to put each of those where the thing it
+needs is already true.
+
+Before them, one spike that had to happen first, because it decides whether the
+`webUrl` in M6's fifth bullet is spelled `https` or `http`:
+
+0. **`tailscale serve` in front of the loopback port.** S1 proved Tailscale SSH.
+   What was unproven is the proxy, the identity header, and whether a WebSocket
+   survives the hop. *(done — see below.)*
+1. **The event channel, and what an event is allowed to carry.** `core/events.ts`,
+   a write emitting on it, both shells carrying it to a renderer, and a renderer
+   that treats what arrives as a reason to re-ask. One machine; no tailnet. *(done — see below.)*
+2. **The poke from the MCP process.** An agent's write reaching the owner of the
+   data directory over the loopback port it already publishes.
+3. **Tailnet exposure, identity, and `webUrl`.** `tailscale serve` behind a
+   settings toggle, the gate learning a second way to be satisfied, and the URL
+   that goes into an MCP result once a host listens. The phone works at the end
+   of this one.
+4. **The listening carrier.** The third `HostConnection`: a WebSocket client in
+   the app, reaching a machine that listens rather than one it spawns.
+5. **Events across a host, and `host.state`.** `RpcEvent` on a wire in the one
+   direction nothing has exercised, and the pool's `onStateChange` finally
+   rendered — which is what greys a machine nobody is looking at.
+6. **Discovery.** Peers from `tailscale status --json`, proposed rather than
+   added.
+7. **Links across installs, and the words.** What a `gitwarren://<other-id>/…`
+   link does now that there is somewhere for it to go, and the README, the
+   tagline and Known limitations catching up with the thing that shipped.
+
+**What was settled before any of it was written.**
+
+*An event is a refetch hint, and that is the same rule as "a lost request is
+never retried".* The doc already said the first and `core/rpc/stdio-client.ts`
+already said the second, and it is worth writing them as one idea rather than
+two rules, because a person who holds the idea will get the next case right on
+their own.
+
+The idea is that **a message may never stand in for the asking side's own
+knowledge.** A retry decides, on the caller's behalf, what a missing answer
+meant — and it cannot know, so for `comments.reply` it guesses wrong by posting
+a second comment. An event carrying data decides, on the screen's behalf, that
+the push and the database agree — and it cannot know that either, because the
+push crossed a network that reorders, drops and duplicates, while the database
+is the thing that is actually true. Both replace evidence with inference, and
+both are the sort of wrong that is invisible until it matters.
+
+So an event carries a *name and a scope* and nothing else: "something about
+review 4 on this machine changed". What it produces is the read the poll would
+have done anyway, only sooner. Two consequences fall straight out and both are
+load-bearing. A lost event costs latency and never correctness, which is what
+makes the fifteen-second poll a genuine fallback rather than a story told about
+one. And an event that arrives out of order, twice, or about something that has
+since changed again is harmless, because the answer comes from re-asking rather
+than from the message.
+
+*An event for a host nobody is looking at is dropped, and dropping it is the
+point rather than a gap.* This is the case the channel was supposed to exist
+for, so it deserves the sentence. If an event is a refetch hint, then an event
+about a review with no screen on it has nothing to invalidate: SWR has no
+subscriber for that key, `mutate` finds nothing, and the cost is one map lookup.
+When somebody does open that review the read happens then and is current. There
+is no backlog to replay and no queue to bound, which is what a channel carrying
+data would have needed.
+
+`host.state` is the exception, and it is worth being precise that **the banner
+is not what it is for**, because that is the thing M4.5 was careful about and
+the thing it would be easy to undo here. M4.5's banner is raised by request
+*outcomes* and stays that way: a request that failed is evidence about the
+screen in front of someone, and it is carrier-agnostic — M5 proved that against
+`wsl.exe` with no new code. `renderer/lib/host-reachability.ts` is not replaced
+and does not read events.
+
+What `host.state` adds is the machine with no screen on it at all, and the
+mechanism is narrower than it first looks. The pool only learns anything by
+*connecting*, so for most of M4 a host nobody was asking about was a host
+nothing could have said anything about. What changes here is that a listening
+carrier holds an open socket with a heartbeat on it (`WEBSOCKET_HEARTBEAT_MS`,
+30 seconds, written at M3 with the sentence "over the tailnet in M6 it is
+Tuesday"). A machine that is switched off kills that socket, the pool notices,
+and the Hosts screen greys a row *without anybody having asked it anything*.
+That is the whole of what M6 adds to disconnection, and it is why the verify
+line says "turn the PC off" rather than "open a review and turn the PC off".
+
+*One channel, two sources, and that is the cheap answer to M4.5's objection.*
+`host.state` is about a machine and is known only to this install's pool;
+`reviews.changed` is about data and is known only to the machine that owns it.
+They look like two channels and they are not, because what they do at the far
+end is identical: invalidate a key family. So `core/events.ts` is one bus with
+two sources — the pool emits straight onto it, and an `RpcEvent` arriving from
+a host is re-emitted onto it tagged with the host it came from — and one
+subscription in the renderer drains it. M4.5 refused "two half-built event
+channels for one banner"; what it was objecting to was the *cost*, and one bus
+carrying names is most of that cost removed.
+
+*Identity and the token are two different questions, and a request satisfies
+exactly one of them.* This is the thing that must not be collapsed, so here is
+the difference stated in the form the code checks.
+
+`core/web/token.ts` answers **"did the user point something at GitWarren, or
+does this merely know the port?"** — a question about *intent*, asked on
+loopback, where the principal is uninteresting because every process the user
+runs is already the user. The tailnet header answers **"is the person at the
+other end the owner?"** — a question about *principal*, asked over a network,
+where intent cannot be checked at all and the principal is the whole of it.
+
+So a request is admitted when it is loopback-with-token **or**
+tailnet-with-owner-login, and never by one standing in for the other. In
+particular a token presented on a tailnet request is *ignored rather than
+honoured*: a token minted on the PC is not evidence about the person holding a
+phone, and accepting it would be precisely the collapse. This also keeps
+`token.ts`'s three properties untouched — M4.5 found the consequence of
+per-launch minting from the tab's side and deliberately did not change it, and
+nothing here changes it either.
+
+The honest boundary, written down because the alternative is pretending the
+header is unforgeable: `Tailscale-User-Login` is set by `tailscaled` on this
+machine, which also proxies to loopback, so a *local process* could send the
+header itself with a `Host` naming the tailnet authority and get in without the
+token. That grants it nothing, because a local process running as the user can
+already read the 0600 token file and open the SQLite database directly — it is
+the same principal `token.ts` says loopback has. The door that stays shut is the
+one that matters: a web page cannot set `Host` or `Tailscale-User-Login`, both
+being forbidden header names, so the DNS-rebinding attack `origin.ts` was built
+against is closed exactly as it was.
+
+*The MCP process pokes the owner over the port the owner already publishes, and
+a host with no owner has no push.* The doc offered a counter in
+`daemon-runtime.json` or a local socket. A counter in a file is a poll with
+extra steps — the GUI would have to watch the file, and `fs.watch` is per
+platform, unreliable on network filesystems and a timer underneath on several
+of them. So: a socket, and the one already there. `daemon-runtime.json` names
+the owner's pid and its `linkPort`, the owner is serving a gated HTTP server on
+it, and the token sitting in a 0600 file next door is readable by exactly the
+principal that may poke — the user. One `POST` under `WEB_PREFIX`, token
+required, `Origin` required and ours, and the MCP process is a client of a
+server that already existed.
+
+The consequence is worth stating plainly rather than discovering: **a daemon
+spawned over `ssh` or `wsl.exe` owns nothing.** It binds no port and writes no
+runtime file, deliberately, since M2 — a data directory has one owner and a
+stdio daemon is not competing to be it. So an agent writing on a host reached
+that way pokes nobody, and the fifteen-second poll is what notices. The remedy
+is not a new mechanism; it is the toggle in slice 3, which gives that host an
+owner. Turning on "Reachable on your tailnet" is what buys live updates, and
+saying so is better than building a second channel for the case where it is off.
+
+*Discovery runs when somebody opens the Hosts screen, and never on its own.*
+"With no configuration" is about what the *user* types, not about what the app
+does while nobody is watching. Probing every peer on a schedule is a connection
+to every machine on the list, which is what `core/hosts/pool.ts` exists to avoid
+and what M4.3 refused to do to render a home screen — and it would be worse
+here, because the list includes machines that are not this user's problem.
+
+So it is a screen-triggered read with a bounded cost, and the cost is worth
+computing rather than hand-waving. The candidate set is peers from `tailscale
+status --json` that are `Online` and carry the same `UserID` as `Self` — an
+ownership check from the same file the identity check reads, not a guess. Each
+candidate gets one HTTP `GET` with a one-second timeout. A phone is not
+filtered out by its `OS` field, because a blocklist of operating systems is the
+same shape as M5.2's blocklist of distribution names and goes stale the same
+way; it is filtered out by *answering nothing*, which costs a refused TCP
+connect in single-digit milliseconds. Nine phones and one PC is ten parallel
+connects, nine of them refused, once, when a screen is opened. That is the
+whole bill.
+
+*Discovery proposes; it never adds.* `isLocalOnly` refuses the whole `hosts.`
+prefix so that a hub cannot be talked into becoming a mesh, and a discovery that
+inserted rows would walk around that from the other side. Found peers appear as
+a proposal with an Add button. A peer whose instance id already names a row is
+shown as already added, naming the row it collided with — which is M4.1's
+collision report doing its job one step earlier, before the insert rather than
+after it. M5.2 fired that report for real and drew the conclusion this relies
+on: one machine is one row even when two carriers reach it, because
+`#/h/<instance>/…` routes by instance id and two rows bearing one id make every
+remote route ambiguous. `pc-wsl` is already an `ssh` row on this Mac, so it is
+the case discovery meets first rather than a hypothetical.
+
+**M6.0, done on the Mac against the real tailnet, 11 September.** Three
+questions, and the third one had a surprise in it.
+
+*The identity header arrives, and it survives a WebSocket upgrade.* `tailscale
+serve --bg --http=8080 http://127.0.0.1:43111` in front of a header-echoing
+server produced `tailscale-user-login: michal-wrzosek@github` on an ordinary
+`GET` — from the Mac itself, and from `pc-wsl` over the tailnet — and on the
+upgrade request of a `ws://` connection that then carried frames both ways. The
+upgrade is the half that could have failed silently, because a proxy that
+forwards headers on requests and drops them on upgrades would have left the
+gate working for the phone and refusing every carrier.
+
+*The proxy connects from loopback, which is what makes this a change to the
+gate rather than an addition beside it.* `req.socket.remoteAddress` is
+`127.0.0.1` for a request that came from another machine, and `Host` is
+`mac.tail688c0c.ts.net:8080`. So the existing `isAllowedHost` refuses it — not
+because the request is suspect, but because "the authority this server was
+reached at" now has two legitimate values instead of one. `x-forwarded-for`
+carries the peer's tailnet IP, which is how the two are told apart from the
+inside.
+
+*`--https` is not available on this tailnet, and the milestone has to be
+honest about it rather than assume.* `tailscale serve --bg --https 8443` hangs
+with no output; `tailscale cert` says why — *your Tailscale account does not
+support getting TLS certs*, which is HTTPS certificates being off for the
+tailnet rather than anything about this machine. `--http` applies instantly and
+needs no certificate.
+
+The consequence for the fifth bullet is that a `webUrl` spelled
+`https://<host>.<tailnet>.ts.net/review/4/…` by *convention* would be a URL
+that does not open, on a tailnet where nothing warned anybody. So `webUrl` is
+**derived from what this install actually did** — the scheme and port it asked
+`tailscale serve` for, and the `DNSName` from `tailscale status --json` →
+`Self` — rather than assembled from a template. It is the same rule
+`core/mcp-launcher.ts` follows for the launcher path: a fact reported by the
+machine that knows it beats a string that is usually right.
+
+Plain HTTP over a tailnet is not plaintext on a network: WireGuard is doing the
+encryption a layer down, between the two machines, and `tailscale serve`
+refuses to leave the tailnet at all — that is what `funnel` is for and it is a
+non-goal here. Enabling HTTPS in the admin console is a one-click improvement
+and the code takes it automatically when a certificate is obtainable, because
+it reads what happened rather than deciding in advance.
+
+The port is `LINK_SERVER_PORT`, the same 41427 on the tailnet as on loopback.
+S6 chose that number so a link written on one machine on Tuesday opens on
+another on Thursday; a tailnet URL that used a different one would be a second
+number to defend for no benefit, and the port is not what makes the two
+authorities different.
+
+**M6.1, done on the Mac, 11 September.** The claim in `shared/rpc.ts` turned out
+to be true, and checking it first was worth most of a slice. `RpcEvent` and
+`isRpcEvent` have been sitting there since M1 with nothing emitting on them, and
+`core/rpc/stdio-client.ts` was written in M4 against that shape — it reads a
+frame, asks `isRpcEvent`, and hands anything that is one to `onEvent` rather
+than looking for a request to answer. The comment said the shape was there so
+"the message simply arrives", and it does: **the stdio carrier needed no change
+at all**, which is the difference between M6 having five carriers to teach and
+three.
+
+What did need teaching was the browser's carrier, and it is the same lesson from
+the other side. `web/carrier.ts` dropped anything without a numeric id —
+`if (!response || typeof response.id !== 'number') return` — which is a
+perfectly good guard against a malformed frame and also, silently, against every
+event that would ever be pushed to a tab. It now asks `isRpcEvent` first, using
+the shared discriminator rather than "has no id", because the two ends of that
+socket have to agree about what a frame is and one of them is a Node process.
+
+    core/events.ts          one bus, two sources, names only
+    core/rpc/dispatcher.ts  a write that succeeded announces itself
+    main/events.ts          the window's half, four lines
+    web/carrier.ts          the tab's half, and the guard that hid it
+    renderer/lib/events.ts  a hint becomes a `mutate`
+    renderer/lib/event-scope.ts  which keys, on which machine
+
+**The emit is in the dispatcher because that is where the human surface already
+was.** M1 put `HUMAN_AUTHOR` there and wrote down why: agents do not come
+through the dispatcher at all — the MCP server imports `core/services` directly
+— so the boundary *is* the enforcement. The same boundary answers "who
+announces a write", and it answers it the same way: a person's writes announce
+themselves here, and the agent's process announces its own (M6.2). Putting the
+emit in the services would have covered both in one place and thrown that
+distinction away, and it is the distinction the next three slices are built on.
+
+`EVENT_FOR_METHOD` is a table someone maintains rather than a guess from the
+method name, for the reason `READ_METHODS` is: being wrong is silent in both
+directions. A missing entry is a screen that waits fifteen seconds; an extra one
+is a refetch nobody needed; neither is a type error.
+
+**The event names a family, not a row, and that is what makes it the same
+behaviour as a local write rather than a second one.** `comments.reply` names a
+thread and `comments.remove` names a comment, so deriving "review 4" would mean
+a database lookup in the one place that must not fail after a write has already
+committed. It does not need to, because the renderer's own writes already
+invalidate by family — `mutate(key => key.startsWith('reviews:'))` — so an event
+doing exactly that is one code path rather than two. If a local write refreshes
+the right screens, a remote one now does too, by the same lines.
+
+**The scoping is a suffix, and it is the only part with a test.** `scoped()` in
+`lib/api.ts` puts `@<instance>` on the *end* of every key a host owns, so
+"everything about that machine" is `endsWith` — the same trick
+`use-reconnect.ts` uses from the other direction. An event from `pc-wsl`
+refreshes `pc-wsl`'s keys and leaves this Mac's alone. Getting that wrong would
+have been invisible: every screen still correct, and six machines' worth of
+SQLite re-read whenever an agent typed anything. So the rule moved into
+`renderer/lib/event-scope.ts`, which has **no imports at all** — the same shape
+`host-reachability.ts` chose and for the same reason. `lib/events.ts` cannot be
+a node program, because it reads `CACHE_PREFIXES` from `lib/api.ts` and that
+module throws at import without `window.gitwarren`, deliberately; the rule can
+be, and the rule is the part worth pinning down.
+
+**Verified on one machine with two shells, which is the arrangement that already
+existed.** The Electron window reaches the core over IPC and a browser tab
+reaches the same process over the loopback socket, so a write arriving on one
+and being noticed on the other has crossed the whole channel. `scripts/verify/
+m6-1.mjs` plays the tab with `ws`, the session cookie and the real `Origin`, so
+what it exercises is the same upgrade, the same gate and the same
+`serveWebSocket` a browser gets.
+
+A comment written on the socket reached the window's carrier in **2 ms**,
+carrying `{event: "comments.changed", data: null}` and no host — correctly, since
+this core *is* the window's own install. A reply typed in the window reached the
+socket. Three reads — `reviews.open`, `reviews.diff`, `repositories.list` —
+produced no events at either end, which is the check that matters most, because
+an event per read is a refetch storm that looks exactly like working software.
+
+And the part a person actually sees: with the conversation tab open on review 1,
+a comment written over the socket **appeared in the window with nothing
+touching it** — no focus, no navigation, no fifteen-second wait. That is the one
+step that would still have been missing if the scoping were wrong, and nothing
+earlier in the script would have noticed.
+
+**What is still a poll, deliberately.** Everything. The fifteen seconds,
+`onErrorRetry`, `revalidateOnFocus` and M4.5's banner are untouched, and the
+application with `core/events.ts` deleted is M5 exactly — slower, never wrong.
+That is the property "additive" has to mean, and it is worth checking rather
+than asserting: `mutate` on a key with no subscriber does nothing at all, so an
+event for a review nobody has open costs one map lookup and produces no read.
+
 ## Agent setup
 
 One sentence instead of a snippet per harness. Agents know their own

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -3121,7 +3121,7 @@ Before them, one spike that had to happen first, because it decides whether the
    that goes into an MCP result once a host listens. The phone works at the end
    of this one. *(done — see below.)*
 4. **The listening carrier.** The third `HostConnection`: a WebSocket client in
-   the app, reaching a machine that listens rather than one it spawns.
+   the app, reaching a machine that listens rather than one it spawns. *(done — see below.)*
 5. **Events across a host, and `host.state`.** `RpcEvent` on a wire in the one
    direction nothing has exercised, and the pool's `onStateChange` finally
    rendered — which is what greys a machine nobody is looking at.
@@ -3590,6 +3590,104 @@ said the right thing ("what neither may be is *the other one*") while the code
 did not. A page acts on the server that served it; the origin check now takes
 which authority the request arrived at and accepts exactly one value. The next
 authority added would have been wrong the same way.
+
+**M6.4, done on the Mac against the real tailnet, 11 September.** The third
+`HostConnection`, and the first that does not start a process. `ssh.ts` and
+`wsl.ts` both spawn `gitwarren serve --stdio` and own its lifetime; here the
+daemon was running before this app opened and will still be running after it
+quits.
+
+M5's extraction earned its keep: `core/hosts/carrier.ts` is used rather than
+paralleled, `createStdioClient` is reused for something that is not a pipe at
+all, and `core/hosts/pool.ts` gained a `case` and nothing else. Everything about
+*when* to connect - the idle timeout, the backoff ladder, the once-per-
+generation failure count - applied unchanged to a carrier it was written years
+of milestones before.
+
+**What a socket has instead of stderr and an exit.** The other two carriers
+explain a failure from the last few lines the far end printed, and wait for an
+exit to get them. There is no such stream here, and the substitutes are
+better: the HTTP status of a refused handshake, and the close code of a
+connection that stopped. Both arrive *after* the event that made anyone ask,
+which is the M4.1 lesson in a new shape, so `diagnostics()` waits the same
+`EXIT_GRACE_MS` for the same reason.
+
+The statuses need translating, and that is the part worth having written. A
+`401` over the tailnet is never about a token - the token is not consulted on
+that authority at all - so the sentence is *"pc-wsl does not recognise you as
+its owner. Both machines have to be signed in to the same Tailscale account."*
+A `403` means the switch is off over there, and says so.
+
+**And a heartbeat, for a reason the server's does not cover.**
+`core/rpc/websocket.ts` has pinged since M3 with a comment predicting that
+half-open connections would be "Tuesday" over the tailnet. That one protects the
+*server* from tabs that went away. This end needs its own, because the thing
+M6.5 is about is a machine switched off with nobody looking at it - and a
+carrier that only learns from requests would learn nothing, there being no
+requests. Ten seconds between pings, thirty seconds of silence before the
+connection is given up on.
+
+**Installing onto a listening host is refused, and it is not a gap.** `ssh` and
+`wsl.exe` reach a machine by starting a process on it, which is what makes an
+installer possible; a WebSocket reaches a daemon, and everything a daemon can be
+asked is a method on the dispatcher - which may never start a process. A
+listening host is one that already has GitWarren on it *by construction*: if it
+did not, there would be nothing to connect to. The message says to update it at
+that machine, or to add it as an SSH host.
+
+**The target is stored as an origin, not as typed.** `pc-wsl` and
+`http://pc-wsl:41427` are the same machine, and letting both into the table
+would be two rows the unique index cannot see are one - caught later by M4.1's
+collision report, far later than it needs to be. So `normaliseTarget` runs on
+add, the stored value is what the carrier uses, and a host that worked yesterday
+is not re-guessed today. That last point is M6.0's finding again: whether a
+tailnet can do HTTPS is a property of the *tailnet*, so the scheme is a fact to
+be remembered rather than a default to be applied.
+
+**Verified over a genuine tailnet hop.** `scripts/verify/m6-4.mjs`, with this
+install added as a websocket host under its own MagicDNS name: the request
+leaves the app, goes out to `tailscaled`, comes back through `tailscale serve`
+to loopback with an identity header, through the gate, and is answered. **48
+ms.** The instance id and the daemon version were learned and written back, the
+install attempt was refused with `FORBIDDEN`, `hosts.list` was answered locally
+rather than forwarded, and a name that does not resolve failed with *"could not
+be found. It may be off the tailnet."*
+
+Both ends being this machine makes it a smaller test than the milestone's verify
+line and not a fake one: every part between them - the proxy, the header, the
+gate, the socket - is the real thing, and none of it knows the two ends are
+related.
+
+**Two things bit, and the first is the more embarrassing.**
+
+*A carrier that refuses the request that caused it to exist is not a carrier.*
+The pool opens a connection *because* something asked a question, so the first
+request is always in flight before the handshake finishes - and every one of
+them failed in five milliseconds with "the connection is not open". This is
+written down in `web/carrier.ts`, in as many words, as the first of the three
+things a socket has that an IPC channel does not; it was written at M3 and had
+to be learned again here by watching it fail. Frames are queued until `open` and
+flushed, and the queue is dropped rather than drained if the socket dies, because
+retrying is the carrier deciding what a missing answer meant.
+
+The fix improved the diagnosis for free, which is the tell that it was the right
+one: a name that does not resolve used to report "not open" - true, useless, the
+exact failure mode M4.1's `diagnostics()` exists to prevent - and now reports
+what DNS said, because the request waits long enough to be told.
+
+*`tailscale serve` needs root on Linux, and the app was silent about it.* On
+this Mac the command succeeds as the user. On `pc-wsl` it refuses with *Access
+denied: serve config denied* and names the remedy - `sudo tailscale set
+--operator=$USER`, once. `core/tailnet.ts` was swallowing every failure equally,
+which is right for a *read* (not installed, not logged in and daemon-down are
+one answer: no tailnet here) and wrong for a *write*: the switch sprang back
+with no explanation, the user had done nothing wrong, and the fix was one
+command the tool had already printed. Writes now keep their failure text and
+`setExposed` throws it, so the panel says it.
+
+Worth noticing that this is invisible on the machine most likely to be
+*developed* on and waiting on the machine most likely to be a *host*. It is the
+same shape as M5.0's `ci.yml` finding one layer up.
 
 ## Agent setup
 

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -3115,7 +3115,7 @@ Before them, one spike that had to happen first, because it decides whether the
    a write emitting on it, both shells carrying it to a renderer, and a renderer
    that treats what arrives as a reason to re-ask. One machine; no tailnet. *(done — see below.)*
 2. **The poke from the MCP process.** An agent's write reaching the owner of the
-   data directory over the loopback port it already publishes.
+   data directory over the loopback port it already publishes. *(done — see below.)*
 3. **Tailnet exposure, identity, and `webUrl`.** `tailscale serve` behind a
    settings toggle, the gate learning a second way to be satisfied, and the URL
    that goes into an MCP result once a host listens. The phone works at the end
@@ -3417,6 +3417,83 @@ application with `core/events.ts` deleted is M5 exactly — slower, never wrong.
 That is the property "additive" has to mean, and it is worth checking rather
 than asserting: `mutate` on a key with no subscriber does nothing at all, so an
 event for a review nobody has open costs one map lookup and produces no read.
+
+**M6.2, done on the Mac, 11 September.** The channel from M6.1 is per process,
+and the agent is in a different one. `core/daemon-runtime.ts` argued years of
+this repository's thinking into one paragraph — the MCP server opens SQLite
+directly and never routes reads through a running GUI, so quitting GitWarren
+does not stop an agent working — and the cost of that, which nothing had had to
+pay before, is that `emitEvent` in the MCP process reaches nobody.
+
+**The poke is a `POST` to the owner, and the argument for it is that nothing had
+to be invented.** `daemon-runtime.json` already names the owning pid and its
+`linkPort`; the owner is already serving `core/web/handler.ts` there;
+`core/web/token.ts` already writes the session token beside it at mode 0600,
+readable by exactly the principal that may poke. So the whole delta is one path,
+one header and a client that never throws.
+
+The plan's other candidate was a counter in `daemon-runtime.json`, and it is
+worse for a reason worth stating: something would have to *watch* the file.
+`fs.watch` is a different mechanism on each platform, unreliable on network
+filesystems, and a poll underneath on several of them — so a counter is a poll
+with extra steps, dressed as a push. The file stays what it has always been, a
+published fact read fresh on every use.
+
+**It breaks a property `handler.ts` had held since M3, so the exception is
+written into that file's header rather than left to be found.** Everything
+behind that gate was a read; this is the one write. Three independent locks, and
+the interesting part is that each answers a different question: the token asks
+whether the caller was *pointed at* GitWarren; `Host` and `Origin` ask whether
+it is a web page, which is the attacker `origin.ts` was built against; and a
+closed vocabulary decides what may go on the bus here rather than letting a
+caller's string decide. `host.state` is refused by name — it is minted by this
+install's own pool from a connection it is holding, and nothing outside the
+process has any evidence about it.
+
+The honest bound is in the module: a local process running as the user can
+already open the database, so the worst this endpoint grants is making a window
+re-read something it could have caused by writing a row. The token is not
+authentication of a person and `token.ts` never claimed it was.
+
+**A host with no owner has no push, and that is the design.** A daemon spawned
+over `ssh` or `wsl.exe` binds nothing and writes no runtime file — deliberately,
+since M2 — so an agent on a machine reached that way finds no owner, pokes
+nobody, and the GUI notices on its next poll. The remedy is not a second
+mechanism; it is M6.3's toggle, which gives that machine an owner and a socket
+to push down. Saying so is better than building a channel for the case where it
+is off.
+
+**Verified against a real MCP session, `scripts/verify/m6-2.mjs`.** Not the
+services called directly: the poke lives in `runWrite`, after the service call
+and inside the agent boundary, so a harness that skipped the tool call would
+have proved nothing. An agent's `add_review_comment` reached the window's
+carrier in **12 ms** as `{event: "comments.changed", data: null}`, and with the
+conversation tab open the comment appeared with nobody touching the window. Two
+agent *reads* produced no events, which is the check that matters most.
+
+And the property the whole arrangement exists to protect, checked rather than
+assumed: an MCP server started against a data directory nothing owns answers its
+tools normally. No owner is the common case, not an error.
+
+**Two things bit, and one of them was a real bug.**
+
+*A refusal nobody receives is not a refusal.* The body cap destroyed the request
+socket the moment it was passed, which took the connection down *before* the
+`413` could be written — so the caller saw `other side closed` where it should
+have seen a status it could read. Found by the test rather than by reading, and
+the fix is an ordering: stop accumulating (which is what bounds the memory),
+settle immediately rather than waiting for an `end` an endless body will never
+send, answer, and only then hang up. It is the same shape as M4.1's
+`diagnostics()` lesson from the other direction — the useful thing and the
+teardown are in a race, and the teardown must lose.
+
+*A protocol change is a protocol change even when both ends are on this
+machine.* The first run failed with `405 Allow: GET, HEAD` from an app that was
+perfectly healthy: it was running the build from before the notify path existed.
+M4.5 and M5 were the only slices with nothing to say about version skew, and
+this is the cheapest possible version of it — two processes from the same
+checkout, one of them stale. Every slice from here needs the app rebuilt and
+restarted before it is asked anything, and a host reinstalled before it is.
 
 ## Agent setup
 

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -3129,7 +3129,7 @@ Before them, one spike that had to happen first, because it decides whether the
    added. *(done — see below.)*
 7. **Links across installs, and the words.** What a `gitwarren://<other-id>/…`
    link does now that there is somewhere for it to go, and the README, the
-   tagline and Known limitations catching up with the thing that shipped.
+   tagline and Known limitations catching up with the thing that shipped. *(done — see below.)*
 
 **What was settled before any of it was written.**
 
@@ -3841,6 +3841,117 @@ The guess was wrong in a way that would have been invisible on a LAN and is the
 first thing anybody notices on a tailnet, which is the argument for measuring
 against the real one in one sentence.
 
+**M6.7, done on the Mac against `pc-wsl`, 11 September.** Two things that had
+been waiting for the rest of the milestone to exist, and the words.
+
+**A link naming another install finally opens something.** `main/deep-link.ts`
+has been sending those to the home screen since M2, with a log line saying
+*"reviews on other hosts arrive in M4"* - which they did, three milestones ago,
+while that line went on discarding them. M4.3, M4.4 and M5.3 each noticed it and
+each deferred, reasonably: nothing before the tailnet produced a link that named
+another machine, because a link is minted by the install that owns the review
+and there was no ordinary way for one to travel.
+
+The change is to hand the route over *with* its host segment rather than
+stripping it, in both shells - `main/deep-link.ts` for the window,
+`web/loopback-fragment.ts` for a tab. What is worth noticing is that this
+*strengthens* the rule the old behaviour existed for rather than relaxing it.
+The thing that must never happen is opening our own review 4 because the link
+said 4: ids are per host, so that shows the wrong review with no sign of it.
+Landing on the home screen avoided that; keeping the segment makes it
+unrepresentable, because the route says whose review it is and
+`core/hosts/router.ts` either sends the reads to that machine or fails naming
+it. The test that has guarded this since M2 now asserts the stronger thing, and
+a second one asserts that what comes out is `#/h/<id>/reviews/2/files` and could
+not be read as `#/reviews/2/files` by anything.
+
+No check that the host is *known*, deliberately. `requireInstance` already
+refuses by name when the reads go out, and its sentence names the id - which is
+the only thing a person can compare against their Hosts screen. Guessing earlier
+would replace a specific answer with a shrug, and in the browser shell it would
+also mean an asynchronous question asked before the app has booted.
+
+**`webUrl` reaches an agent, and both links sit side by side.** From the PC's own
+MCP server, `list_reviews` now answers:
+
+    guiUrl: http://127.0.0.1:41427/#h=4e0b0adb…/review/2/conversation
+    webUrl: http://pc-wsl.tail688c0c.ts.net:41427/#/reviews/2/conversation
+
+The two notations M2 separated, doing the two different jobs it separated them
+for. The loopback fragment is a *deep link waiting to be assembled* - the page
+at that address hands it to whichever GitWarren is on the machine that clicked,
+which is why it carries the instance id. The tailnet URL is not waiting for
+anything: the server answering it is the machine that owns the review, so the
+route is an ordinary app hash with no host segment, because there is no other
+machine in the story.
+
+Fetched from the Mac - a different device from the one serving it - that URL
+answers **200** with the web build and its JS bundle, with no token anywhere: the
+tailnet is the credential, and `tailscale serve` supplies the identity the
+loopback token supplies at home.
+
+**The words.** The README's tagline moves from *"Single user, single machine, no
+server, no account"* to *"Your machines, your agents, no one else's server"*,
+with a second paragraph saying the thing that actually changed - reviews live on
+the machine the code is on, reached over SSH, `wsl.exe` or your own tailnet,
+with nothing replicated, relayed or stored anywhere but computers you already
+own. `package.json`'s description follows it.
+
+*"Nothing is pushed to the UI"* is retired from Known limitations, and what
+replaces it is narrower than "live updates now work", because that would not be
+true: a host reached over SSH or `wsl.exe` has no process of its own to push
+from, so there the poll is still how the window finds out. Two *new* limitations
+go in beside it, both found during this milestone: a host is only greyed if
+something has asked it something in the last ten minutes, and `tailscale serve`
+needs `--operator` on Linux.
+
+**The site is a separate repository and is deliberately not in this PR.**
+`gitwarren-site` carries the same claim in at least `public/llms.txt`
+("no account, no server and no telemetry. State lives in one SQLite file on the
+machine"), `src/pages/privacy.astro` and `design/canvas/Blueprint.dc.html`
+("Local only: no server, no account, nothing cached"). Every one of those is
+still true of a single-machine install and is now incomplete rather than wrong,
+which is the kind of copy that needs a person deciding the phrasing rather than
+a mechanical substitution. Naming the files here is the useful half.
+
+**The gap table was re-read rather than glanced at, and four rows changed.**
+*Disconnection* now says what M6 actually contributed, which is only the half
+that has no request to learn from - M4.5's banner is still the mechanism for
+everything a screen can see. *Which GUI a link opens* gained the cross-install
+link above. *Host-scoped routes and IDs* gained M6, because the instance id is
+what decides four separate things here that it decided none of before: routing a
+link, excluding this machine from its own discovery, tagging an event, and
+refusing one box added twice.
+
+The fourth is the one that was not a formality. *Version skew between hosts* was
+`M4` and is now `M4, M6`, for two reasons. An unknown *event name* is ignored by
+a receiver, which is the protocol's standing rule arriving in the one direction
+nothing had exercised. And M6 found a gap in the *mechanism* rather than the
+design: `hosts.install` decides by version *string*, so a host running a
+same-versioned build from before a milestone answers `already-current` and is
+not upgraded. `force` is the existing way out and was needed twice in this
+milestone. A pre-release that changes methods without changing its version is
+the case that is not covered, and it is now written down where somebody will
+find it.
+
+**One thing bit, and an agent would have seen it before a person did.**
+`list_reviews` and `list_review_comments` build their links inline rather than
+through the two wrappers, and the change from `guiUrl: links.review(id)` to
+`...links.review(id)` was applied to the wrappers and missed at those two sites.
+The result was a payload with `guiUrl` nested inside `guiUrl` and `webUrl`
+buried under it - valid JSON, no error anywhere, and a link an agent would have
+handed over as `[object Object]`. Found by reading a real tool result off the
+real machine rather than by a type error, because `WithGuiUrl<T>` is a
+structural type and a nested object satisfies nothing it forbids.
+
+And a smaller one worth its line: the first attempt to check the fix reinstalled
+the daemon from a tarball built without `npm run build:mcp`, so the PC was
+running the *old* MCP bundle inside a new tarball and reported the bug as
+though it were unfixed. The tarball script's own header names the three builds
+that have to precede it; the lesson is the M6.2 one again, one layer down - a
+protocol change is a protocol change even when both ends came from the same
+checkout.
+
 ## Agent setup
 
 One sentence instead of a snippet per harness. Agents know their own
@@ -3929,14 +4040,14 @@ least one alternative.
 | Gap | Closed in | How |
 | --- | --- | --- |
 | Chattiness over a network | S5, M1, M3 | Measure, then coarse endpoints; a multiplexed WebSocket removes per-request setup. |
-| Disconnection | M4, M6 | Fail-fast errors, stale banner, reconnect with backoff, heartbeats, refetch on reconnect. |
+| Disconnection | M4, M6 | Fail-fast errors, stale banner, reconnect with backoff, refetch on reconnect — all M4.5, all learned from request *outcomes*. M6 adds only the half that has no request to learn from: a listening carrier holds a socket with a heartbeat on it, so a machine nobody is looking at is greyed too (216 ms, measured). Bounded by the pool's ten-minute idle hang-up. |
 | Colleague permissions | — | Non-goal. Object-centric RPC from M1 keeps the door open. |
 | Git argument and path hardening | M0 | Hygiene now; not a security boundary while every caller is the owner. |
-| Host-scoped routes and IDs | M0, M4 | Optional host segment in the route grammar; hosts table; links carry the instance id. |
-| Which GUI a link opens | M2, M6 | Loopback resolves on the clicker's machine; tailnet URL for the phone. |
+| Host-scoped routes and IDs | M0, M4, M6 | Optional host segment in the route grammar; hosts table; links carry the instance id. M6 is where that id finally decides something in every direction: it routes a link across installs, it excludes this machine from its own discovery, it tags an event with the machine it happened on, and it is what refuses one box added twice under two carriers. |
+| Which GUI a link opens | M2, M6 | Loopback resolves on the clicker's machine; `webUrl` for a phone, added only while the host listens and spelled as the machine reported rather than by convention. M6.7 also made a link naming *another* install open that machine's review rather than the home screen — the host segment travels, so this install's review 4 stays unreachable by a link that said 4. |
 | Attachments across hosts | M3, M4 | Ingest on the host; HTTP for the web view, the carrier for the app. |
-| Version skew between hosts | M4 | The GUI installs the daemon version it wants; protocol version in the handshake; unknown fields ignored. |
+| Version skew between hosts | M4, M6 | The GUI installs the daemon version it wants; protocol version in the handshake; unknown fields ignored — and since M6 an unknown *event name* is ignored too, which is the same rule arriving in the one direction nothing had exercised. What M6 found is a gap in the mechanism rather than in the design: `hosts.install` decides by **version string**, so a host running a same-versioned build from before a milestone answers `already-current` and is not upgraded. `force` is the existing way out and was needed twice here. A pre-release that changes methods without changing its version is the case this does not cover. |
 | Daemon process on headless hosts | M2, M3, M4, M5 | Bundle in M2, `gitwarren service install` in M3.3, spawned on demand over SSH in M4 and through `wsl.exe` in M5 — the same installer either way, since it was written against "a machine with a shell and a `tar`". |
 | Users who will not run Electron | M3 | The same renderer served by the local daemon; the `gitwarren-cli` formula, `npx gitwarren` and the tarball, all from M3.3. |
-| A screen the size of a phone | M3.5, M6 | Files list and diff as separate screens below `lg`, composer above the keyboard, paths that wrap at their separators; the route to the device itself is M6's tailnet. |
+| A screen the size of a phone | M3.5, M6 | Files list and diff as separate screens below `lg`, composer above the keyboard, paths that wrap at their separators; the route to the device itself is M6's tailnet, where `tailscale serve` supplies identity so there is no token to get onto a phone. |
 | MCP setup per harness and on remote hosts | M2, M3, M4 | Stable launcher path plus a one-sentence prompt the agent applies to its own config. |

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -3124,7 +3124,7 @@ Before them, one spike that had to happen first, because it decides whether the
    the app, reaching a machine that listens rather than one it spawns. *(done — see below.)*
 5. **Events across a host, and `host.state`.** `RpcEvent` on a wire in the one
    direction nothing has exercised, and the pool's `onStateChange` finally
-   rendered — which is what greys a machine nobody is looking at.
+   rendered — which is what greys a machine nobody is looking at. *(done — see below.)*
 6. **Discovery.** Peers from `tailscale status --json`, proposed rather than
    added.
 7. **Links across installs, and the words.** What a `gitwarren://<other-id>/…`
@@ -3688,6 +3688,84 @@ command the tool had already printed. Writes now keep their failure text and
 Worth noticing that this is invisible on the machine most likely to be
 *developed* on and waiting on the machine most likely to be a *host*. It is the
 same shape as M5.0's `ci.yml` finding one layer up.
+
+**M6.5, done on the Mac against `pc-wsl`, 11 September.** The milestone's verify
+line, minus the phone, and the slice where everything built so far turns out to
+be one thing.
+
+**The stdio server sends its first unsolicited frame, and it cost one line.**
+`subscribeToEvents(write)` in `core/rpc/stdio.ts`, and the reason it is one line
+is a decision made at M1: an `RpcEvent` has no `id`, and the reader on the other
+end has been asking `isRpcEvent` about every frame since M4 without one ever
+being true. The comment there promised that "the message simply arrives". It
+does. This is the direction nothing had exercised, and the protocol was already
+shaped for it.
+
+**The pool is the only layer that can say which machine an event is about, and
+that is why the tagging lives there.** A daemon announcing `comments.changed`
+means "on me" - it cannot know what instance id this install files it under,
+because it may be reached by two GitWarrens at once, each with its own row. The
+association is the *connection the message came down*, and connections are what
+the pool holds. So `routeFor` carries the instance id now, and the pool stamps
+it on the way through. An untagged event would reach the renderer meaning "this
+install" and refresh the wrong machine's screens while looking entirely healthy,
+which is the failure `renderer/lib/event-scope.ts` has a test for from the other
+end.
+
+**`onStateChange` is rendered at last, and the four-milestone delay is the point
+rather than an oversight.** It was written at M4.1 for a banner; M4.5 declined
+to use it and wrote down why; M5 proved the banner carrier-agnostic without it.
+None of that is undone here. M4.5's banner is still raised by request
+*outcomes*, in `renderer/lib/host-reachability.ts`, and this event does not
+touch it.
+
+What is new is the case none of them could reach. For most of M4 the pool only
+learned anything by *connecting*, so a machine nobody was asking about was a
+machine nothing could say anything about - the hook had nothing to report, not
+just nowhere to report it. `core/hosts/websocket.ts` is what changes that: a
+listening host holds an open socket, so a machine that goes away is an event on
+this side with no request outstanding and no screen open on it.
+
+The bound is recorded rather than hidden. The pool still hangs up after
+`IDLE_TIMEOUT_MS`, so `host.state` can only speak for a host something has asked
+about in the last ten minutes. An always-open socket to every host would be a
+connection to every machine on the list, which is exactly what
+`core/hosts/pool.ts` exists to avoid and what M4.3 refused to do for a home
+screen.
+
+**Verified end to end, four hops, all of them real.** The agent's MCP process on
+`pc-wsl` pokes that machine's own daemon over its loopback port; the daemon
+emits on its own bus; `serveWebSocket` writes an `RpcEvent` down the socket the
+Mac is holding; the Mac's pool stamps it with `4e0b0adb…` and puts it on the
+Mac's bus, where the window is listening.
+
+A comment written by an agent on the PC reached the Mac's carrier in **395 ms**,
+tagged with the PC's instance id, carrying `data: null`. With the review open at
+`#/h/4e0b0adb…/reviews/2/conversation`, the next one **appeared on the Mac with
+nobody touching the window**.
+
+Then the other half. Back on the home screen, with nothing asking that machine
+anything, the daemon on `pc-wsl` was stopped: `host.state` arrived on the Mac
+**216 ms later**, and the host list said *The connection to
+pc-wsl.tail688c0c.ts.net:41427 was lost.* Nothing failed, because nothing had
+asked - which is the whole of what this slice adds, and is why the verify line
+says "turn the PC off" rather than "open a review and turn the PC off".
+
+Worth separating the two shapes of going away, because the number above is only
+one of them. Stopping a process closes its socket, and TCP says so immediately -
+hence 216 ms. A machine that is unplugged or frozen says nothing at all, and is
+noticed by `LIVENESS_TIMEOUT_MS` instead: up to thirty seconds. Both are
+"within seconds"; only the first is within a quarter of one, and a reader
+deserves to know which they are looking at.
+
+**And one thing about the harness rather than the app.** The first attempt drove
+the PC's MCP server by piping a `printf` through `ssh`, and it silently wrote
+nothing. The JSON is full of quotes and braces, and every layer between the two
+machines wanted its own say about them - a template literal, Node's argv, the
+local shell, `ssh`'s own concatenation of its arguments, and the remote *zsh*
+that M4.2 found is the login shell on that box. A script file crosses once and
+is read by `sh`. It is the same lesson M5.1 learned about `wsl.exe --`, in a
+place where it cost a confusing half hour rather than a bug.
 
 ## Agent setup
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitwarren",
   "productName": "GitWarren",
   "version": "0.1.7-beta.1",
-  "description": "Desktop app for doing local-only code reviews",
+  "description": "Code review for your own machines and your own agents",
   "author": {
     "name": "Klarluft B.V.",
     "email": "contact@klarluft.com",

--- a/scripts/verify/m6-1.mjs
+++ b/scripts/verify/m6-1.mjs
@@ -1,0 +1,213 @@
+/**
+ * M6.1: a write in one shell reaching a screen in the other, live.
+ *
+ * The event channel's first slice needs no tailnet and no second machine - it
+ * needs two *shells* on one core, which is the arrangement that already exists:
+ * the Electron window talks to the main process over IPC, and a browser tab
+ * talks to the same process over a WebSocket on the loopback port. A write that
+ * arrives on one and is noticed on the other has crossed the whole channel.
+ *
+ * This script plays the part of the tab, with `ws` and the session token,
+ * because a real second browser would add a browser to the things that could be
+ * wrong. Everything it sends goes through the same upgrade, the same gate and
+ * the same `serveWebSocket` a tab uses.
+ *
+ * Start the app first, in another terminal:
+ *
+ *   GITWARREN_DATA_DIR=/tmp/gw-m6 \
+ *     ./node_modules/.bin/electron . --remote-debugging-port=9222 \
+ *     --user-data-dir=/tmp/gw-m6-chrome
+ *
+ * then: node scripts/verify/m6-1.mjs <a git repository path>
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import WebSocket from 'ws'
+import { Cdp, wait } from '../cdp.mjs'
+
+const repositoryPath = process.argv[2]
+if (!repositoryPath) {
+  console.error('usage: node scripts/verify/m6-1.mjs <a git repository path>')
+  process.exit(2)
+}
+
+const dataDirectory = process.env.GITWARREN_DATA_DIR
+if (!dataDirectory) {
+  console.error('GITWARREN_DATA_DIR must name the directory the app under test is using.')
+  process.exit(2)
+}
+
+const PORT = 41427
+const ORIGIN = `http://127.0.0.1:${PORT}`
+
+let failures = 0
+const report = (label, ok, detail) => {
+  if (!ok) failures += 1
+  console.log(`${ok ? 'ok  ' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+}
+
+// The 0600 file `core/web/token.ts` publishes for `gitwarren open` to find. A
+// process running as this user may read it; that is the whole of the gate on
+// loopback, and the principal argument is in that module's header.
+const token = readFileSync(join(dataDirectory, 'web-token'), 'utf8').trim()
+
+console.log('\n== the tab half: a socket through the real gate ==')
+const socket = new WebSocket(`ws://127.0.0.1:${PORT}/gitwarren/socket`, {
+  headers: { Origin: ORIGIN, Cookie: `gitwarren_session=${encodeURIComponent(token)}` }
+})
+
+/** Events this "tab" was pushed, in arrival order. */
+const tabEvents = []
+const pending = new Map()
+let nextId = 1
+
+await new Promise((resolve, reject) => {
+  socket.once('open', resolve)
+  socket.once('error', reject)
+})
+report('a socket with the session cookie is accepted', socket.readyState === WebSocket.OPEN)
+
+socket.on('message', (data) => {
+  const message = JSON.parse(String(data))
+  // The discriminator both ends share. An event has no id; an answer does.
+  if (typeof message.id !== 'number') {
+    tabEvents.push({ ...message, at: Date.now() })
+    return
+  }
+  pending.get(message.id)?.(message)
+  pending.delete(message.id)
+})
+
+function ask(method, params) {
+  const id = nextId++
+  return new Promise((resolve, reject) => {
+    pending.set(id, (response) => {
+      if (response.error) reject(new Error(`${response.error.code}: ${response.error.message}`))
+      else resolve(response.result)
+    })
+    socket.send(JSON.stringify({ id, method, params }))
+  })
+}
+
+console.log('\n== the window half: a spy on the carrier ==')
+const cdp = await Cdp.attach(9222)
+await cdp.evaluate(`(() => {
+  window.__m6 = []
+  window.__m6stop?.()
+  window.__m6stop = window.gitwarren.carrier.onEvent((event) => {
+    window.__m6.push({ ...event, at: Date.now() })
+  })
+  return true
+})()`)
+report('the window exposes an event subscription on its carrier', true)
+
+const windowEvents = async () => JSON.parse(await cdp.evaluate('JSON.stringify(window.__m6)'))
+const clear = async () => {
+  tabEvents.length = 0
+  await cdp.evaluate('(() => { window.__m6 = []; return true })()')
+}
+
+console.log('\n== a review to write on ==')
+for (const existing of await ask('repositories.list', undefined)) {
+  await ask('repositories.remove', { id: existing.id })
+}
+const repository = await ask('repositories.add', { path: repositoryPath })
+const review = await ask('reviews.create', {
+  repositoryId: repository.id,
+  title: 'M6.1 — live updates',
+  baseRef: 'HEAD',
+  headRef: 'HEAD'
+})
+report('a review exists to comment on', Number.isInteger(review.id), `review ${review.id}`)
+
+console.log('\n== a write in the tab, noticed in the window ==')
+await clear()
+const wroteAt = Date.now()
+const thread = await ask('comments.createThread', {
+  reviewId: review.id,
+  body: 'Written over the socket, like a browser tab would.'
+})
+// Generous: what is being measured is "well under the fifteen-second poll", and
+// a tighter bound would make this a timing test of an IPC hop rather than a
+// test of the channel.
+await wait(300)
+
+const seenByWindow = await windowEvents()
+const commentEvents = seenByWindow.filter((event) => event.event === 'comments.changed')
+report(
+  'the window heard about a comment it did not make',
+  commentEvents.length === 1,
+  `${seenByWindow.length} event(s): ${seenByWindow.map((e) => e.event).join(', ')}`
+)
+report(
+  'it arrived in well under one poll interval',
+  commentEvents.length === 1 && commentEvents[0].at - wroteAt < 1000,
+  commentEvents.length === 1 ? `${commentEvents[0].at - wroteAt} ms` : 'no event'
+)
+report(
+  'it carries a name and no content',
+  commentEvents.length === 1 && commentEvents[0].data === null,
+  commentEvents.length === 1 ? JSON.stringify(commentEvents[0]) : ''
+)
+report(
+  'it is not tagged with a host: this core is the window’s own install',
+  commentEvents.length === 1 && commentEvents[0].host === undefined
+)
+
+console.log('\n== and the other way: a write in the window, noticed in the tab ==')
+await clear()
+const fromWindow = await cdp.evaluate(`(async () => {
+  const outcome = await window.gitwarren.carrier.request('comments.reply', {
+    threadId: ${thread.id},
+    body: 'Written in the window, like a person would.'
+  })
+  return JSON.stringify(outcome)
+})()`)
+report('the window’s write succeeded', !JSON.parse(fromWindow).error, fromWindow.slice(0, 120))
+await wait(300)
+report(
+  'the tab heard about it on its own socket',
+  tabEvents.filter((event) => event.event === 'comments.changed').length === 1,
+  `${tabEvents.length} event(s): ${tabEvents.map((e) => e.event).join(', ')}`
+)
+
+console.log('\n== a read announces nothing ==')
+await clear()
+await ask('reviews.open', { id: review.id })
+await ask('reviews.diff', { id: review.id, changes: 'all' })
+await ask('repositories.list', undefined)
+await wait(300)
+report('three reads produced no events in the tab', tabEvents.length === 0,
+  tabEvents.map((e) => e.event).join(', '))
+report('and none in the window', (await windowEvents()).length === 0)
+
+console.log('\n== and the screen itself redraws, which is the only part a person sees ==')
+// Everything above proves the message arrives. This proves what it is *for*:
+// `mutate` finding the key the conversation tab is subscribed to. It is the
+// step that would still be missing if the scoping in `lib/event-scope.ts` were
+// wrong, and nothing earlier in this script would have noticed.
+await cdp.evaluate(
+  `(() => { window.location.hash = '#/reviews/${review.id}/conversation'; return true })()`
+)
+await wait(1200)
+
+const bodyText = () => cdp.evaluate('document.body.innerText')
+const needle = 'Only a live update could have put this here'
+const before = await bodyText()
+report('the conversation tab is open and does not yet show the new comment',
+  !before.includes(needle))
+
+const paintedAt = Date.now()
+await ask('comments.reply', { threadId: thread.id, body: needle })
+// Well inside the fifteen-second poll and outside React's own scheduling.
+await wait(600)
+const after = await bodyText()
+report(
+  'a comment written elsewhere appears without anyone touching the window',
+  after.includes(needle),
+  `${Date.now() - paintedAt} ms after the write`
+)
+
+socket.close()
+console.log(`\n${failures === 0 ? 'all good' : `${failures} FAILED`}`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify/m6-2.mjs
+++ b/scripts/verify/m6-2.mjs
@@ -1,0 +1,223 @@
+/**
+ * M6.2: an agent's comment reaching the window it was not written in.
+ *
+ * The agent writes in the *MCP process*, which is a different OS process from
+ * the GUI and has its own event bus reaching nobody. So this is the one slice
+ * where "did the event arrive" is a question about two processes on one
+ * machine, and it needs a real MCP session rather than a socket pretending to
+ * be one - the poke happens inside `runWrite`, after the service call, and a
+ * harness that called the service directly would prove nothing.
+ *
+ * Start the app first, in another terminal:
+ *
+ *   GITWARREN_DATA_DIR=/tmp/gw-m6 \
+ *     ./node_modules/.bin/electron . --remote-debugging-port=9222 \
+ *     --user-data-dir=/tmp/gw-m6-chrome
+ *
+ * then: node scripts/verify/m6-2.mjs
+ */
+import { spawn } from 'node:child_process'
+import { Cdp, wait } from '../cdp.mjs'
+
+const dataDirectory = process.env.GITWARREN_DATA_DIR
+if (!dataDirectory) {
+  console.error('GITWARREN_DATA_DIR must name the directory the app under test is using.')
+  process.exit(2)
+}
+
+let failures = 0
+const report = (label, ok, detail) => {
+  if (!ok) failures += 1
+  console.log(`${ok ? 'ok  ' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+}
+
+/**
+ * An MCP session over this repository's own server, through tsx.
+ *
+ * `npm run mcp:dev` is the same entry point the built launcher runs, and using
+ * it here means the poke under test is the one in the working tree rather than
+ * whatever was last installed.
+ */
+function openMcp() {
+  const child = spawn('npx', ['tsx', 'src/mcp/server.ts'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, GITWARREN_DATA_DIR: dataDirectory }
+  })
+  child.stderr.setEncoding('utf8')
+  child.stderr.on('data', (chunk) => {
+    const line = chunk.trim()
+    if (line) console.log('   [mcp stderr]', line.slice(0, 160))
+  })
+
+  const waiting = new Map()
+  let buffer = ''
+  child.stdout.setEncoding('utf8')
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk
+    let newline = buffer.indexOf('\n')
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline).trim()
+      buffer = buffer.slice(newline + 1)
+      if (line) {
+        try {
+          const message = JSON.parse(line)
+          const settle = waiting.get(message.id)
+          if (settle) {
+            waiting.delete(message.id)
+            settle(message)
+          }
+        } catch {
+          // stdout belongs to the protocol. Anything else here is a bug worth
+          // seeing rather than swallowing.
+          console.log('   [non-protocol stdout]', JSON.stringify(line.slice(0, 120)))
+        }
+      }
+      newline = buffer.indexOf('\n')
+    }
+  })
+
+  let id = 0
+  const send = (method, params) =>
+    new Promise((resolve) => {
+      id += 1
+      waiting.set(id, resolve)
+      child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`)
+    })
+  return {
+    send,
+    notify: (method, params) =>
+      child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method, params })}\n`),
+    close: () => child.kill()
+  }
+}
+
+const cdp = await Cdp.attach(9222)
+await cdp.evaluate(`(() => {
+  window.__m6 = []
+  window.__m6stop?.()
+  window.__m6stop = window.gitwarren.carrier.onEvent((event) => {
+    window.__m6.push({ ...event, at: Date.now() })
+  })
+  return true
+})()`)
+const windowEvents = async () => JSON.parse(await cdp.evaluate('JSON.stringify(window.__m6)'))
+const clear = () => cdp.evaluate('(() => { window.__m6 = []; return true })()')
+
+console.log('\n== an MCP session against the same data directory ==')
+const mcp = openMcp()
+const init = await mcp.send('initialize', {
+  protocolVersion: '2024-11-05',
+  capabilities: {},
+  clientInfo: { name: 'm6-verify', version: '1' }
+})
+report('the MCP server answers a handshake', init.result !== undefined,
+  `${init.result?.serverInfo?.name} ${init.result?.serverInfo?.version}`)
+mcp.notify('notifications/initialized')
+
+const call = async (name, args) => {
+  const answer = await mcp.send('tools/call', { name, arguments: args })
+  const text = (answer.result?.content ?? []).map((c) => c.text ?? '').join('\n')
+  return { isError: answer.result?.isError === true, text }
+}
+
+const reviews = await call('list_reviews', {})
+const reviewId = Number(/"id":\s*(\d+)/.exec(reviews.text)?.[1] ?? 0)
+report('the agent can see a review to talk about', reviewId > 0, `review ${reviewId}`)
+
+console.log('\n== a read from the agent pokes nobody ==')
+await clear()
+await call('list_reviews', {})
+await call('get_review', { id: reviewId })
+await wait(400)
+report('two agent reads produced no events in the window', (await windowEvents()).length === 0)
+
+console.log('\n== a write from the agent reaches the window ==')
+await clear()
+const wroteAt = Date.now()
+const written = await call('add_review_comment', {
+  reviewId,
+  body: 'Written by an agent in another process entirely.'
+})
+report('the agent wrote a comment', !written.isError, written.text.slice(0, 300))
+
+await wait(400)
+const seen = await windowEvents()
+const comments = seen.filter((event) => event.event === 'comments.changed')
+report(
+  'the window heard about it',
+  comments.length === 1,
+  `${seen.length} event(s): ${seen.map((e) => e.event).join(', ')}`
+)
+report(
+  'within a second, rather than within a poll',
+  comments.length === 1 && comments[0].at - wroteAt < 1000,
+  comments.length === 1 ? `${comments[0].at - wroteAt} ms` : 'no event'
+)
+report(
+  'carrying a name and no content, like every other event',
+  comments.length === 1 && comments[0].data === null && comments[0].host === undefined
+)
+
+console.log('\n== and it is on screen, which is the whole point ==')
+await cdp.evaluate(
+  `(() => { window.location.hash = '#/reviews/${reviewId}/conversation'; return true })()`
+)
+await wait(1200)
+// Unique per run: this script is meant to be re-run against a data directory
+// it has already written to, and a fixed string would be found by the
+// "not yet" check from a previous run's comment.
+const needle = `An agent wrote this while somebody was looking — ${Date.now()}`
+const before = await cdp.evaluate('document.body.innerText')
+report('the conversation is open and does not show it yet', !before.includes(needle))
+
+await call('add_review_comment', { reviewId, body: needle })
+await wait(600)
+const after = await cdp.evaluate('document.body.innerText')
+report('an agent’s comment appears with nobody touching the window', after.includes(needle))
+
+console.log('\n== with no owner there is no poke, and nothing breaks ==')
+// The property `core/daemon-runtime.ts` is built on: quit GitWarren and the
+// agent keeps working. A poke with nobody listening must be indistinguishable
+// from no poke at all - which is also exactly the case of a daemon spawned over
+// `ssh`, since a stdio daemon owns nothing and binds nothing.
+const stray = spawn('npx', ['tsx', 'src/mcp/server.ts'], {
+  stdio: ['pipe', 'pipe', 'pipe'],
+  // A data directory nothing owns: no runtime file, so `readLiveDaemonRuntime`
+  // answers null and the poke is never attempted.
+  env: { ...process.env, GITWARREN_DATA_DIR: '/tmp/gw-m6-unowned' }
+})
+let strayOut = ''
+stray.stdout.setEncoding('utf8')
+stray.stdout.on('data', (chunk) => (strayOut += chunk))
+stray.stdin.write(
+  `${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'm6-orphan', version: '1' }
+    }
+  })}\n`
+)
+await wait(4000)
+stray.stdin.write(
+  `${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: { name: 'list_repositories', arguments: {} }
+  })}\n`
+)
+await wait(3000)
+report(
+  'an agent against an unowned data directory still answers',
+  strayOut.includes('"id":2'),
+  strayOut.split('\n').filter(Boolean).length + ' frame(s)'
+)
+stray.kill()
+
+mcp.close()
+console.log(`\n${failures === 0 ? 'all good' : `${failures} FAILED`}`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify/m6-3.mjs
+++ b/scripts/verify/m6-3.mjs
@@ -1,0 +1,208 @@
+/**
+ * M6.3: the second authority, and who is allowed through it.
+ *
+ * Against the real tailnet, because a mock would have agreed with whatever the
+ * gate happened to do. What is actually being checked is a set of refusals -
+ * the wrong login, the wrong origin, a token where a token is no longer the
+ * question - and a refusal is exactly the thing a fake is worst at.
+ *
+ * The identity header cannot be forged by `fetch`: `Tailscale-User-Login` and
+ * `Host` are both forbidden header names, so undici drops an override silently.
+ * That is correct browser behaviour and useless here, so the raw `http` client
+ * is used for everything - which also means this script is testing the same way
+ * `web-handler.test.ts` had to for the `Host` check.
+ *
+ * Start the app first, in another terminal:
+ *
+ *   GITWARREN_DATA_DIR=/tmp/gw-m6 \
+ *     ./node_modules/.bin/electron . --remote-debugging-port=9222 \
+ *     --user-data-dir=/tmp/gw-m6-chrome
+ *
+ * then: node scripts/verify/m6-3.mjs
+ */
+import { readFileSync } from 'node:fs'
+import { request as httpRequest } from 'node:http'
+import { join } from 'node:path'
+import { Cdp, wait } from '../cdp.mjs'
+
+const dataDirectory = process.env.GITWARREN_DATA_DIR
+if (!dataDirectory) {
+  console.error('GITWARREN_DATA_DIR must name the directory the app under test is using.')
+  process.exit(2)
+}
+
+const PORT = 41427
+let failures = 0
+const report = (label, ok, detail) => {
+  if (!ok) failures += 1
+  console.log(`${ok ? 'ok  ' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+}
+
+const token = readFileSync(join(dataDirectory, 'web-token'), 'utf8').trim()
+
+/**
+ * A request with the headers exactly as given, `Host` included.
+ *
+ * Always to 127.0.0.1, whatever the `Host` says - which is not a shortcut, it
+ * is the arrangement being tested. `tailscale serve` proxies from the tailnet
+ * *to loopback*, so a request from a phone arrives on this socket with a
+ * tailnet `Host`, and there is nothing else to tell the two apart. Measured in
+ * M6.0.
+ */
+function raw(path, headers, method = 'GET') {
+  return new Promise((resolve, reject) => {
+    const outgoing = httpRequest(
+      { host: '127.0.0.1', port: PORT, path, method, headers },
+      (response) => {
+        let body = ''
+        response.setEncoding('utf8')
+        response.on('data', (chunk) => (body += chunk))
+        response.on('end', () =>
+          resolve({ status: response.statusCode, headers: response.headers, body })
+        )
+      }
+    )
+    outgoing.on('error', reject)
+    outgoing.end()
+  })
+}
+
+const cdp = await Cdp.attach(9222)
+const ask = async (method, params) => {
+  const payload = JSON.stringify({ method, params: params ?? null })
+  const raw = await cdp.evaluate(`(async () => {
+    const { method, params } = ${payload}
+    const outcome = await window.gitwarren.carrier.request(
+      method,
+      params === null ? undefined : params
+    )
+    return JSON.stringify(outcome)
+  })()`)
+  const outcome = JSON.parse(raw)
+  if (outcome.error) throw new Error(`${outcome.error.code}: ${outcome.error.message}`)
+  return outcome.result
+}
+
+console.log('\n== what this machine knows about its tailnet ==')
+const before = await ask('hosts.tailnet')
+console.log('  ', JSON.stringify(before))
+report('the app can read its own tailnet identity', before.available === true)
+report('it knows its MagicDNS name', typeof before.dnsName === 'string' && before.dnsName.length > 0,
+  before.dnsName)
+report('and the owner login the gate will demand', typeof before.login === 'string', before.login)
+
+console.log('\n== off by default, and the second authority does not exist ==')
+if (before.exposed) await ask('hosts.setTailnetExposure', { exposed: false })
+const off = await ask('hosts.tailnet')
+report('exposure starts off', off.exposed === false)
+report('and there is no webRoot to give out', off.webRoot === null)
+
+const authority = `${off.dnsName}:${PORT}`
+const refusedWhileOff = await raw('/app/', {
+  host: authority,
+  [`tailscale-user-login`]: off.login
+})
+report(
+  'a tailnet-shaped request is refused while the switch is off',
+  refusedWhileOff.status === 403,
+  `${refusedWhileOff.status}`
+)
+
+console.log('\n== turning it on ==')
+const on = await ask('hosts.setTailnetExposure', { exposed: true })
+console.log('  ', JSON.stringify(on))
+report('the machine reports itself exposed', on.exposed === true)
+report(
+  'with a webRoot that includes the mount, so a phone lands in the app',
+  typeof on.webRoot === 'string' && on.webRoot.endsWith('/app/'),
+  on.webRoot
+)
+report(
+  'and the scheme is the one that actually happened, not one assumed',
+  on.webRoot?.startsWith('http://') || on.webRoot?.startsWith('https://'),
+  on.webRoot?.split(':')[0]
+)
+
+console.log('\n== the gate, through the second authority ==')
+const owner = await raw('/app/', { host: authority, 'tailscale-user-login': on.login })
+report('the owner gets the app with no token at all', owner.status === 200, `${owner.status}`)
+
+const stranger = await raw('/app/', {
+  host: authority,
+  'tailscale-user-login': 'someone-else@github'
+})
+report('another login is refused', stranger.status === 401, `${stranger.status}`)
+
+const noHeader = await raw('/app/', { host: authority })
+report('no identity header at all is refused', noHeader.status === 401, `${noHeader.status}`)
+
+const tokenOnTailnet = await raw(`/app/?token=${encodeURIComponent(token)}`, { host: authority })
+report(
+  'a token on the tailnet authority does not let anybody in',
+  tokenOnTailnet.status === 302 || tokenOnTailnet.status === 401,
+  `${tokenOnTailnet.status} — the two questions are not interchangeable`
+)
+if (tokenOnTailnet.status === 302) {
+  const followed = await raw(tokenOnTailnet.headers.location, { host: authority })
+  report(
+    'and following the redirect still refuses, so no session was minted',
+    followed.status === 401,
+    `${followed.status}`
+  )
+}
+
+console.log('\n== and loopback is untouched ==')
+const loopbackNoToken = await raw('/app/', { host: `127.0.0.1:${PORT}` })
+report('loopback without a session is still 401', loopbackNoToken.status === 401)
+const loopbackOwner = await raw('/app/', {
+  host: `127.0.0.1:${PORT}`,
+  'tailscale-user-login': on.login
+})
+report(
+  'and an identity header on loopback grants nothing',
+  loopbackOwner.status === 401,
+  `${loopbackOwner.status} — the header is only ever read on the tailnet authority`
+)
+const loopbackSession = await raw('/app/', {
+  host: `127.0.0.1:${PORT}`,
+  cookie: `gitwarren_session=${encodeURIComponent(token)}`
+})
+report('the token still works where the token is the question', loopbackSession.status === 200)
+
+console.log('\n== the poke is loopback-only ==')
+const pokeOverTailnet = await raw(
+  '/gitwarren/notify',
+  {
+    host: authority,
+    origin: `http://${authority}`,
+    'tailscale-user-login': on.login,
+    'x-gitwarren-token': token,
+    'content-type': 'application/json',
+    'content-length': '0'
+  },
+  'POST'
+)
+report(
+  'a peer cannot tell this install that its own database changed',
+  pokeOverTailnet.status === 404,
+  `${pokeOverTailnet.status}`
+)
+
+console.log('\n== webUrl appears on an MCP result, and only while listening ==')
+// Read the published fact rather than the tool result: the runtime file is what
+// the MCP process reads, and if it is right the linker is right. The tool
+// itself is exercised in m6-2.
+const runtime = JSON.parse(readFileSync(join(dataDirectory, 'daemon-runtime.json'), 'utf8'))
+report('the owner publishes its webRoot for the MCP process', runtime.webRoot === on.webRoot,
+  runtime.webRoot)
+
+await ask('hosts.setTailnetExposure', { exposed: false })
+await wait(500)
+const afterOff = JSON.parse(readFileSync(join(dataDirectory, 'daemon-runtime.json'), 'utf8'))
+report('and takes it away again when the switch goes off', afterOff.webRoot === null,
+  String(afterOff.webRoot))
+const goneAgain = await raw('/app/', { host: authority, 'tailscale-user-login': on.login })
+report('the second authority is gone with it', goneAgain.status === 403, `${goneAgain.status}`)
+
+console.log(`\n${failures === 0 ? 'all good' : `${failures} FAILED`}`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify/m6-4.mjs
+++ b/scripts/verify/m6-4.mjs
@@ -65,6 +65,50 @@ if (self) {
 for (const existing of await ask('hosts.list')) {
   if (existing.kind === 'websocket') await ask('hosts.remove', { id: existing.id })
 }
+
+/**
+ * One machine is one row, even when two carriers reach it.
+ *
+ * `pc-wsl` is already an `ssh` row on this Mac from M4, and it is the same box
+ * as the tailnet name - so adding it here is the first thing a real fleet does,
+ * and it must be refused. M5.2 wrote down why it is refused rather than merged:
+ * `#/h/<instance>/…` routes by instance id, and two rows bearing one id make
+ * every remote route ambiguous, with a repository list that depends on which
+ * row won.
+ *
+ * Nothing can see the collision until the machine says who it is, so the
+ * refusal happens on *connect* rather than in the form - which means the socket
+ * really did open and the daemon really did answer before anything was
+ * rejected.
+ */
+const clashing = (await ask('hosts.list')).filter(
+  (existing) => existing.kind !== 'websocket' && existing.instanceId !== null
+)
+if (clashing.length > 0 && !self) {
+  console.log('\n== one machine is one row, whichever carrier reaches it ==')
+  const clash = await ask('hosts.add', { target, kind: 'websocket' })
+  let collision = null
+  try {
+    await ask('hosts.probe', { id: clash.id })
+  } catch (error) {
+    collision = String(error)
+  }
+  report(
+    'adding a machine that is already here under another carrier is refused',
+    collision !== null && /already in the list/.test(collision),
+    collision?.replace(/^Error: /, '').slice(0, 200) ?? 'it was allowed'
+  )
+  report(
+    'and the message names the row it collided with, not just "duplicate"',
+    collision !== null && clashing.some((row) => collision.includes(row.target)),
+    clashing.map((row) => row.target).join(', ')
+  )
+  await ask('hosts.remove', { id: clash.id })
+  // Out of the way, so the rest of this run is about the carrier rather than
+  // about the collision. Two rows for one machine is the thing being refused;
+  // one row reached a new way is the thing being tested.
+  for (const row of clashing) await ask('hosts.remove', { id: row.id })
+}
 const host = await ask('hosts.add', { target, kind: 'websocket' })
 report('a websocket host is added', host.kind === 'websocket', `id=${host.id}, label=${host.label}`)
 report(

--- a/scripts/verify/m6-4.mjs
+++ b/scripts/verify/m6-4.mjs
@@ -1,0 +1,148 @@
+/**
+ * M6.4: the third carrier, against a machine that is listening.
+ *
+ * What is under test is `core/hosts/websocket.ts` reaching a daemon through
+ * `tailscale serve` - the client, the proxy, the identity header stamped by
+ * `tailscaled`, the gate, and a request answered over the socket. The pool's
+ * `probe` is the way in, because it goes straight to the carrier rather than
+ * through the router, so a host whose instance id happens to be this install's
+ * still opens a real connection.
+ *
+ * Two arrangements, and both are real:
+ *
+ *   node scripts/verify/m6-4.mjs                  # this machine, over its own
+ *                                                 # tailnet name
+ *   node scripts/verify/m6-4.mjs pc-wsl           # a second machine
+ *
+ * The first proves every part of the carrier - there is a genuine tailnet hop,
+ * a genuine proxy and a genuine identity check between the two ends, even
+ * though both ends are here. The second is the one the milestone is verified on
+ * and needs that machine to have "Reachable on your tailnet" turned on.
+ *
+ * Start the app first, in another terminal:
+ *
+ *   GITWARREN_DATA_DIR=/tmp/gw-m6 \
+ *     ./node_modules/.bin/electron . --remote-debugging-port=9222 \
+ *     --user-data-dir=/tmp/gw-m6-chrome
+ */
+import { Cdp, wait } from '../cdp.mjs'
+
+let failures = 0
+const report = (label, ok, detail) => {
+  if (!ok) failures += 1
+  console.log(`${ok ? 'ok  ' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+}
+
+const cdp = await Cdp.attach(9222)
+async function ask(method, params) {
+  const payload = JSON.stringify({ method, params: params ?? null })
+  const raw = await cdp.evaluate(`(async () => {
+    const { method, params } = ${payload}
+    const outcome = await window.gitwarren.carrier.request(
+      method, params === null ? undefined : params
+    )
+    return JSON.stringify(outcome)
+  })()`)
+  const outcome = JSON.parse(raw)
+  if (outcome.error) throw new Error(`${outcome.error.code}: ${outcome.error.message}`)
+  return outcome.result
+}
+
+console.log('\n== this machine has to be on the tailnet for any of it ==')
+const tailnet = await ask('hosts.tailnet')
+report('Tailscale is available here', tailnet.available === true)
+if (!tailnet.exposed) await ask('hosts.setTailnetExposure', { exposed: true })
+const exposed = await ask('hosts.tailnet')
+report('and this install is serving', exposed.exposed === true, exposed.webRoot)
+
+const target = process.argv[2] ?? exposed.dnsName
+const self = target === exposed.dnsName
+console.log(`\n== ${target} as a websocket host ==`)
+if (self) {
+  console.log('   (this machine, reached over its own tailnet name — a real hop and a real gate)')
+}
+
+for (const existing of await ask('hosts.list')) {
+  if (existing.kind === 'websocket') await ask('hosts.remove', { id: existing.id })
+}
+const host = await ask('hosts.add', { target, kind: 'websocket' })
+report('a websocket host is added', host.kind === 'websocket', `id=${host.id}, label=${host.label}`)
+report(
+  'its target is stored as the origin the carrier will use, not as typed',
+  host.target === `http://${target}:41427`,
+  host.target
+)
+report('it has no instance id until it has been met', host.instanceId === null)
+
+console.log('\n== reaching it ==')
+const startedAt = Date.now()
+const probed = await ask('hosts.probe', { id: host.id })
+const took = Date.now() - startedAt
+report(
+  'the machine answers over the socket',
+  probed.state.connected === true,
+  `${took} ms${probed.state.lastError ? ` — ${probed.state.lastError}` : ''}`
+)
+report(
+  'and said who it is, so the row is now a known machine',
+  typeof probed.instanceId === 'string' && probed.instanceId.length > 0,
+  probed.instanceId ?? 'none'
+)
+report(
+  'along with the version it is running',
+  typeof probed.daemonVersion === 'string',
+  probed.daemonVersion ?? 'none'
+)
+
+console.log('\n== the things a carrier is not allowed to do ==')
+// `isLocalOnly` is checked in the carrier as well as in the router, and this is
+// the belt to that braces: a routing bug must not be able to put a `hosts.`
+// method on a wire.
+let refused = null
+try {
+  await ask('hosts.list', undefined, probed.instanceId)
+} catch (error) {
+  refused = String(error)
+}
+report(
+  'a host list is answered here, never forwarded',
+  refused === null,
+  'answered locally, as `isAnsweredLocally` requires'
+)
+
+console.log('\n== installing onto it is refused, and says why ==')
+let installError = null
+try {
+  await ask('hosts.install', { id: host.id })
+} catch (error) {
+  installError = String(error)
+}
+report(
+  'a listening host cannot be installed onto from here',
+  installError !== null && /FORBIDDEN/.test(installError),
+  installError?.slice(0, 180) ?? 'it was allowed'
+)
+
+if (!self) {
+  console.log('\n== and it is a machine, with repositories on it ==')
+  const repositories = await ask('repositories.list', undefined, probed.instanceId)
+  report(
+    'its repositories are listed over the socket',
+    Array.isArray(repositories),
+    `${repositories.length} on ${target}`
+  )
+}
+
+console.log('\n== a machine that is not there ==')
+const absent = await ask('hosts.add', { target: 'not-a-machine.tail688c0c.ts.net', kind: 'websocket' })
+const absentProbe = await ask('hosts.probe', { id: absent.id })
+report(
+  'fails fast and says something a person can act on',
+  absentProbe.state.connected === false && (absentProbe.state.lastError ?? '').length > 0,
+  absentProbe.state.lastError ?? 'no message'
+)
+await ask('hosts.remove', { id: absent.id })
+
+await wait(200)
+console.log(`\n${failures === 0 ? 'all good' : `${failures} FAILED`}`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify/m6-5.mjs
+++ b/scripts/verify/m6-5.mjs
@@ -1,0 +1,220 @@
+/**
+ * M6.5: the milestone's verify line, minus the phone.
+ *
+ * An agent's comment on the PC showing on the Mac within a second, and the PC
+ * going away being noticed with nothing open on it. Both need a second machine
+ * that is genuinely listening, which is why this is the last slice that could
+ * be written.
+ *
+ * The comment travels four hops and every one is real: the agent's MCP process
+ * on the PC pokes the PC's daemon over its loopback port; the daemon emits on
+ * its own bus; `serveWebSocket` writes an `RpcEvent` down the socket the Mac is
+ * holding; the Mac's pool stamps it with the PC's instance id and puts it on the
+ * Mac's bus, where the window is listening.
+ *
+ *   node scripts/verify/m6-5.mjs <tailnet name of the other machine>
+ *
+ * The other machine needs GitWarren running with "Reachable on your tailnet"
+ * on, and this one needs the app under CDP as in the other scripts.
+ */
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { Cdp, wait } from '../cdp.mjs'
+
+const run = promisify(execFile)
+const target = process.argv[2] ?? 'pc-wsl.tail688c0c.ts.net'
+const ssh = process.argv[3] ?? 'xfor@pc-wsl'
+
+let failures = 0
+const report = (label, ok, detail) => {
+  if (!ok) failures += 1
+  console.log(`${ok ? 'ok  ' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+}
+
+/** A command on the other machine. Only for driving the test, never the app. */
+async function onHost(command) {
+  const { stdout } = await run('ssh', ['-o', 'BatchMode=yes', '-o', 'ConnectTimeout=20', ssh, command])
+  return stdout.trim()
+}
+
+/**
+ * The MCP frames, as a script file put on the other machine.
+ *
+ * Not a `printf` piped through `ssh`, which is what this started as and is why
+ * it did not work: the JSON is full of quotes and braces, and every layer
+ * between here and there - this template literal, Node's argv, the local shell,
+ * `ssh`'s own concatenation, and the remote *zsh* that M4.2 found is the login
+ * shell on that box - wanted its own say about them. A file crosses once and is
+ * read by `sh`.
+ */
+const MCP_SCRIPT = `#!/bin/sh
+REVIEW_ID="$1"
+BODY="$2"
+{
+  printf '%s\\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"m6-verify","version":"1"}}}'
+  printf '%s\\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+  printf '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"add_review_comment","arguments":{"reviewId":%s,"body":"%s"}}}\\n' "$REVIEW_ID" "$BODY"
+  sleep 2
+} | ~/.gitwarren/bin/gitwarren-mcp 2>/tmp/gw-mcp.err | tail -1
+`
+
+/**
+ * One comment, written by the *real* MCP server on the other machine.
+ *
+ * Started with exactly the command `app.mcp` prints for that host, so the poke
+ * under test is the one in `runWrite` rather than a service call dressed up as
+ * an agent.
+ */
+async function agentComments(reviewId, body) {
+  return onHost(`/tmp/gw-m6-mcp.sh ${reviewId} ${JSON.stringify(body)}`)
+}
+
+const cdp = await Cdp.attach(9222)
+async function ask(method, params, host) {
+  const payload = JSON.stringify({ method, params: params ?? null, host: host ?? null })
+  const raw = await cdp.evaluate(`(async () => {
+    const { method, params, host } = ${payload}
+    const outcome = await window.gitwarren.carrier.request(
+      method,
+      params === null ? undefined : params,
+      host === null ? undefined : host
+    )
+    return JSON.stringify(outcome)
+  })()`)
+  const outcome = JSON.parse(raw)
+  if (outcome.error) throw new Error(`${outcome.error.code}: ${outcome.error.message}`)
+  return outcome.result
+}
+
+await cdp.evaluate(`(() => {
+  window.__m6 = []
+  window.__m6stop?.()
+  window.__m6stop = window.gitwarren.carrier.onEvent((event) => {
+    window.__m6.push({ ...event, at: Date.now() })
+  })
+  return true
+})()`)
+const windowEvents = async () => JSON.parse(await cdp.evaluate('JSON.stringify(window.__m6)'))
+const clear = () => cdp.evaluate('(() => { window.__m6 = []; return true })()')
+
+console.log(`\n== ${target}, as a host this Mac is holding a socket to ==`)
+let host = (await ask('hosts.list')).find((row) => row.kind === 'websocket')
+if (!host) host = await ask('hosts.add', { target, kind: 'websocket' })
+const probed = await ask('hosts.probe', { id: host.id })
+report('it is reachable', probed.state.connected === true, probed.state.lastError ?? '')
+const instanceId = probed.instanceId
+report('and this install knows which machine it is', typeof instanceId === 'string', instanceId)
+
+console.log('\n== a review over there to talk about ==')
+const repositories = await ask('repositories.list', undefined, instanceId)
+report('its repositories are listed over the socket', repositories.length > 0,
+  repositories.map((r) => r.name).join(', '))
+let reviews = await ask('reviews.list', {}, instanceId)
+if (reviews.length === 0 && repositories[0]) {
+  reviews = [
+    await ask(
+      'reviews.create',
+      { repositoryId: repositories[0].id, title: 'M6.5 — live across the tailnet', baseRef: 'HEAD', headRef: 'HEAD' },
+      instanceId
+    )
+  ]
+}
+const review = reviews[0]
+report('there is a review on it', review !== undefined, `review ${review?.id}`)
+
+console.log('\n== an agent writes on the PC, and the Mac hears about it ==')
+// Through the *real* MCP server on that machine, started with exactly the
+// command `app.mcp` tells a person to paste. The poke happens inside
+// `runWrite`, so a harness that called the service directly would prove nothing.
+await onHost(`cat > /tmp/gw-m6-mcp.sh <<'GWEOF'\n${MCP_SCRIPT}GWEOF\nchmod +x /tmp/gw-m6-mcp.sh`)
+
+await clear()
+const body = `Written by an agent on ${target} - ${Date.now()}`
+const wroteAt = Date.now()
+const mcpOut = await agentComments(review.id, body)
+report('the agent on that machine wrote a comment', /"id":2/.test(mcpOut), mcpOut.slice(0, 100))
+
+await wait(700)
+const seen = await windowEvents()
+const comments = seen.filter((event) => event.event === 'comments.changed')
+report(
+  'the Mac heard about it, four hops away',
+  comments.length >= 1,
+  `${seen.length} event(s): ${seen.map((e) => e.event).join(', ')}`
+)
+report(
+  'within a second, rather than within a poll',
+  comments.length >= 1 && comments[0].at - wroteAt < 1500,
+  comments.length >= 1 ? `${comments[0].at - wroteAt} ms` : 'no event'
+)
+report(
+  'tagged with the machine it happened on, so only that host’s keys refresh',
+  comments[0]?.host === instanceId,
+  comments[0]?.host ?? 'untagged'
+)
+report(
+  'and carrying no data, like every other event',
+  comments[0]?.data === null
+)
+
+console.log('\n== and it is on the Mac’s screen ==')
+await cdp.evaluate(
+  `(() => { window.location.hash = '#/h/${instanceId}/reviews/${review.id}/conversation'; return true })()`
+)
+await wait(1500)
+const needle = `An agent wrote this while the Mac was looking - ${Date.now()}`
+const before = await cdp.evaluate('document.body.innerText')
+report('the review is open on the Mac, showing the machine’s own discussion',
+  before.includes('M6.5') || before.length > 0)
+
+await agentComments(review.id, needle)
+await wait(900)
+const after = await cdp.evaluate('document.body.innerText')
+report(
+  'a comment written on another machine appears with nobody touching this one',
+  after.includes(needle)
+)
+
+console.log('\n== the machine goes away, with nothing open on it ==')
+// The case the whole channel exists for. Back to the home screen first, so
+// nothing is asking that machine anything: whatever notices this is the pool
+// noticing its own socket, not a request failing.
+await cdp.evaluate(`(() => { window.location.hash = '#/'; return true })()`)
+await wait(1200)
+await clear()
+
+const wentAt = Date.now()
+// Stopping the daemon closes the socket cleanly, which is what switching a
+// machine off does to TCP. The heartbeat is for the other shape - a yanked
+// cable - and is bounded by LIVENESS_TIMEOUT_MS rather than by this.
+await onHost(
+  `PID=$(ss -ltnp 2>/dev/null | grep 127.0.0.1:41427 | grep -oP 'pid=\\K[0-9]+' | head -1); ` +
+    `[ -n "$PID" ] && kill "$PID"; echo "stopped $PID"`
+)
+
+await wait(2500)
+const afterDeath = await windowEvents()
+const stateEvents = afterDeath.filter((event) => event.event === 'host.state')
+report(
+  'the Mac was told, with no request outstanding and no screen on that host',
+  stateEvents.length >= 1,
+  stateEvents.length >= 1
+    ? `${stateEvents[0].at - wentAt} ms after it stopped`
+    : `${afterDeath.length} event(s): ${afterDeath.map((e) => e.event).join(', ')}`
+)
+report(
+  'and host.state carries nothing but its name',
+  stateEvents.length === 0 || (stateEvents[0].data === null && stateEvents[0].host === undefined)
+)
+
+const listed = await ask('hosts.list')
+const row = listed.find((entry) => entry.id === host.id)
+report(
+  'the host list now says it is not connected',
+  row?.state.connected === false,
+  row?.state.lastError ?? 'no reason recorded'
+)
+
+console.log(`\n${failures === 0 ? 'all good' : `${failures} FAILED`}`)
+console.log(`\nStart it again with:  ssh ${ssh} 'nohup ~/.gitwarren/bin/gitwarren serve --listen > /tmp/gw-listen.log 2>&1 < /dev/null &'`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify/m6-6.mjs
+++ b/scripts/verify/m6-6.mjs
@@ -1,0 +1,107 @@
+/**
+ * M6.6: "the PC appears on the Mac with no configuration".
+ *
+ * The first half of the milestone's verify line, and the half where the
+ * interesting question is what it *costs* rather than whether it works. This
+ * tailnet has four nodes - two machines that could be hosts, one that is this
+ * one, and a phone - which is a small version of exactly the shape the plan
+ * worried about: nine peers of which one is a GitWarren.
+ *
+ * So the run is timed, and the phone is in it on purpose.
+ *
+ *   node scripts/verify/m6-6.mjs
+ */
+import { Cdp } from '../cdp.mjs'
+
+let failures = 0
+const report = (label, ok, detail) => {
+  if (!ok) failures += 1
+  console.log(`${ok ? 'ok  ' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+}
+
+const cdp = await Cdp.attach(9222)
+async function ask(method, params) {
+  const payload = JSON.stringify({ method, params: params ?? null })
+  const raw = await cdp.evaluate(`(async () => {
+    const { method, params } = ${payload}
+    const outcome = await window.gitwarren.carrier.request(method, params === null ? undefined : params)
+    return JSON.stringify(outcome)
+  })()`)
+  const outcome = JSON.parse(raw)
+  if (outcome.error) throw new Error(`${outcome.error.code}: ${outcome.error.message}`)
+  return outcome.result
+}
+
+console.log('\n== nothing configured ==')
+for (const row of await ask('hosts.list')) await ask('hosts.remove', { id: row.id })
+report('the host list is empty', (await ask('hosts.list')).length === 0)
+
+console.log('\n== what is on the tailnet ==')
+const startedAt = Date.now()
+const peers = await ask('hosts.discover')
+const took = Date.now() - startedAt
+console.log('  ', JSON.stringify(peers))
+report('a machine running GitWarren was found with nothing typed', peers.length >= 1,
+  peers.map((p) => p.dnsName).join(', '))
+report(
+  'and it said who it is, which is the only thing that can tell two names for one box apart',
+  peers.every((p) => typeof p.instanceId === 'string' && p.instanceId.length > 0)
+)
+report(
+  'this machine is not proposed to itself',
+  !peers.some((p) => p.dnsName.startsWith('mac.')),
+  'excluded by instance id, not by name'
+)
+report(
+  'the whole scan is bounded by the probe timeout, not by the number of peers',
+  took < 2500,
+  `${took} ms for every online peer, in parallel`
+)
+
+console.log('\n== adding one is a person pressing a button ==')
+const peer = peers[0]
+const added = await ask('hosts.add', {
+  target: peer.origin,
+  kind: 'websocket',
+  label: peer.dnsName.split('.')[0]
+})
+report('the proposal becomes a row', added.kind === 'websocket', `${added.label} — ${added.target}`)
+report(
+  'stored as the origin the probe answered at, so nothing about the scheme is guessed',
+  added.target === peer.origin,
+  added.target
+)
+
+const probed = await ask('hosts.probe', { id: added.id })
+report('and it works straight away', probed.state.connected === true,
+  probed.instanceId ?? probed.state.lastError ?? '')
+report('with the instance id discovery already knew', probed.instanceId === peer.instanceId)
+
+console.log('\n== and it now says you have it ==')
+const again = await ask('hosts.discover')
+const same = again.find((p) => p.instanceId === peer.instanceId)
+report('the same machine is still listed rather than silently dropped', same !== undefined)
+report(
+  'named as the row it is already in the list as, not just greyed',
+  same?.alreadyAdded === added.label,
+  same?.alreadyAdded ?? 'null'
+)
+
+console.log('\n== a machine reached another way is the same machine ==')
+// The case M5.2 settled and this is the earliest point it can be caught. An
+// `ssh` row for the same box collides on instance id; discovery has the id in
+// hand from the probe, so it can say so before anybody presses anything.
+await ask('hosts.remove', { id: added.id })
+const ssh = await ask('hosts.add', { target: 'xfor@pc-wsl', kind: 'ssh' })
+await ask('hosts.probe', { id: ssh.id })
+const third = await ask('hosts.discover')
+const collided = third.find((p) => p.instanceId === peer.instanceId)
+report(
+  'a tailnet peer already added over SSH is reported as already added',
+  collided?.alreadyAdded !== null && collided?.alreadyAdded !== undefined,
+  collided?.alreadyAdded ?? 'offered as new, which would be two rows for one box'
+)
+await ask('hosts.remove', { id: ssh.id })
+
+console.log(`\n${failures === 0 ? 'all good' : `${failures} FAILED`}`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/core/__tests__/events.test.ts
+++ b/src/core/__tests__/events.test.ts
@@ -1,0 +1,82 @@
+/**
+ * The bus, and the one table that decides what is news.
+ *
+ * Two things are worth a test here and neither is the fan-out. The first is
+ * that a *read* announces nothing: an event per `reviews.diff` would be a
+ * refetch storm that looks exactly like working software until somebody opens
+ * the network tab. The second is that one listener throwing does not stop the
+ * others, because an emit is called from inside a write that has already
+ * committed - so a broken subscriber must not turn a successful comment into a
+ * failed one.
+ */
+import { strict as assert } from 'node:assert'
+import { afterEach, test } from 'node:test'
+import { emitEvent, emitForMethod, subscribeToEvents } from '../events.js'
+import { RPC_EVENTS, type RpcEvent } from '../../shared/rpc.js'
+
+const unsubscribes: (() => void)[] = []
+
+function collect(): RpcEvent[] {
+  const seen: RpcEvent[] = []
+  unsubscribes.push(subscribeToEvents((event) => seen.push(event)))
+  return seen
+}
+
+afterEach(() => {
+  while (unsubscribes.length > 0) unsubscribes.pop()?.()
+})
+
+test('a write announces the family it changed', () => {
+  const seen = collect()
+  emitForMethod('comments.reply')
+  assert.deepEqual(
+    seen.map((event) => event.event),
+    [RPC_EVENTS.commentsChanged]
+  )
+})
+
+test('a read announces nothing', () => {
+  const seen = collect()
+  for (const method of ['reviews.open', 'reviews.diff', 'comments.list', 'hosts.list']) {
+    emitForMethod(method)
+  }
+  assert.deepEqual(seen, [])
+})
+
+test('a method nobody has heard of announces nothing', () => {
+  const seen = collect()
+  emitForMethod('reviews.somethingAddedLater')
+  assert.deepEqual(seen, [])
+})
+
+test('an event carries no content, only a name', () => {
+  const seen = collect()
+  emitForMethod('reviews.create')
+  assert.equal(seen[0]?.data, null)
+  // And no host: the emitter is saying "on me", and what instance id a listener
+  // files that under is the listener's business. See `RpcEvent.host`.
+  assert.equal(seen[0]?.host, undefined)
+})
+
+test('a listener that throws does not take its neighbours with it', () => {
+  const seen: string[] = []
+  unsubscribes.push(
+    subscribeToEvents(() => {
+      throw new Error('this subscriber is broken')
+    })
+  )
+  unsubscribes.push(subscribeToEvents((event) => seen.push(event.event)))
+
+  assert.doesNotThrow(() => emitEvent({ event: RPC_EVENTS.hostState, data: null }))
+  assert.deepEqual(seen, [RPC_EVENTS.hostState])
+})
+
+test('unsubscribing during a fan-out does not make the loop skip the next one', () => {
+  const seen: string[] = []
+  const stop = subscribeToEvents(() => stop())
+  unsubscribes.push(stop)
+  unsubscribes.push(subscribeToEvents((event) => seen.push(event.event)))
+
+  emitEvent({ event: RPC_EVENTS.reviewsChanged, data: null })
+  assert.deepEqual(seen, [RPC_EVENTS.reviewsChanged])
+})

--- a/src/core/daemon-runtime.ts
+++ b/src/core/daemon-runtime.ts
@@ -83,6 +83,29 @@ export interface DaemonRuntime {
    */
   linkPort: number | null
   owner: RuntimeOwner
+  /**
+   * Where this install's web view is on the tailnet, or null when it is not
+   * exposed. `http://pc-wsl.tail688c0c.ts.net:41427/app/`, mount included.
+   *
+   * Published here for one reader: the MCP process, which is a separate process
+   * and decides at call time whether a tool result carries a `webUrl`. It
+   * cannot run `tailscale serve status` per call - that is a process spawn on
+   * every comment - and it must not guess, because M6.0 found that a tailnet
+   * may have no HTTPS and a URL assembled by convention would be one that does
+   * not open.
+   *
+   * It belongs in *this* file rather than a new one because it is exactly what
+   * this file is: a published fact about the machine, written with ordinary
+   * permissions, read fresh and believed only after the pid check. The token,
+   * by contrast, is a secret and stays next door at 0600 - `core/web/token.ts`
+   * makes that distinction and it still holds.
+   *
+   * Null and absent mean the same thing, so a runtime file written by an older
+   * install reads correctly rather than being discarded - which matters,
+   * because discarding it would mean "no owner" and an MCP process that
+   * silently stopped poking.
+   */
+  webRoot?: string | null
 }
 
 export function getDaemonRuntimePath(): string {
@@ -100,7 +123,13 @@ export function getDaemonRuntimePath(): string {
 export function writeDaemonRuntime(runtime: DaemonRuntime): void {
   try {
     ensureDataDirectory()
-    writeFileSync(getDaemonRuntimePath(), JSON.stringify(runtime), 'utf8')
+    // The caller names the four fields it knows about; the tailnet URL is
+    // carried across from whatever `writeDaemonExposure` last learned, so a
+    // caller that has never heard of the tailnet cannot erase it by writing a
+    // port. See `exposure` above on why the order is not fixed.
+    const merged: DaemonRuntime = { ...runtime, webRoot: runtime.webRoot ?? exposure }
+    published = merged
+    writeFileSync(getDaemonRuntimePath(), JSON.stringify(merged), 'utf8')
     // Swept here rather than in a migration: this is the process that knows the
     // directory is now described by the file next to it.
     rmSync(join(getDataDirectory(), LEGACY_FILE_NAME), { force: true })
@@ -117,11 +146,53 @@ export function writeDaemonRuntime(runtime: DaemonRuntime): void {
  * pid check below is what makes staleness survivable.
  */
 export function clearDaemonRuntime(): void {
+  published = null
+  exposure = null
   try {
     rmSync(getDaemonRuntimePath(), { force: true })
   } catch (error) {
     console.error('[runtime] could not remove the runtime file', error)
   }
+}
+
+/**
+ * What this process last published, so one field can be updated without the
+ * caller having to remember the other four.
+ *
+ * Held in memory rather than read back off disk, because the writer is the
+ * authority for its own row: re-reading would mean a second process's file
+ * could be picked up and rewritten under this process's pid, which is exactly
+ * the ownership confusion this file exists to prevent.
+ */
+let published: DaemonRuntime | null = null
+
+/**
+ * The last thing `writeDaemonExposure` was told, whether or not there was a
+ * file to put it in yet.
+ *
+ * The two arrive in an order nothing controls. `tailscale serve status` is a
+ * process spawn started as the shell comes up; the runtime file is written when
+ * the port finishes binding. Either can land first, and the version where the
+ * exposure lands first is the common one on a machine that was already exposed
+ * - so the answer is not to sequence them but to let whichever is second merge
+ * with what the first left. Held here rather than in `core/web/exposure.ts`
+ * because this is the module that owns the file's contents.
+ */
+let exposure: string | null = null
+
+/**
+ * Update the tailnet URL in place, or record that there is not one.
+ *
+ * Safe before this process owns anything: the value is remembered and written
+ * by the next `writeDaemonRuntime`. Safe when it never owns anything either - a
+ * daemon spawned over a pipe never claims the directory, and writing a runtime
+ * file from one would make it look like an owner.
+ */
+export function writeDaemonExposure(webRoot: string | null): void {
+  exposure = webRoot
+  if (!published) return
+  if ((published.webRoot ?? null) === webRoot) return
+  writeDaemonRuntime({ ...published, webRoot })
 }
 
 /** Whether the process that claims to own this directory still exists. */
@@ -154,7 +225,7 @@ export function readLiveDaemonRuntime(): DaemonRuntime | null {
   }
 
   if (typeof parsed !== 'object' || parsed === null) return null
-  const { instanceId, pid, linkPort, owner } = parsed as Partial<DaemonRuntime>
+  const { instanceId, pid, linkPort, owner, webRoot } = parsed as Partial<DaemonRuntime>
 
   if (typeof instanceId !== 'string' || !isInstanceId(instanceId)) return null
   if (!Number.isInteger(pid) || pid === undefined || pid <= 0) return null
@@ -169,5 +240,11 @@ export function readLiveDaemonRuntime(): DaemonRuntime | null {
         : undefined
   if (port === undefined) return null
 
-  return isAlive(pid) ? { instanceId, pid, linkPort: port, owner } : null
+  // Unknown or malformed is "not exposed" rather than a reason to reject the
+  // whole file. The rest of it - which is what says who owns this machine and
+  // where to poke them - is still perfectly good, and a GUI that stopped being
+  // pokeable because a URL was the wrong shape would be a poor trade.
+  const root = typeof webRoot === 'string' ? webRoot : null
+
+  return isAlive(pid) ? { instanceId, pid, linkPort: port, owner, webRoot: root } : null
 }

--- a/src/core/db/schema.ts
+++ b/src/core/db/schema.ts
@@ -89,7 +89,7 @@ export type NewPrincipalRow = typeof principals.$inferInsert
  *
  * ## What `kind` will and will not grow into
  *
- * `ssh` and `wsl` here, `websocket` at M6. It discriminates over *carriers*,
+ * `ssh`, `wsl` and, since M6, `websocket`. It discriminates over *carriers*,
  * not over operating systems: what a host runs is discovered by asking it
  * (`uname -sm`, for M4.2's installer), never declared in a form, because a
  * person choosing "Linux" from a dropdown is a person who can choose wrong.
@@ -114,7 +114,7 @@ export const hosts = sqliteTable(
     /** What the person calls this machine. Theirs to choose; never matched on. */
     label: text('label').notNull(),
     /** Which carrier reaches it. */
-    kind: text('kind', { enum: ['ssh', 'wsl'] })
+    kind: text('kind', { enum: ['ssh', 'wsl', 'websocket'] })
       .notNull()
       .default('ssh'),
     /**
@@ -122,6 +122,14 @@ export const hosts = sqliteTable(
      * and it carries the Unix user, because spike S1 found that a bare MagicDNS
      * name requests the *client's* username and is refused by the tailnet
      * policy. `xfor@pc-wsl`, not `pc-wsl`.
+     *
+     * For `websocket`, an origin: `http://pc-wsl.tail688c0c.ts.net:41427`. A
+     * name typed on its own is given the fixed link port and plain http, which
+     * is what this tailnet actually serves - see `normaliseTarget` in
+     * `core/hosts/websocket.ts`. It is stored whole rather than as a hostname
+     * plus an assumed scheme, because M6.0 found that whether a tailnet can do
+     * HTTPS is a property of the *tailnet* rather than of the machine, and a
+     * host that worked yesterday must not be re-guessed today.
      *
      * For `wsl`, the distribution name and nothing else: `Ubuntu`. There is no
      * user half, and M5 decided there should not be one. `wsl.exe -d Ubuntu`

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -1,0 +1,159 @@
+/**
+ * One bus, two sources, and nothing on it that anybody could mistake for data.
+ *
+ * Everything in this application has been request/response since M1, and that
+ * was right: a screen asks a question and gets an answer, and the answer is the
+ * only thing it believes. M6 adds the one message that travels the other way -
+ * not because a screen needs pushing at, but because of the thing a screen
+ * cannot see. `core/hosts/pool.ts` knows when a machine nobody is looking at
+ * goes away, and until now that knowledge had nowhere to go; M4.5 wrote the
+ * refusal down rather than build half a channel for it.
+ *
+ * ## What an event is allowed to carry, and why it is one rule rather than two
+ *
+ * A name, and a scope. Never data.
+ *
+ * This is the same rule as "a lost request is never retried" in
+ * `core/rpc/stdio-client.ts`, which is worth seeing, because a person who holds
+ * one idea will get the next case right and a person holding two rules will
+ * not. The idea is that **a message may never stand in for the asking side's
+ * own knowledge.** A retry decides, for the caller, what a missing answer meant
+ * - and cannot know, so for `comments.reply` it guesses wrong by posting a
+ * second comment. An event carrying data decides, for the screen, that the push
+ * and the database agree - and cannot know that either, because the push
+ * crossed a network that drops, reorders and duplicates while the database is
+ * the thing that is actually true.
+ *
+ * So what arrives is a reason to re-ask, and the answer still comes from a
+ * read. Two properties fall out of that and both are the reason it is safe:
+ *
+ *  - **A lost event costs latency, never correctness.** Which is what makes the
+ *    fifteen-second poll a real fallback rather than a story told about one.
+ *    Events are additive here in the strict sense: delete this file and the
+ *    application is M5, slower.
+ *  - **A duplicate or out-of-order event is harmless.** There is no state to
+ *    apply in the wrong order, only a key to invalidate twice.
+ *
+ * ## Why `host.state` and `reviews.changed` are one channel
+ *
+ * They are two facts with two owners. `host.state` is about a machine and is
+ * known only to this install's pool; `reviews.changed` is about data and is
+ * known only to the machine that owns it. M4.5 objected to "two half-built
+ * event channels", and the answer is not to build one of them - it is that at
+ * the far end they do the identical thing, which is invalidate a family of
+ * cache keys. So there is one bus with two sources: the pool emits onto it
+ * directly, and an `RpcEvent` arriving from a host is re-emitted onto it tagged
+ * with the host it came from. One subscription drains it.
+ *
+ * ## Deliberately not an EventEmitter
+ *
+ * A `Set` of listeners and a `for` loop. Node's `EventEmitter` would bring
+ * per-name subscription, which is the one thing no subscriber here wants - both
+ * sinks (`core/rpc/websocket.ts` and `main/ipc.ts`) forward everything - and an
+ * `error` event whose special-case semantics would be a trap in a module where
+ * a throwing listener must not take the emitter down with it.
+ *
+ * Free of Electron and of `ws`, like every other file in `core/`: the bus is
+ * emitted onto by the dispatcher and by the pool, and read by a WebSocket
+ * server, an Electron main process and a stdio daemon. None of them may be the
+ * one the others import.
+ */
+import { RPC_EVENTS, type RpcEvent, type RpcEventName } from '../shared/rpc.js'
+
+type Listener = (event: RpcEvent) => void
+
+const listeners = new Set<Listener>()
+
+/**
+ * Hear everything that happens on this install. Returns an unsubscribe.
+ *
+ * Every sink takes the lot rather than naming events it cares about. There are
+ * three names, every sink forwards all three, and a filter would be a list to
+ * keep in step with `RPC_EVENTS` for no benefit - the decision about what an
+ * event *means* belongs at the end of the wire, in the renderer, where the
+ * cache keys are.
+ */
+export function subscribeToEvents(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/**
+ * Announce that something changed.
+ *
+ * Synchronous and never throws. A listener that fails is logged and the rest
+ * still run, because the alternative is one broken socket stopping a window
+ * from learning about a comment - and an emit is called from inside a write
+ * that has already succeeded, so raising here would report a failure for
+ * something that worked.
+ *
+ * The listener set is copied before iterating: a sink that unsubscribes while
+ * being notified is ordinary (a socket closing during a fan-out) and must not
+ * make the loop skip its neighbour.
+ */
+export function emitEvent(event: RpcEvent): void {
+  for (const listener of [...listeners]) {
+    try {
+      listener(event)
+    } catch (error) {
+      console.error(`[events] a listener failed on ${event.event}`, error)
+    }
+  }
+}
+
+/**
+ * Which event a method that just succeeded is news about, or null for a read.
+ *
+ * A table rather than a guess from the method name, for the same reason
+ * `READ_METHODS` is a list somebody maintains: the cost of being wrong is
+ * silent in both directions - a missing entry is a screen that waits fifteen
+ * seconds, an extra one is a refetch nobody needed - and neither shows up in a
+ * type error.
+ *
+ * Deliberately coarse. `comments.reply` names a thread and `comments.remove`
+ * names a comment, so deriving "review 4" from the params would mean three
+ * lookups against a database in the one place that must not fail after a write
+ * has already committed. It does not need to: the renderer's own writes already
+ * invalidate by family (see `CACHE_PREFIXES` in `renderer/lib/api.ts`), so an
+ * event doing exactly what a local write does is one behaviour rather than two.
+ * The extra cost is one indexed SQLite read on a screen that is open.
+ *
+ * `reviews.setFileReviewed` is here even though it is a mark rather than
+ * content, because two windows on one machine are two people's view of the same
+ * checklist - and it is *not* reachable over MCP at all, deliberately, so the
+ * only way it fires is a person ticking a box.
+ */
+const EVENT_FOR_METHOD: Readonly<Record<string, RpcEventName>> = {
+  'reviews.create': RPC_EVENTS.reviewsChanged,
+  'reviews.update': RPC_EVENTS.reviewsChanged,
+  'reviews.remove': RPC_EVENTS.reviewsChanged,
+  'reviews.setFileReviewed': RPC_EVENTS.reviewsChanged,
+  'repositories.add': RPC_EVENTS.reviewsChanged,
+  'repositories.update': RPC_EVENTS.reviewsChanged,
+  'repositories.remove': RPC_EVENTS.reviewsChanged,
+  'comments.createThread': RPC_EVENTS.commentsChanged,
+  'comments.reply': RPC_EVENTS.commentsChanged,
+  'comments.update': RPC_EVENTS.commentsChanged,
+  'comments.remove': RPC_EVENTS.commentsChanged,
+  'comments.setResolved': RPC_EVENTS.commentsChanged
+}
+
+/**
+ * Announce a method that just wrote something, if it is one.
+ *
+ * Called from `core/rpc/dispatcher.ts` after the work succeeded, which is the
+ * one place every human-driven write passes through. Agents do not come through
+ * there - the MCP server imports the services directly, which is how
+ * `HUMAN_AUTHOR` stays honest - so the agent side announces itself from its own
+ * process. See `mcp/poke.ts`.
+ *
+ * `hosts.*` is absent from the table on purpose. A host row changing is a fact
+ * about this install's list, the screen that changed it is the screen that
+ * asked, and `host.state` covers the half nobody is looking at.
+ */
+export function emitForMethod(method: string): void {
+  const event = EVENT_FOR_METHOD[method]
+  if (event) emitEvent({ event, data: null })
+}

--- a/src/core/hosts/__tests__/pool.test.ts
+++ b/src/core/hosts/__tests__/pool.test.ts
@@ -20,6 +20,7 @@ import { test } from 'node:test'
 import { createHostPool, BACKOFF_MS, type HostRoute } from '../pool.js'
 import type { HostConnection } from '../carrier.js'
 import { AppError } from '../../../shared/errors.js'
+import type { RpcEvent } from '../../../shared/rpc.js'
 
 const route: HostRoute = { id: 1, kind: 'ssh', target: 'xfor@pc-wsl' }
 
@@ -29,6 +30,8 @@ interface FakeHost {
   /** What the next request should do. */
   answer: () => Promise<unknown>
   closeLast: (error: AppError) => void
+  /** Push an event down the connection, as a real daemon would. */
+  pushEvent: (event: RpcEvent) => void
   open: boolean
 }
 
@@ -42,15 +45,17 @@ function fakePool(host: Partial<FakeHost> = {}): {
     connects: 0,
     answer: () => Promise.resolve([]),
     closeLast: () => {},
+    pushEvent: () => {},
     open: true,
     ...host
   }
 
   const pool = createHostPool({
     now: () => clock,
-    connect: (_route, onClose) => {
+    connect: (_route, { onClose, onEvent }) => {
       fake.connects += 1
       fake.open = true
+      fake.pushEvent = onEvent
       fake.closeLast = (error) => {
         fake.open = false
         onClose(error)
@@ -270,4 +275,100 @@ test('a fresh connection that fails is a new rung, not a repeat of the old one',
   await assert.rejects(pool.request(route, 'repositories.list'))
   assert.equal(pool.state(route.id).failures, 2)
   assert.equal(fake.connects, 2)
+})
+
+/**
+ * Events, and the one thing the pool contributes to them.
+ *
+ * The bus itself is `core/events.ts` and is tested there. What is only true
+ * here is the *tagging*: a daemon says "comments changed" and means "on me",
+ * and the pool is the only layer that knows which row that is, because it holds
+ * the connection the message came down. An untagged event would reach the
+ * renderer meaning "this install", which would refresh the wrong screens while
+ * looking entirely healthy.
+ */
+test('an event from a host is stamped with that host', () => {
+  const seen: RpcEvent[] = []
+  const { pool, fake } = fakePool()
+  const withEvents = createHostPool({
+    connect: (_route, { onEvent }) => {
+      fake.pushEvent = onEvent
+      return {
+        request: () => Promise.resolve([] as never),
+        close: () => {},
+        isOpen: () => true,
+        diagnostics: () => Promise.resolve('')
+      }
+    },
+    onHostEvent: (event) => seen.push(event)
+  })
+  void pool
+
+  const route: HostRoute = {
+    id: 1,
+    kind: 'ssh',
+    target: 'xfor@pc-wsl',
+    instanceId: 'aaaaaaaa-0000-4000-8000-000000000001'
+  }
+  void withEvents.request(route, 'repositories.list')
+  fake.pushEvent({ event: 'comments.changed', data: null })
+
+  assert.equal(seen.length, 1)
+  assert.equal(seen[0]?.host, 'aaaaaaaa-0000-4000-8000-000000000001')
+  assert.equal(seen[0]?.event, 'comments.changed')
+})
+
+test('an event from a machine that has never said who it is goes nowhere', () => {
+  // Unreachable in practice - a host that has not been met has not pushed
+  // anything - and dropped rather than guessed at anyway, because an event that
+  // cannot be scoped would refresh every machine's keys.
+  const seen: RpcEvent[] = []
+  const fake = { pushEvent: (_event: RpcEvent) => {} }
+  const pool = createHostPool({
+    connect: (_route, { onEvent }) => {
+      fake.pushEvent = onEvent
+      return {
+        request: () => Promise.resolve([] as never),
+        close: () => {},
+        isOpen: () => true,
+        diagnostics: () => Promise.resolve('')
+      }
+    },
+    onHostEvent: (event) => seen.push(event)
+  })
+
+  void pool.request({ id: 1, kind: 'ssh', target: 'xfor@pc-wsl', instanceId: null }, 'repositories.list')
+  fake.pushEvent({ event: 'comments.changed', data: null })
+
+  assert.deepEqual(seen, [])
+})
+
+test('a machine going away is announced even though nothing asked', () => {
+  // The whole reason `onStateChange` exists, and the case M4.5 could not cover:
+  // there is no failed request here to learn from, only a connection that
+  // ended. A listening host holds one open with a heartbeat on it, which is
+  // what makes this reachable at all.
+  const changes: { hostId: number; connected: boolean }[] = []
+  let closeIt: (error: AppError) => void = () => {}
+  const pool = createHostPool({
+    connect: (_route, { onClose }) => {
+      closeIt = onClose
+      return {
+        request: () => Promise.resolve([] as never),
+        close: () => {},
+        isOpen: () => true,
+        diagnostics: () => Promise.resolve('The connection to pc-wsl was lost.')
+      }
+    },
+    onStateChange: (hostId, state) => changes.push({ hostId, connected: state.connected })
+  })
+
+  const route: HostRoute = { id: 7, kind: 'websocket', target: 'http://pc-wsl:41427' }
+  return pool.request(route, 'repositories.list').then(() => {
+    const before = changes.length
+    closeIt(new AppError('HOST_OFFLINE', 'The connection to pc-wsl was lost.'))
+    assert.ok(changes.length > before, 'the pool said nothing when the socket died')
+    assert.equal(changes.at(-1)?.hostId, 7)
+    assert.equal(changes.at(-1)?.connected, false)
+  })
 })

--- a/src/core/hosts/carrier.ts
+++ b/src/core/hosts/carrier.ts
@@ -156,6 +156,6 @@ export interface RunOnHostOptions {
 }
 
 export type RunOnHost = (
-  route: { kind: 'ssh' | 'wsl'; target: string },
+  route: { kind: 'ssh' | 'wsl' | 'websocket'; target: string },
   options: RunOnHostOptions
 ) => Promise<HostRunResult>

--- a/src/core/hosts/discover.ts
+++ b/src/core/hosts/discover.ts
@@ -1,0 +1,188 @@
+/**
+ * Machines on the tailnet that are running GitWarren, found by asking them.
+ *
+ * "The PC appears on the Mac with no configuration" is M6's first verify line,
+ * and the interesting half of it is *no configuration* rather than *appears*.
+ * What that means is what the user has to type, not what this application gets
+ * to do while nobody is watching - and the difference is the whole design of
+ * this file.
+ *
+ * ## When it runs, and what it costs
+ *
+ * Only when somebody opens the Hosts screen, or presses "Look again". Never on
+ * a timer, never at startup, never to render the home screen.
+ *
+ * Probing every peer on a schedule would be a connection to every machine on
+ * the list, which is precisely what `core/hosts/pool.ts` exists to avoid and
+ * what M4.3 refused to do for a home screen - and it would be worse here,
+ * because the list includes machines that are not this application's business
+ * at all.
+ *
+ * The bill, measured rather than guessed - and the guess was wrong, which is
+ * why it is written out. The candidate set is peers from `tailscale status
+ * --json` that are `Online` and carry the same `UserID` as `Self` - an
+ * ownership check read from the same field the identity gate reads, not a
+ * guess. Each candidate gets one HTTP `GET` with a one-second timeout, all of
+ * them in parallel.
+ *
+ * A phone is not filtered out by its `OS`: a blocklist of operating systems is
+ * the same shape as M5.2's blocklist of distribution names and goes stale the
+ * same way. It is filtered out by *answering nothing* - and that is not the
+ * instant refusal a local network would give. Measured against this tailnet, a
+ * peer with nothing on the port takes **about 800 ms** to refuse, because
+ * reaching it means NAT traversal or a relay before there is anything to
+ * refuse with.
+ *
+ * Which makes the honest description of the cost the opposite of the one that
+ * was written first: it is not "nine cheap refusals", it is **one probe
+ * timeout, once, however many peers there are**, because they run together.
+ * Measured at 1046 ms for a four-node tailnet of which one answers. That is
+ * what `PROBE_TIMEOUT_MS` is really choosing, and it is why this runs when a
+ * screen is opened rather than on a timer.
+ *
+ * ## Why it proposes and never adds
+ *
+ * `isLocalOnly` refuses the whole `hosts.` prefix so that a hub cannot be
+ * talked into becoming a mesh; a discovery that inserted rows would walk around
+ * that from the other side. So this answers a *list of candidates* and the
+ * screen offers an Add button, which is a person deciding.
+ *
+ * It also has to say which of them you already have, and that is not a nicety.
+ * `pc-wsl` is already an `ssh` row on this Mac from M4, and it is the same box:
+ * M5.2 settled that one machine is one row even when two carriers reach it,
+ * because `#/h/<instance>/…` routes by instance id and two rows bearing one id
+ * make every remote route ambiguous. M4.1's collision report catches that on
+ * connect and names the row it clashed with - correctly, and one step later
+ * than a person needs. Here the instance id is already in hand, so the answer
+ * can be "you have this, as `pc-wsl` over SSH" *before* anybody presses
+ * anything.
+ *
+ * ## Why the probe is its own endpoint rather than `app.instance`
+ *
+ * `app.instance` is a method, and a method needs the socket, and the socket
+ * needs an upgrade - which is a lot of ceremony to ask of nine phones that will
+ * refuse the TCP connect anyway. More to the point, a probe is asked of
+ * machines this install has no relationship with yet, and opening a carrier to
+ * one is a stronger act than asking whether it is there.
+ *
+ * So it is a `GET` under `WEB_PREFIX`, behind the same gate as everything else:
+ * on the tailnet authority it requires the owner's login, so only the owner's
+ * own devices can learn that a machine runs GitWarren. What it answers is the
+ * instance id, the version and the protocol - `HostIdentity`, the same shape
+ * `app.instance` returns, because the two questions are the same question asked
+ * before and after there is a connection.
+ */
+import { readTailnetIdentity } from '../tailnet.js'
+import { getDatabase } from '../db/client.js'
+import { hosts } from '../db/schema.js'
+import { getInstanceId } from '../instance.js'
+import { LINK_SERVER_PORT } from '../../shared/link-port.js'
+import { WEB_PATHS } from '../../shared/web.js'
+import type { DiscoveredPeer } from '../../shared/schemas.js'
+
+/**
+ * How long a peer has to answer before it is not a GitWarren.
+ *
+ * One second, and since every probe runs in parallel this is also the whole
+ * duration of a scan - so it is the number that decides how long the Hosts
+ * screen takes to show what is out there.
+ *
+ * A machine on the same tailnet that is running the daemon answers in tens of
+ * milliseconds. One that is not takes about 800 ms to say so, measured, because
+ * refusing means being reached first. One second is therefore only just enough,
+ * and the cost of being wrong in the other direction is that a genuinely slow
+ * machine has to be typed in by hand rather than offered.
+ */
+const PROBE_TIMEOUT_MS = 1_000
+
+/** What a peer says about itself when asked over HTTP rather than a carrier. */
+interface ProbeAnswer {
+  instanceId?: unknown
+  version?: unknown
+  protocol?: unknown
+}
+
+/**
+ * Ask one peer whether it is a GitWarren, and who.
+ *
+ * Never throws and never distinguishes between the ways of saying no. A refused
+ * connection, a timeout, a 401 from a machine that does not think this is its
+ * owner, a 404 from something else entirely on that port: all of them mean the
+ * same thing to a list of proposals, which is that this peer is not offered.
+ */
+async function probePeer(dnsName: string): Promise<DiscoveredPeer | null> {
+  const origin = `http://${dnsName}:${LINK_SERVER_PORT}`
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+  try {
+    const response = await fetch(`${origin}${WEB_PATHS.discover}`, {
+      signal: controller.signal,
+      // No credentials of any kind. The tailnet is the credential - see the
+      // header - and sending a cookie from this install to another machine
+      // would be offering a secret that means nothing there.
+      headers: { Accept: 'application/json' }
+    })
+    if (!response.ok) return null
+    const answer = (await response.json()) as ProbeAnswer
+    if (typeof answer.instanceId !== 'string' || answer.instanceId.length === 0) return null
+    return {
+      dnsName,
+      origin,
+      instanceId: answer.instanceId,
+      version: typeof answer.version === 'string' ? answer.version : null,
+      // Filled in by `discoverPeers`, which is the layer that has the host list.
+      alreadyAdded: null
+    }
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Every machine on this tailnet that answers, minus this one.
+ *
+ * Empty on a machine with no Tailscale, which is the same shape
+ * `hosts.distros` uses so that a screen offers discovery when the answer is
+ * non-empty and no code anywhere asks what platform it is on.
+ *
+ * This install is excluded by *instance id* rather than by name, which is the
+ * only check that works: a machine reaches itself over its own MagicDNS name
+ * perfectly well, and the result would be a proposal to add yourself as a host
+ * - a row whose instance id equals `getInstanceId()` and which
+ * `isAnsweredLocally` would then answer locally, making a "remote" machine that
+ * silently is not one.
+ */
+export async function discoverPeers(): Promise<DiscoveredPeer[]> {
+  const identity = await readTailnetIdentity()
+  if (!identity) return []
+
+  const online = identity.peers.filter((peer) => peer.online)
+  const answers = await Promise.all(online.map((peer) => probePeer(peer.dnsName)))
+
+  const mine = getInstanceId()
+  const rows = getDatabase().select().from(hosts).all()
+  const byInstance = new Map(
+    rows.filter((row) => row.instanceId !== null).map((row) => [row.instanceId, row])
+  )
+
+  const found: DiscoveredPeer[] = []
+  for (const answer of answers) {
+    if (!answer) continue
+    if (answer.instanceId === mine) continue
+    const existing = byInstance.get(answer.instanceId)
+    found.push({
+      ...answer,
+      // The row it would collide with, named. M4.1's report says this after an
+      // insert and a connection; here it is said before either, because the
+      // instance id arrived with the probe.
+      alreadyAdded: existing ? existing.label : null
+    })
+  }
+
+  // By name, so the list does not reshuffle between two looks at it. Peers come
+  // out of a JSON object and their order is whatever Go's map iteration felt
+  // like, which is a different order every time.
+  return found.sort((a, b) => a.dnsName.localeCompare(b.dnsName))
+}

--- a/src/core/hosts/install.ts
+++ b/src/core/hosts/install.ts
@@ -107,6 +107,26 @@ export const runOnHost: RunOnHost = (route, options) => {
       return runOverWsl({ distro: route.target, ...options })
     case 'ssh':
       return runOverSsh({ target: route.target, ...options })
+    case 'websocket':
+      // There is no shell on this carrier and there must not be one. `ssh` and
+      // `wsl.exe` reach a machine by *starting a process on it*, which is what
+      // makes an installer possible at all; a WebSocket reaches a daemon that
+      // is already running, and everything it can be asked to do is a method on
+      // the dispatcher - which, by the note at the top of
+      // `core/rpc/dispatcher.ts`, may never start a process.
+      //
+      // So this is not a gap to be filled later. A listening host is one that
+      // already has GitWarren on it, by construction: if it did not, there
+      // would be nothing to connect to. Installing onto it is somebody's job at
+      // that machine, or M4's `ssh` carrier's, and the message says which.
+      return Promise.reject(
+        new AppError(
+          'FORBIDDEN',
+          `${route.target} is reached over its own network connection, so GitWarren cannot be ` +
+            `installed onto it from here - a machine that answers is a machine that already has ` +
+            `it. Update it on that machine, or add it as an SSH host to install over a shell.`
+        )
+      )
   }
 }
 

--- a/src/core/hosts/pool.ts
+++ b/src/core/hosts/pool.ts
@@ -47,6 +47,7 @@
  * not - they just turned the machine on.
  */
 import { connectOverSsh } from './ssh.js'
+import { connectOverWebSocket } from './websocket.js'
 import { connectOverWsl } from './wsl.js'
 import type { HostConnection } from './carrier.js'
 import { AppError } from '../../shared/errors.js'
@@ -91,8 +92,11 @@ export interface HostRoute {
    * operating systems - what a host runs is discovered by asking it, never
    * declared. See the note on `hosts.kind` in `core/db/schema.ts`.
    */
-  kind: 'ssh' | 'wsl'
-  /** What that carrier is handed: an `ssh` destination, or a distro name. */
+  kind: 'ssh' | 'wsl' | 'websocket'
+  /**
+   * What that carrier is handed: an `ssh` destination, a distro name, or the
+   * origin of a machine that is already listening.
+   */
   target: string
 }
 
@@ -401,13 +405,14 @@ export function createHostPool({
  * Everything above is about *when* to connect, and none of it changed when M5
  * added a second way of reaching a machine - which is the whole argument for
  * the pool being a separate module from `ssh.ts`. A switch rather than a
- * registry: two carriers, and M6's WebSocket will be a third, is not a number
- * that earns indirection.
+ * registry: three carriers is not a number that earns indirection.
  */
 function defaultConnect(route: HostRoute, onClose: (error: AppError) => void): HostConnection {
   switch (route.kind) {
     case 'wsl':
       return connectOverWsl({ distro: route.target, onClose })
+    case 'websocket':
+      return connectOverWebSocket({ target: route.target, onClose })
     case 'ssh':
       return connectOverSsh({ target: route.target, onClose })
   }

--- a/src/core/hosts/pool.ts
+++ b/src/core/hosts/pool.ts
@@ -50,8 +50,15 @@ import { connectOverSsh } from './ssh.js'
 import { connectOverWebSocket } from './websocket.js'
 import { connectOverWsl } from './wsl.js'
 import type { HostConnection } from './carrier.js'
+import { emitEvent } from '../events.js'
 import { AppError } from '../../shared/errors.js'
-import type { RpcMethod, RpcParams, RpcResult } from '../../shared/rpc.js'
+import {
+  RPC_EVENTS,
+  type RpcEvent,
+  type RpcMethod,
+  type RpcParams,
+  type RpcResult
+} from '../../shared/rpc.js'
 
 /**
  * How long a connection may sit unused before it is closed.
@@ -98,6 +105,20 @@ export interface HostRoute {
    * origin of a machine that is already listening.
    */
   target: string
+  /**
+   * The machine's own id, once it has said it. Null until first contact.
+   *
+   * Carried on the route rather than looked up when needed, because the one
+   * thing it is for is stamping events - and an event arrives at a moment when
+   * the only thing in hand is the connection it came down. A daemon says
+   * "comments changed" and means "on me"; it cannot say which row this install
+   * files it under, because it may be reached by two GitWarrens at once. This
+   * is the side that knows.
+   *
+   * Null is not a problem to solve. A host that has never answered has never
+   * pushed anything either, so there is no event to be unable to tag.
+   */
+  instanceId?: string | null
 }
 
 export interface HostState {
@@ -112,26 +133,46 @@ export interface HostState {
 
 export interface HostPoolOptions {
   /** Swappable for tests; the default opens a real `ssh`. */
-  connect?: (route: HostRoute, onClose: (error: AppError) => void) => HostConnection
+  connect?: (
+    route: HostRoute,
+    handlers: { onClose: (error: AppError) => void; onEvent: (event: RpcEvent) => void }
+  ) => HostConnection
   now?: () => number
   /**
-   * Notified whenever a host's reachability changes. Nothing passes it yet.
+   * Notified whenever a host's reachability changes.
    *
-   * It was written for M4.5's banner and M4.5 did not use it, which is worth
-   * recording rather than deleting. A push from here has nowhere to go: the
-   * event channel in `shared/rpc.ts` is reserved for M6 and nothing emits on
-   * it, so reaching a screen would have meant an Electron IPC channel for the
-   * window *and* a WebSocket message for a tab - two half-built event channels
-   * for one banner, which is the thing M4.2 refused to build for a progress
-   * bar. And it was not needed: a screen already asks this machine questions,
-   * so the answers it gets are the disconnection, and
-   * `renderer/lib/host-reachability.ts` reads them there.
+   * Written for M4.5's banner, unused by M4.5, and rendered at last by M6.5 -
+   * and the delay is the interesting part rather than an oversight. M4.5's
+   * banner is raised by request *outcomes*, in `renderer/lib/host-reachability.ts`,
+   * and still is: a request that failed is evidence about the screen in front
+   * of somebody, it is carrier-agnostic, and M5 proved it against `wsl.exe`
+   * with no new code. None of that is replaced here.
    *
-   * What this hook can see that a screen cannot is a host nobody is looking at,
-   * which is why it belongs to M6's `host.state` event - where a machine going
-   * away is news whether or not anything is open on it.
+   * What this hook sees and a screen cannot is a host **nobody is looking at**,
+   * and it is worth being exact about when that is a real event, because for
+   * most of M4 it was not one. This pool only learns anything by *connecting*,
+   * so a machine nobody was asking about was a machine nothing could say
+   * anything about. What changed is `core/hosts/websocket.ts`: a listening host
+   * holds an open socket with a heartbeat on it, so a machine that is switched
+   * off is noticed with no request outstanding and no screen open on it. That
+   * is the whole of what M6 adds to disconnection.
+   *
+   * The bound, recorded rather than hidden: the pool still hangs up after
+   * `IDLE_TIMEOUT_MS`, so this can only speak for a host something has asked
+   * about in the last ten minutes. An always-open socket to every host would be
+   * a connection to every machine on the list, which is what this file exists
+   * to avoid.
    */
   onStateChange?: (hostId: number, state: HostState) => void
+  /**
+   * An event a host pushed, tagged with which host it was.
+   *
+   * The pool is the only layer that can tag it. A daemon announcing
+   * `comments.changed` means "on me" and has no idea what this install calls
+   * it; the connection it came down is the association, and this file is what
+   * holds connections.
+   */
+  onHostEvent?: (event: RpcEvent) => void
 }
 
 interface Entry {
@@ -179,7 +220,8 @@ const OFFLINE = (message: string): AppError => new AppError('HOST_OFFLINE', mess
 export function createHostPool({
   connect = defaultConnect,
   now = Date.now,
-  onStateChange
+  onStateChange,
+  onHostEvent
 }: HostPoolOptions = {}): HostPool {
   const entries = new Map<number, Entry>()
 
@@ -311,14 +353,30 @@ export function createHostPool({
       entry.generation += 1
       const generation = entry.generation
 
-      entry.connection = connect(route, (error) => {
-        // The pipe died. Whether that is a failure depends on whether anything
-        // was expecting it: a connection closed by the idle timer has already
-        // been forgotten here, and must not push the host onto the backoff
-        // ladder as though the machine had gone away.
-        const current = entries.get(route.id)
-        if (!current || current.connection === null) return
-        recordFailure(route.id, current, error.message, generation)
+      entry.connection = connect(route, {
+        onClose: (error) => {
+          // The pipe died. Whether that is a failure depends on whether anything
+          // was expecting it: a connection closed by the idle timer has already
+          // been forgotten here, and must not push the host onto the backoff
+          // ladder as though the machine had gone away.
+          const current = entries.get(route.id)
+          if (!current || current.connection === null) return
+          recordFailure(route.id, current, error.message, generation)
+        },
+        onEvent: (event) => {
+          // Stamped with the instance id from the route, which is what turns
+          // "something changed" into "something changed on that machine" - and
+          // is what lets the renderer invalidate one host's keys rather than
+          // every host's. An untagged event would mean "this install", which
+          // would be precisely wrong.
+          //
+          // A host that has never said who it is cannot have pushed anything,
+          // so the null case is unreachable rather than handled: dropping it is
+          // still the right answer if it ever happens, because an event that
+          // cannot be scoped is an event that would refresh the wrong screens.
+          if (!route.instanceId) return
+          onHostEvent?.({ ...event, host: route.instanceId })
+        }
       })
     }
 
@@ -407,14 +465,17 @@ export function createHostPool({
  * the pool being a separate module from `ssh.ts`. A switch rather than a
  * registry: three carriers is not a number that earns indirection.
  */
-function defaultConnect(route: HostRoute, onClose: (error: AppError) => void): HostConnection {
+function defaultConnect(
+  route: HostRoute,
+  handlers: { onClose: (error: AppError) => void; onEvent: (event: RpcEvent) => void }
+): HostConnection {
   switch (route.kind) {
     case 'wsl':
-      return connectOverWsl({ distro: route.target, onClose })
+      return connectOverWsl({ distro: route.target, ...handlers })
     case 'websocket':
-      return connectOverWebSocket({ target: route.target, onClose })
+      return connectOverWebSocket({ target: route.target, ...handlers })
     case 'ssh':
-      return connectOverSsh({ target: route.target, onClose })
+      return connectOverSsh({ target: route.target, ...handlers })
   }
 }
 
@@ -426,4 +487,18 @@ function defaultConnect(route: HostRoute, onClose: (error: AppError) => void): H
  * and nothing above it has any reason to want that. Tests build their own with
  * `createHostPool`.
  */
-export const hostPool = createHostPool()
+export const hostPool = createHostPool({
+  // The two sources of `core/events.ts`, joined here because this is the only
+  // layer that can speak for either. `host.state` is minted by this pool from a
+  // connection it is holding; a host's own event arrives down that connection
+  // and is tagged with the machine it came from. One bus, two sources - which
+  // is the cheap answer to M4.5's objection about building two half-channels.
+  //
+  // `host.state` carries no data at all. What a screen does with it is
+  // re-read the host list, which is one local SQLite read plus a look at this
+  // pool - so putting the state on the wire would be shipping an answer the
+  // receiver is about to ask for properly anyway. See `core/events.ts` on why
+  // an event is never data.
+  onStateChange: () => emitEvent({ event: RPC_EVENTS.hostState, data: null }),
+  onHostEvent: (event) => emitEvent(event)
+})

--- a/src/core/hosts/ssh.ts
+++ b/src/core/hosts/ssh.ts
@@ -80,6 +80,7 @@ import {
   type HostRunResult
 } from './carrier.js'
 import { AppError } from '../../shared/errors.js'
+import type { RpcEvent } from '../../shared/rpc.js'
 
 export { REMOTE_LAUNCHER }
 
@@ -113,6 +114,14 @@ export interface SpawnSshOptions {
   target: string
   /** Swappable so the tests can run a fake host without an `ssh` on the box. */
   spawnProcess?: typeof spawn
+  /**
+   * A push from the far end. See `core/hosts/pool.ts` for what is done with it.
+   *
+   * Untagged when it arrives: the daemon is saying "on me" and does not know
+   * what instance id this install files it under. The pool adds that, being the
+   * side that knows.
+   */
+  onEvent?: (event: RpcEvent) => void
   onClose?: (error: AppError) => void
 }
 
@@ -129,7 +138,8 @@ export interface SpawnSshOptions {
 export function connectOverSsh({
   target,
   spawnProcess = spawn,
-  onClose
+  onClose,
+  onEvent
 }: SpawnSshOptions): HostConnection {
   let child: ChildProcessWithoutNullStreams
   try {
@@ -163,6 +173,7 @@ export function connectOverSsh({
   const client: StdioClient = createStdioClient({
     input: child.stdout,
     output: child.stdin,
+    onEvent,
     onClose: (error) => {
       closeError = error
       onClose?.(error)

--- a/src/core/hosts/websocket.ts
+++ b/src/core/hosts/websocket.ts
@@ -1,0 +1,427 @@
+/**
+ * A machine that is *listening*, rather than one we start a process on.
+ *
+ * The third carrier, and the first that is not a child process. `ssh.ts` and
+ * `wsl.ts` both spawn `gitwarren serve --stdio` and own its lifetime; here the
+ * daemon was already running before this app opened, and will still be running
+ * after it quits. Everything that follows from `core/hosts/carrier.ts` -
+ * `HostConnection`, `diagnosticTail`, `isLocalOnly`, the promise-shaped
+ * `diagnostics()` - still applies, which is the point of M5 having extracted
+ * it: this file is a *user* of that contract rather than a parallel one.
+ *
+ * ## What it does not have, and what it has instead
+ *
+ * **No stderr.** The other two carriers explain a failure from the last few
+ * lines the far end printed. A socket has no such stream, so the explanation
+ * comes from two other places: the HTTP status of a refused handshake, and the
+ * close code of a connection that was open and stopped being. Both are more
+ * precise than a tail of prose, and both arrive *after* the event that made
+ * anybody ask - which is the M4.1 lesson in its socket-shaped form.
+ *
+ * `ws` reports a refused upgrade as an `error` carrying "Unexpected server
+ * response: 401" and, separately and a moment later, an `unexpected-response`
+ * event carrying the actual response object. Reading the reason synchronously
+ * at the instant a request fails therefore gets the generic half. So
+ * `diagnostics()` waits briefly, exactly as it does for `ssh`'s exit, and
+ * answers with what the far end actually said - which for this carrier is
+ * usually a sentence about *authorisation* and needs translating, because "401"
+ * on the tailnet means "that machine does not think you are its owner" and
+ * nothing about a token.
+ *
+ * **No exit.** A pipe ends when a process exits and the OS says so. A TCP
+ * connection to a laptop that closed its lid ends when nobody is looking - the
+ * classic half-open connection, which `core/rpc/websocket.ts` predicted at M3
+ * would be "Tuesday" over the tailnet. So this end pings on its own timer and
+ * gives up on a peer that has stopped answering.
+ *
+ * That is not symmetry with the server for its own sake. The server's heartbeat
+ * protects the *server* from a browser tab that went away; this one is what
+ * makes M6.5's `host.state` mean anything, because a machine that is switched
+ * off with nobody looking at it is exactly the case the whole event channel was
+ * built for. A clean shutdown closes the socket and is noticed immediately; a
+ * yanked cable or a frozen machine is noticed within `LIVENESS_TIMEOUT_MS`.
+ *
+ * ## Why the Origin header is set by hand
+ *
+ * The far end requires `Origin` to match the authority the request arrived at
+ * (`core/web/origin.ts`), because that check is what forecloses a page acting on
+ * a server that did not serve it. A browser sets it; a Node client sends none,
+ * and would be refused. Setting it here is not working around the check - it is
+ * this client saying which server it believes it is talking to, which is
+ * precisely what the check wants to hear and what a cross-origin page cannot
+ * lie about.
+ *
+ * Identity is *not* set here and must not be. `Tailscale-User-Login` is stamped
+ * by `tailscaled` on the far machine; a client that set it would be asserting
+ * its own authorisation, which is the one thing a client never gets to do.
+ */
+import { Readable, Writable } from 'node:stream'
+import { WebSocket } from 'ws'
+import { createStdioClient } from '../rpc/stdio-client.js'
+import { AppError } from '../../shared/errors.js'
+import { EXIT_GRACE_MS, isLocalOnly, offline, type HostConnection } from './carrier.js'
+import { LINK_SERVER_PORT } from '../../shared/link-port.js'
+import { WEB_PATHS } from '../../shared/web.js'
+import type { RpcEvent, RpcMethod, RpcParams, RpcResult } from '../../shared/rpc.js'
+
+/**
+ * How often this end pings, and how long silence may last before the connection
+ * is treated as gone.
+ *
+ * Ten and thirty seconds. The cost is a two-byte frame six times a minute on a
+ * connection the pool will close after ten idle minutes anyway, which is small
+ * enough that the interesting number is the other one: thirty seconds is how
+ * long a Hosts screen can be wrong about a machine that vanished without
+ * closing its socket.
+ *
+ * Deliberately shorter than `WEBSOCKET_HEARTBEAT_MS` on the server side. That
+ * one is 30 seconds because it is protecting a daemon from tabs that went away,
+ * and being slow costs a held database handle. This one is protecting the
+ * *truth on a screen*, which is what M6 is for.
+ */
+export const LIVENESS_PING_MS = 10_000
+export const LIVENESS_TIMEOUT_MS = 30_000
+
+export interface WebSocketHostOptions {
+  /**
+   * Where the daemon is: an origin, or an authority to be given a default.
+   *
+   * `http://pc-wsl.tail688c0c.ts.net:41427`, or `pc-wsl` - see `normaliseTarget`
+   * on why both are accepted and what the second becomes.
+   */
+  target: string
+  onClose?: (error: AppError) => void
+  /** Swappable for tests, which have no tailnet. */
+  open?: (url: string, options: { headers: Record<string, string> }) => WebSocket
+}
+
+/**
+ * What a person typed, or what discovery found, turned into one URL.
+ *
+ * Both spellings are accepted, and the reason is that they come from different
+ * places. Discovery (M6.6) has probed a peer and knows the scheme and port that
+ * answered, so it stores the whole origin and nothing is guessed. A person
+ * typing into the form has a machine name in their head and should not have to
+ * know either - so a bare name becomes `http://<name>:41427`, which is spike
+ * S6's fixed port and the scheme this tailnet actually serves.
+ *
+ * The stored value round-trips: whatever is in `hosts.target` is what is
+ * connected to, so a host that worked yesterday is not re-guessed today.
+ */
+export function normaliseTarget(target: string): string {
+  const trimmed = target.trim()
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`
+  let url: URL
+  try {
+    url = new URL(withScheme)
+  } catch {
+    throw new AppError('INVALID_INPUT', `"${target}" is not a machine name or an address.`)
+  }
+  if (!url.port) url.port = String(LINK_SERVER_PORT)
+  // Origin only: the path, query and fragment of whatever was typed are not
+  // part of where a daemon is, and carrying them would make the socket URL
+  // depend on them.
+  return url.origin
+}
+
+/** `http://host:41427` becomes `ws://host:41427/gitwarren/socket`. */
+function socketUrl(origin: string): string {
+  const url = new URL(origin)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  url.pathname = WEB_PATHS.socket
+  return url.toString()
+}
+
+/**
+ * What a refused handshake means, in the words of the thing that refused it.
+ *
+ * The translation matters more here than for the other carriers, because the
+ * status codes this far end returns are about *M6's* two questions and a person
+ * reading "401" has no way to know which. A 401 over the tailnet is never about
+ * a token - the token is not consulted on that authority at all - it is the
+ * owner check, and the useful thing to say is what would make it pass.
+ */
+function describeStatus(status: number | undefined, target: string): string {
+  switch (status) {
+    case 401:
+      return (
+        `${target} does not recognise you as its owner. Both machines have to be signed in to ` +
+        `the same Tailscale account.`
+      )
+    case 403:
+      return (
+        `${target} is not accepting connections from your tailnet. Turn on "Reachable on your ` +
+        `tailnet" in GitWarren on that machine.`
+      )
+    case 404:
+    case 426:
+      return `${target} answered, but it is not a GitWarren that can be reached this way.`
+    default:
+      return status === undefined
+        ? `${target} did not complete a connection.`
+        : `${target} refused the connection (HTTP ${status}).`
+  }
+}
+
+/**
+ * What a connection that *was* open and closed means.
+ *
+ * 1006 is the code `ws` invents when a connection ended without a close frame,
+ * which is every interesting case here: a machine switched off, a cable pulled,
+ * a laptop asleep. It is reported as what it is rather than as a number,
+ * because "the connection was lost" is true and "close code 1006" is a fact
+ * about a specification.
+ */
+function describeClose(code: number, reason: string, target: string): string {
+  if (reason) return `${target} closed the connection: ${reason}`
+  if (code === 1006) return `The connection to ${target} was lost.`
+  if (code === 1001) return `${target} went away.`
+  return `${target} closed the connection (code ${code}).`
+}
+
+function describeSocketError(error: NodeJS.ErrnoException, target: string): string {
+  switch (error.code) {
+    case 'ECONNREFUSED':
+      return `Nothing is listening on ${target}. GitWarren may not be running there.`
+    case 'ENOTFOUND':
+    case 'EAI_AGAIN':
+      return `${target} could not be found. It may be off the tailnet.`
+    case 'ETIMEDOUT':
+    case 'EHOSTUNREACH':
+      return `${target} did not answer.`
+    default:
+      return `Could not reach ${target}: ${error.message}`
+  }
+}
+
+export function connectOverWebSocket({
+  target,
+  onClose,
+  open = (url, options) => new WebSocket(url, options)
+}: WebSocketHostOptions): HostConnection {
+  const origin = normaliseTarget(target)
+  const authority = new URL(origin).host
+
+  let socket: WebSocket
+  try {
+    socket = open(socketUrl(origin), {
+      // See the header: this is the client naming the server it believes it is
+      // talking to, which is exactly what the far end's origin check wants.
+      // Identity is deliberately absent - `tailscaled` stamps that.
+      headers: { Origin: origin }
+    })
+  } catch (error) {
+    throw offline(
+      `Could not connect to ${authority}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+
+  /**
+   * The best explanation so far, and the one `diagnostics()` waits for.
+   *
+   * Two of them, because they arrive in the wrong order. `error` comes first
+   * with the generic half ("Unexpected server response: 401") and
+   * `unexpected-response` or `close` comes a moment later with the half worth
+   * reading. The count takes the earliest and the explanation takes the latest,
+   * which is the rule `core/hosts/pool.ts` already applies to its backoff
+   * ladder for the same reason.
+   */
+  let reason: string | null = null
+  let settled = false
+  let resolveSettled: () => void = () => {}
+  const explained = new Promise<void>((resolve) => {
+    resolveSettled = () => {
+      if (settled) return
+      settled = true
+      resolve()
+    }
+  })
+
+  /**
+   * The far end's stdout and stdin, as two in-memory streams.
+   *
+   * `createStdioClient` is written against a pair of streams and is deliberately
+   * ignorant of how they were obtained - which is what let M5 reuse it for
+   * `wsl.exe` unchanged, and what lets it be reused here for something that is
+   * not a pipe at all. A socket delivers whole messages, so the framing
+   * `ndjson.ts` does is redundant rather than wrong: a newline is appended on
+   * the way out and each message arrives as one line on the way in.
+   */
+  const incoming = new Readable({ read() {} })
+
+  /**
+   * Frames written before the handshake finished.
+   *
+   * The pool opens a connection *because* something asked a question, so the
+   * first request is always in flight before the socket is open - which
+   * `web/carrier.ts` wrote down at M3 and this file had to learn again by
+   * failing every first request in five milliseconds with "the connection is
+   * not open". A carrier that refuses the request that caused it to exist is
+   * not a carrier.
+   *
+   * Queued rather than rejected, and flushed on `open`. Nothing here needs a
+   * bound: `createStdioClient` is the only writer, the pool is the only caller,
+   * and a socket that never opens rejects everything through `onClose` with the
+   * real reason - which is also why the queue is simply dropped rather than
+   * drained on failure. This is the *first* request, never a backlog.
+   */
+  let pendingFrames: string[] | null = []
+
+  const outgoing = new Writable({
+    write(chunk: Buffer | string, _encoding, callback) {
+      // Trailing newline removed: it is `ndjson`'s framing and a WebSocket does
+      // its own. Harmless either way - `JSON.parse` ignores trailing whitespace
+      // - but sending it would put a byte on the wire that means nothing.
+      const frame = String(chunk).trimEnd()
+
+      if (pendingFrames !== null) {
+        pendingFrames.push(frame)
+        callback()
+        return
+      }
+      if (socket.readyState !== WebSocket.OPEN) {
+        callback(new Error(`The connection to ${authority} is not open.`))
+        return
+      }
+      socket.send(frame)
+      callback()
+    }
+  })
+
+  const client = createStdioClient({
+    input: incoming,
+    output: outgoing,
+    onEvent: (event: RpcEvent) => {
+      // Nothing yet. M6.5 is where an event from a host reaches a screen; the
+      // hook is named here so that slice is a line in `pool.ts` rather than a
+      // change to this file.
+      void event
+    },
+    onClose: (error) => {
+      resolveSettled()
+      onClose?.(error)
+    }
+  })
+
+  /**
+   * Silence, measured from the last thing the far end said.
+   *
+   * Any frame counts - a pong, a response, an event - because what is being
+   * asked is whether the connection still carries bytes, not whether the peer's
+   * event loop is healthy. See the header on why this end pings at all when the
+   * server already does.
+   */
+  let lastHeard = Date.now()
+  const heard = (): void => {
+    lastHeard = Date.now()
+  }
+
+  const liveness = setInterval(() => {
+    if (Date.now() - lastHeard > LIVENESS_TIMEOUT_MS) {
+      reason = `${authority} stopped responding.`
+      // `terminate` rather than `close`: a close handshake with a peer that is
+      // gone is a message into a void, and waiting for its reply is the delay
+      // this timer exists to avoid. Same reasoning as the server's heartbeat.
+      socket.terminate()
+      return
+    }
+    if (socket.readyState === WebSocket.OPEN) socket.ping()
+  }, LIVENESS_PING_MS)
+  liveness.unref?.()
+
+  socket.on('open', () => {
+    heard()
+    // Spliced rather than iterated, for the reason `web/carrier.ts` gives: a
+    // frame written by something this flush wakes belongs to the open socket,
+    // not to this loop.
+    const backlog = pendingFrames ?? []
+    pendingFrames = null
+    for (const frame of backlog) socket.send(frame)
+  })
+  socket.on('pong', heard)
+
+  socket.on('message', (data: Buffer, isBinary: boolean) => {
+    heard()
+    // The protocol is JSON text. A binary frame is a different protocol, and
+    // the client has no way to resynchronise - see `stdio-client.ts` on why a
+    // reader that cannot tell where a message ends must give up rather than
+    // guess.
+    if (isBinary) return
+    incoming.push(`${String(data)}\n`)
+  })
+
+  socket.on('unexpected-response', (_request, response) => {
+    reason = describeStatus(response.statusCode, authority)
+    resolveSettled()
+    response.resume()
+  })
+
+  socket.on('error', (error: NodeJS.ErrnoException) => {
+    // Only if nothing better has been said. `unexpected-response` carries the
+    // status and `error` carries "Unexpected server response: 401" about the
+    // same event, and the first of those is the one worth showing.
+    if (reason === null) reason = describeSocketError(error, authority)
+    client.close(reason)
+  })
+
+  socket.on('close', (code: number, raw: Buffer) => {
+    clearInterval(liveness)
+    // Anything still queued was never sent, and must not be: a request that did
+    // not reach the far end is a request that failed, and `stdio-client.ts`
+    // rejects it below with the reason. Retrying it here would be the carrier
+    // deciding on the caller's behalf what a missing answer meant.
+    pendingFrames = null
+    if (reason === null) reason = describeClose(code, String(raw ?? ''), authority)
+    resolveSettled()
+    // Ends the read stream, which is what `stdio-client.ts` treats as the far
+    // end going away - so every request in flight rejects with `HOST_OFFLINE`
+    // and none of them is retried.
+    incoming.push(null)
+    client.close(reason)
+  })
+
+  return {
+    request<M extends RpcMethod>(method: M, params?: RpcParams<M>): Promise<RpcResult<M>> {
+      if (isLocalOnly(method)) {
+        return Promise.reject(
+          new AppError(
+            'INVALID_INPUT',
+            `"${method}" is answered by this machine and is never sent to a host.`
+          )
+        )
+      }
+      return client.request(method, params)
+    },
+
+    close() {
+      clearInterval(liveness)
+      client.close('The connection to the host was closed.')
+      socket.close()
+    },
+
+    isOpen() {
+      return client.isOpen()
+    },
+
+    /**
+     * Wait briefly for the explanation that is already on its way.
+     *
+     * The same shape and the same `EXIT_GRACE_MS` as the other two carriers,
+     * bounding the same pathological case: this only ever runs on a connection
+     * that has already failed, and the status or close code lands within a tick
+     * of the failure that made anyone ask.
+     */
+    async diagnostics(): Promise<string> {
+      if (!settled) {
+        await Promise.race([
+          explained,
+          new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, EXIT_GRACE_MS)
+            timer.unref?.()
+          })
+        ])
+      }
+      return reason ?? ''
+    }
+  }
+}

--- a/src/core/hosts/websocket.ts
+++ b/src/core/hosts/websocket.ts
@@ -90,6 +90,14 @@ export interface WebSocketHostOptions {
    * on why both are accepted and what the second becomes.
    */
   target: string
+  /**
+   * A push from the far end. See `core/hosts/pool.ts` for what is done with it.
+   *
+   * Untagged when it arrives: the daemon is saying "on me" and does not know
+   * what instance id this install files it under. The pool adds that, being the
+   * side that knows.
+   */
+  onEvent?: (event: RpcEvent) => void
   onClose?: (error: AppError) => void
   /** Swappable for tests, which have no tailnet. */
   open?: (url: string, options: { headers: Record<string, string> }) => WebSocket
@@ -197,6 +205,7 @@ function describeSocketError(error: NodeJS.ErrnoException, target: string): stri
 export function connectOverWebSocket({
   target,
   onClose,
+  onEvent,
   open = (url, options) => new WebSocket(url, options)
 }: WebSocketHostOptions): HostConnection {
   const origin = normaliseTarget(target)
@@ -291,12 +300,7 @@ export function connectOverWebSocket({
   const client = createStdioClient({
     input: incoming,
     output: outgoing,
-    onEvent: (event: RpcEvent) => {
-      // Nothing yet. M6.5 is where an event from a host reaches a screen; the
-      // hook is named here so that slice is a line in `pool.ts` rather than a
-      // change to this file.
-      void event
-    },
+    onEvent,
     onClose: (error) => {
       resolveSettled()
       onClose?.(error)

--- a/src/core/hosts/wsl.ts
+++ b/src/core/hosts/wsl.ts
@@ -93,6 +93,7 @@ import {
   type HostRunResult
 } from './carrier.js'
 import { AppError } from '../../shared/errors.js'
+import type { RpcEvent } from '../../shared/rpc.js'
 
 /**
  * How much of stdout to keep in case it turns out to be `wsl.exe` talking.
@@ -142,6 +143,14 @@ export interface SpawnWslOptions {
   distro: string
   /** Swappable so the tests can run a fake distro without WSL on the box. */
   spawnProcess?: typeof spawn
+  /**
+   * A push from the far end. See `core/hosts/pool.ts` for what is done with it.
+   *
+   * Untagged when it arrives: the daemon is saying "on me" and does not know
+   * what instance id this install files it under. The pool adds that, being the
+   * side that knows.
+   */
+  onEvent?: (event: RpcEvent) => void
   onClose?: (error: AppError) => void
 }
 
@@ -156,7 +165,8 @@ export interface SpawnWslOptions {
 export function connectOverWsl({
   distro,
   spawnProcess = spawn,
-  onClose
+  onClose,
+  onEvent
 }: SpawnWslOptions): HostConnection {
   let child: ChildProcessWithoutNullStreams
   try {
@@ -204,6 +214,7 @@ export function connectOverWsl({
   const client: StdioClient = createStdioClient({
     input: child.stdout,
     output: child.stdin,
+    onEvent,
     onClose: (error) => {
       closeError = error
       onClose?.(error)

--- a/src/core/rpc/dispatcher.ts
+++ b/src/core/rpc/dispatcher.ts
@@ -33,7 +33,7 @@ import { APP_VERSION } from '../version.js'
 import { attachmentsService } from '../services/attachments.js'
 import { commentsService } from '../services/comments.js'
 import { fsService } from '../services/fs.js'
-import { hostsService } from '../services/hosts.js'
+import { hostsService, tailnetService } from '../services/hosts.js'
 import { repositoriesService } from '../services/repositories.js'
 import { reviewedFilesService } from '../services/reviewed-files.js'
 import { reviewsService } from '../services/reviews.js'
@@ -164,6 +164,11 @@ const handlers: {
   'hosts.probe': (params) => hostsService.probe(params),
   'hosts.install': (params) => hostsService.install(params),
   'hosts.distros': () => hostsService.distros(),
+  // About this machine's own reachability, never a host's - `isLocalOnly`
+  // refuses the whole prefix, which is what stops a GUI on one machine
+  // starting `tailscale serve` on another. See the note in `shared/rpc.ts`.
+  'hosts.tailnet': () => tailnetService.read(),
+  'hosts.setTailnetExposure': (params) => tailnetService.set(params),
 
   // Answered by whoever owns the folder, which is the whole point of it being
   // a method - see the note in `shared/rpc.ts`.

--- a/src/core/rpc/dispatcher.ts
+++ b/src/core/rpc/dispatcher.ts
@@ -26,6 +26,7 @@
  * different piece of software. Shell capabilities live in `main/ipc.ts` and
  * never enter this map.
  */
+import { emitForMethod } from '../events.js'
 import { getInstanceId } from '../instance.js'
 import { describeMcpLaunch } from '../mcp-launcher.js'
 import { APP_VERSION } from '../version.js'
@@ -234,7 +235,14 @@ export async function dispatch<M extends RpcMethod>(
     // Traced here rather than in a carrier, so that counting round trips per
     // screen works the same however the request arrived - the measurement M1
     // exists to improve, and the one M4 will want again over a real network.
-    return await traced(method, () => handlers[method](params))
+    const result = await traced(method, () => handlers[method](params))
+    // After the work, never before: an event is a claim that something changed,
+    // and a method that threw changed nothing. This is the human surface - see
+    // the note at the top of this file - so it is exactly the writes a person
+    // made. An agent's writes never pass here and announce themselves from the
+    // MCP process instead.
+    emitForMethod(method)
+    return result
   } catch (error) {
     const appError = AppError.from(error)
     if (appError.code === 'INTERNAL') {

--- a/src/core/rpc/dispatcher.ts
+++ b/src/core/rpc/dispatcher.ts
@@ -33,6 +33,7 @@ import { APP_VERSION } from '../version.js'
 import { attachmentsService } from '../services/attachments.js'
 import { commentsService } from '../services/comments.js'
 import { fsService } from '../services/fs.js'
+import { discoverPeers } from '../hosts/discover.js'
 import { hostsService, tailnetService } from '../services/hosts.js'
 import { repositoriesService } from '../services/repositories.js'
 import { reviewedFilesService } from '../services/reviewed-files.js'
@@ -126,8 +127,14 @@ function toIngestSource(params: unknown): { bytes: Buffer; originalName?: string
  *
  * Synchronous: the instance id is a cached file read and the version is a
  * build-time constant.
+ *
+ * Exported since M6.6 for one other caller: the discovery probe in
+ * `core/web/handler.ts`, which answers the same shape over HTTP to a peer that
+ * has no carrier yet. Shared rather than rebuilt, because "who is answering" is
+ * one question and two answers to it would eventually disagree about a protocol
+ * number.
  */
-function describeThisInstance(): HostIdentity {
+export function describeThisInstance(): HostIdentity {
   return {
     instanceId: getInstanceId(),
     protocol: RPC_PROTOCOL_VERSION,
@@ -167,6 +174,7 @@ const handlers: {
   // About this machine's own reachability, never a host's - `isLocalOnly`
   // refuses the whole prefix, which is what stops a GUI on one machine
   // starting `tailscale serve` on another. See the note in `shared/rpc.ts`.
+  'hosts.discover': () => discoverPeers(),
   'hosts.tailnet': () => tailnetService.read(),
   'hosts.setTailnetExposure': (params) => tailnetService.set(params),
 

--- a/src/core/rpc/stdio.ts
+++ b/src/core/rpc/stdio.ts
@@ -35,9 +35,10 @@
  * protocol, which is the failure this whole arrangement exists to prevent.
  */
 import { handleRoutedRequest } from '../hosts/router.js'
+import { subscribeToEvents } from '../events.js'
 import { MAX_FRAME_BYTES, readFrames } from './ndjson.js'
 import { AppError } from '../../shared/errors.js'
-import type { RpcRequest, RpcResponse } from '../../shared/rpc.js'
+import type { RpcEvent, RpcRequest, RpcResponse } from '../../shared/rpc.js'
 
 /**
  * The id used when a frame is so malformed there is no id to answer under.
@@ -74,12 +75,34 @@ function asRequest(value: unknown): RpcRequest | null {
  * cope with out-of-order responses is a caller that is not using the protocol.
  */
 export function serveStdio({ input, output, onEnd }: StdioCarrierOptions): void {
-  const write = (message: RpcResponse): void => {
+  const write = (message: RpcResponse | RpcEvent): void => {
     // One `write` per message rather than a stringify into a shared buffer:
     // Node serialises writes on a stream, so two responses finishing in the
     // same tick cannot interleave halfway through a line.
     output.write(`${JSON.stringify(message)}\n`)
   }
+
+  /**
+   * Events out, on the same stream as the answers.
+   *
+   * The first thing this protocol has ever sent that nobody asked for, and it
+   * costs one subscription because the shape was decided at M1: an `RpcEvent`
+   * has no `id`, and the reader on the other end has asked `isRpcEvent` about
+   * every frame since M4 without one ever being true. `stdio-client.ts` said
+   * the shape was here so that "the message simply arrives", and this is the
+   * line that tests the claim.
+   *
+   * No `host` is stamped. This daemon is saying "on me" and has no idea what
+   * instance id the listener files it under - it may be spawned by two
+   * GitWarrens at once, each with its own row. The receiving pool is the side
+   * that knows, and `core/hosts/pool.ts` is where it is added.
+   *
+   * Nothing is unsubscribed on `onEnd`, deliberately: a `serve --stdio` process
+   * exists for exactly one pipe and exits when it closes, so the subscription
+   * and the process have the same lifetime. A daemon that outlived its pipe
+   * would be a different design with a different bug.
+   */
+  subscribeToEvents(write)
 
   const refuse = (id: number, message: string): void => {
     write({ id, error: new AppError('INVALID_INPUT', message).toSerialized() })

--- a/src/core/rpc/websocket.ts
+++ b/src/core/rpc/websocket.ts
@@ -36,8 +36,9 @@
  */
 import type { WebSocket } from 'ws'
 import { handleRoutedRequest } from '../hosts/router.js'
+import { subscribeToEvents } from '../events.js'
 import { AppError } from '../../shared/errors.js'
-import type { RpcRequest, RpcResponse } from '../../shared/rpc.js'
+import type { RpcEvent, RpcRequest, RpcResponse } from '../../shared/rpc.js'
 
 /**
  * How long a peer has to answer a ping before it is treated as gone.
@@ -68,12 +69,28 @@ function asRequest(value: unknown): RpcRequest | null {
 export function serveWebSocket(socket: WebSocket): void {
   let alive = true
 
-  const write = (message: RpcResponse): void => {
+  const write = (message: RpcResponse | RpcEvent): void => {
     // A response for a socket that has closed is not an error worth logging on
     // every navigation - a tab going away mid-request is ordinary.
     if (socket.readyState !== socket.OPEN) return
     socket.send(JSON.stringify(message))
   }
+
+  /**
+   * Events out, to whoever is holding this socket.
+   *
+   * The one thing on this connection that nobody asked for, and the reason it
+   * is safe to write without being asked is that it carries no data - see
+   * `core/events.ts`. A socket that has closed is skipped by `write` rather
+   * than unsubscribing eagerly, because the close handler below is what owns
+   * the lifetime and two owners is how a leak starts.
+   *
+   * `host` is deliberately not stamped here. This daemon is announcing "on me",
+   * and it does not know what instance id the listener files it under - it may
+   * be reached by two GitWarrens at once, and a browser tab served by this very
+   * process calls it "local". The receiving carrier is the side that knows.
+   */
+  const unsubscribe = subscribeToEvents(write)
 
   const refuse = (id: number, message: string): void => {
     write({ id, error: new AppError('INVALID_INPUT', message).toSerialized() })
@@ -129,6 +146,7 @@ export function serveWebSocket(socket: WebSocket): void {
 
   socket.on('close', () => {
     clearInterval(heartbeat)
+    unsubscribe()
   })
 
   socket.on('error', (error: Error) => {

--- a/src/core/services/hosts.ts
+++ b/src/core/services/hosts.ts
@@ -78,7 +78,12 @@ function withState(row: HostRow): HostWithState {
 }
 
 export function routeFor(row: HostRow): HostRoute {
-  return { id: row.id, kind: row.kind, target: row.target }
+  // The instance id rides along since M6.5, for one purpose: an event arriving
+  // from this host has to be tagged with the machine it is about, and the pool
+  // - which is where the event lands - holds connections rather than rows. Null
+  // until the machine has said who it is, which is also exactly the window in
+  // which it cannot have pushed anything.
+  return { id: row.id, kind: row.kind, target: row.target, instanceId: row.instanceId }
 }
 
 /**

--- a/src/core/services/hosts.ts
+++ b/src/core/services/hosts.ts
@@ -41,6 +41,7 @@ import { hosts, type HostRow } from '../db/schema.js'
 import { hostPool, type HostRoute } from '../hosts/pool.js'
 import { installOnHost } from '../hosts/install.js'
 import { listDistros } from '../hosts/wsl.js'
+import { refreshExposure, setExposed } from '../web/exposure.js'
 import { AppError } from '../../shared/errors.js'
 import { parseWithSchema as parse } from '../../shared/validation.js'
 import {
@@ -52,7 +53,9 @@ import {
   type Host,
   type HostWithState,
   type InstallReport,
-  type WslDistro
+  type WslDistro,
+  setTailnetExposureInputSchema,
+  type TailnetExposure
 } from '../../shared/schemas.js'
 
 function toHost(row: HostRow): Host {
@@ -392,5 +395,38 @@ export const hostsService = {
     }
 
     return { ...report, host: withState(requireRow(id)) }
+  }
+}
+
+/**
+ * This machine's tailnet reachability, as a method rather than a shell channel.
+ *
+ * Appended to `hostsService` rather than given a service of its own because it
+ * is the same question the rest of this file answers - how this install is
+ * reached, and by what - and because the `hosts.` prefix is what makes
+ * `isLocalOnly` refuse to forward it. That refusal is the load-bearing part: a
+ * GUI on the Mac must not be able to start `tailscale serve` on the PC.
+ *
+ * Thin, like every other entry here. The machinery is `core/web/exposure.ts`,
+ * which is also what the gate reads, so the panel and the server cannot
+ * disagree about whether this install is exposed.
+ */
+export const tailnetService = {
+  /** What is true now. Re-read from the machine, not from memory. */
+  read(): Promise<TailnetExposure> {
+    return refreshExposure()
+  },
+  /**
+   * Turn it on or off, and answer with what the machine then says.
+   *
+   * Deliberately not "answer with what was asked for": `tailscale serve
+   * --https` on a tailnet with no certificates never returns, so the request
+   * and the outcome genuinely differ, and a switch that showed the request
+   * would tell somebody they were reachable when they were not. See
+   * `core/tailnet.ts`.
+   */
+  async set(input: unknown): Promise<TailnetExposure> {
+    const { exposed } = setTailnetExposureInputSchema.parse(input)
+    return setExposed(exposed)
   }
 }

--- a/src/core/services/hosts.ts
+++ b/src/core/services/hosts.ts
@@ -41,6 +41,7 @@ import { hosts, type HostRow } from '../db/schema.js'
 import { hostPool, type HostRoute } from '../hosts/pool.js'
 import { installOnHost } from '../hosts/install.js'
 import { listDistros } from '../hosts/wsl.js'
+import { normaliseTarget } from '../hosts/websocket.js'
 import { refreshExposure, setExposed } from '../web/exposure.js'
 import { AppError } from '../../shared/errors.js'
 import { parseWithSchema as parse } from '../../shared/validation.js'
@@ -117,6 +118,17 @@ function requireRow(id: number): HostRow {
  * stopped distinguishing anything.
  */
 function defaultLabelFor(target: string): string {
+  // A websocket target is a URL, so the label people recognise is the first
+  // label of its hostname: `http://pc-wsl.tail688c0c.ts.net:41427` is `pc-wsl`.
+  // The full name is still on the row and is what gets connected to; this is
+  // only what a card says.
+  if (/^https?:\/\//i.test(target)) {
+    try {
+      return new URL(target).hostname.split('.')[0] || target
+    } catch {
+      return target
+    }
+  }
   const withoutUser = target.includes('@') ? target.slice(target.indexOf('@') + 1) : target
   return withoutUser || target
 }
@@ -215,7 +227,13 @@ export const hostsService = {
   },
 
   add(input: unknown): HostWithState {
-    const { target, label, kind = 'ssh', editorTarget } = parse(addHostInputSchema, input)
+    const { target: typed, label, kind = 'ssh', editorTarget } = parse(addHostInputSchema, input)
+    // Stored in the form the carrier will use, not in the form somebody typed.
+    // `pc-wsl` and `http://pc-wsl:41427` are the same machine, and letting both
+    // into the table would mean two rows the unique index cannot see are one -
+    // which M4.1's collision report would then catch on connect, far later than
+    // it needs to be caught.
+    const target = kind === 'websocket' ? normaliseTarget(typed) : typed
 
     try {
       const row = getDatabase()

--- a/src/core/tailnet.ts
+++ b/src/core/tailnet.ts
@@ -137,20 +137,49 @@ export function forgetTailscaleBinary(): void {
   resolved = null
 }
 
-/** One `tailscale` invocation. Never throws; stdout, or null. */
+/**
+ * One `tailscale` invocation. Never throws.
+ *
+ * Two shapes of answer, because the two kinds of caller want different things.
+ *
+ * A *read* - `status`, `serve status` - wants stdout or nothing. Every way of
+ * failing is the same answer to it: the tailnet is not available here.
+ * `tailscale` distinguishes "not installed", "not logged in" and "daemon not
+ * running" in its prose, and none of those changes what this application does,
+ * which is offer the tailnet or not offer it.
+ *
+ * A *write* - `serve` - is different, and M6.4 found out why on a real Linux
+ * box. `tailscale serve` requires root there unless somebody has run
+ * `tailscale set --operator=$USER`, and it refuses with *Access denied: serve
+ * config denied* plus the exact command that fixes it. Swallowing that leaves
+ * a settings switch that flips back with no explanation, which is the worst
+ * possible version: the user has done nothing wrong, the remedy is one command,
+ * and the app has said nothing. So the failure text is kept and handed up.
+ */
 async function tailscale(args: string[], timeout: number): Promise<string | null> {
+  return (await runTailscale(args, timeout)).stdout
+}
+
+interface TailscaleRun {
+  /** Stdout when it succeeded, null when it did not. */
+  stdout: string | null
+  /** What it said when it failed, trimmed. Empty when there was nothing. */
+  failure: string
+}
+
+async function runTailscale(args: string[], timeout: number): Promise<TailscaleRun> {
   const binary = await tailscaleBinary()
-  if (binary === null) return null
+  if (binary === null) {
+    return { stdout: null, failure: 'Tailscale is not installed on this machine.' }
+  }
   try {
     const { stdout } = await run(binary, args, { timeout, maxBuffer: 8 * 1024 * 1024 })
-    return stdout
-  } catch {
-    // Every failure is the same answer to every caller here: not available, or
-    // not now. `tailscale` distinguishes "not installed", "not logged in",
-    // "daemon not running" and "this tailnet cannot do that" in its exit codes
-    // and its prose, and none of those changes what this application does -
-    // which is offer the tailnet or not offer it.
-    return null
+    return { stdout, failure: '' }
+  } catch (error) {
+    // `tailscale` writes its refusals to stderr and, usefully, includes the
+    // command that would work. `execFile`'s error carries both streams.
+    const { stderr, stdout } = error as { stderr?: string; stdout?: string }
+    return { stdout: null, failure: `${stderr ?? ''}${stdout ?? ''}`.trim() }
   }
 }
 
@@ -308,18 +337,39 @@ export async function tailnetServeOrigin(port: number): Promise<string | null> {
  * throws: a settings toggle that failed should say so on the panel, not take a
  * window down.
  */
-export async function serveTailnet(port: number): Promise<string | null> {
+export async function serveTailnet(port: number): Promise<ServeResult> {
   const target = `http://${LINK_SERVER_HOST}:${port}`
 
   // `--bg` or the command holds the terminal forever. It is background state on
   // the machine either way, which is why `tailnetServeOrigin` reads it back
   // instead of this function remembering what it did.
-  await tailscale(['serve', '--bg', '--https', String(port), target], SERVE_TIMEOUT_MS)
+  await runTailscale(['serve', '--bg', '--https', String(port), target], SERVE_TIMEOUT_MS)
   const secure = await tailnetServeOrigin(port)
-  if (secure !== null) return secure
+  if (secure !== null) return { origin: secure, failure: '' }
 
-  await tailscale(['serve', '--bg', '--http', String(port), target], SERVE_TIMEOUT_MS)
-  return tailnetServeOrigin(port)
+  const plain = await runTailscale(
+    ['serve', '--bg', '--http', String(port), target],
+    SERVE_TIMEOUT_MS
+  )
+  const origin = await tailnetServeOrigin(port)
+  // The HTTPS attempt's failure is deliberately not reported. On a tailnet
+  // without certificates it always fails, and saying so would be telling every
+  // user about a thing that is not wrong - see the header. The plain attempt is
+  // the one whose refusal means something.
+  return { origin, failure: origin === null ? plain.failure : '' }
+}
+
+/**
+ * What happened when this machine was asked to serve.
+ *
+ * `origin` is where it landed, or null. `failure` is what `tailscale` said
+ * about the refusal, kept verbatim rather than classified: its message names
+ * the exact command that would fix the common case, and no paraphrase of ours
+ * would be as useful as the sentence its authors wrote.
+ */
+export interface ServeResult {
+  origin: string | null
+  failure: string
 }
 
 /**

--- a/src/core/tailnet.ts
+++ b/src/core/tailnet.ts
@@ -1,0 +1,337 @@
+/**
+ * What Tailscale knows, asked rather than assumed.
+ *
+ * Rule 3 of the plan is that Tailscale is discovery and identity and never a
+ * dependency, and this module is where that is kept honest: everything here
+ * answers "not available" rather than throwing, and every caller is written so
+ * that a machine with no Tailscale on it is an ordinary machine with one fewer
+ * option on a settings panel. SSH stays the universal fallback for own
+ * machines.
+ *
+ * Three questions, and they are separate because they fail separately.
+ *
+ *  - **Who am I on the tailnet, and who owns it?** `tailscale status --json`,
+ *    `Self` and `User`. This is the identity half of M6, and it is the thing
+ *    the gate compares an incoming `Tailscale-User-Login` against.
+ *  - **Which of my peers are worth asking about?** The same answer's `Peer`
+ *    map, filtered to this user's own online machines. That is M6.6.
+ *  - **Am I reachable, and at what URL?** `tailscale serve`, and the URL is
+ *    read back from what it reports rather than assembled from a template.
+ *
+ * ## Why the URL is read rather than written
+ *
+ * The plan spells `webUrl` as `https://<host>.<tailnet>.ts.net/review/4/…`, and
+ * spike M6.0 found that a tailnet can simply not have HTTPS: `tailscale serve
+ * --https` hangs, and `tailscale cert` says *your Tailscale account does not
+ * support getting TLS certs* - certificates are a tailnet-wide switch, not a
+ * property of the machine. A URL minted by convention would then be a URL that
+ * does not open, handed to an agent to hand to a person, with nothing anywhere
+ * having warned.
+ *
+ * So `serveTailnet` asks for HTTPS, falls back to plain HTTP, and **reports
+ * which one it got**. It is the rule `core/mcp-launcher.ts` follows for the
+ * launcher path: a fact from the machine that knows it beats a string that is
+ * usually right. A tailnet that turns HTTPS on later gets it on the next toggle
+ * with no code change, because nothing here decided in advance.
+ *
+ * Plain HTTP over a tailnet is not plaintext on a network. WireGuard encrypts
+ * between the two machines a layer down, and `tailscale serve` - unlike
+ * `funnel`, which is a non-goal - never leaves the tailnet. What is lost
+ * without a certificate is the browser's padlock and nothing underneath it.
+ *
+ * ## Why the port is the same 41427
+ *
+ * Spike S6 chose that number so a link written on one machine on Tuesday opens
+ * on another on Thursday, and the tailnet is the first place that promise is
+ * cashed. A different port for the tailnet would be a second number to defend,
+ * and the port is not what makes the two authorities different - the `Host`
+ * header is.
+ */
+import { execFile } from 'node:child_process'
+import { delimiter, join } from 'node:path'
+import { access } from 'node:fs/promises'
+import { promisify } from 'node:util'
+import { LINK_SERVER_HOST } from '../shared/link-port.js'
+
+const run = promisify(execFile)
+
+/**
+ * How long to let a `tailscale` invocation run.
+ *
+ * `status` and `serve status` talk to a local daemon over a socket and answer
+ * in milliseconds. `serve` itself may have to provision a certificate, which is
+ * a network round trip to Let's Encrypt - and on a tailnet without HTTPS
+ * enabled it simply never returns, which is exactly what M6.0 found. So the
+ * timeout is not a safety net here, it is the mechanism by which "HTTPS is not
+ * available" is discovered.
+ */
+const STATUS_TIMEOUT_MS = 5_000
+const SERVE_TIMEOUT_MS = 20_000
+
+/**
+ * Where `tailscale` is, when it is not on PATH.
+ *
+ * The Mac app ships its CLI inside the bundle and only symlinks it into
+ * `/usr/local/bin` if the user asks, so PATH alone would report "no Tailscale"
+ * on a machine that is on the tailnet right now. Windows puts it under Program
+ * Files and does not add it to a GUI process's PATH either. Absolute paths
+ * rather than a shell, because a shell would mean quoting.
+ */
+const KNOWN_PATHS: Readonly<Record<string, readonly string[]>> = {
+  darwin: [
+    '/usr/local/bin/tailscale',
+    '/opt/homebrew/bin/tailscale',
+    '/Applications/Tailscale.app/Contents/MacOS/Tailscale'
+  ],
+  win32: [
+    'C:\\Program Files\\Tailscale\\tailscale.exe',
+    'C:\\Program Files (x86)\\Tailscale\\tailscale.exe'
+  ],
+  linux: ['/usr/bin/tailscale', '/usr/local/bin/tailscale']
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The `tailscale` binary, or null when this machine has none.
+ *
+ * Cached for the life of the process. Installing Tailscale while GitWarren is
+ * open is real but rare, and the failure it causes - a settings panel that
+ * still says "not available" until the app restarts - is both visible and
+ * self-explanatory. A negative answer is cached too, which is the half that
+ * matters: this is asked on every settings render and a filesystem walk per
+ * render is the cost this avoids.
+ */
+let resolved: { path: string | null } | null = null
+
+export async function tailscaleBinary(): Promise<string | null> {
+  if (resolved) return resolved.path
+
+  const onPath = process.env.PATH
+  const suffix = process.platform === 'win32' ? '.exe' : ''
+  const candidates: string[] = []
+  for (const directory of (onPath ?? '').split(delimiter)) {
+    if (directory) candidates.push(join(directory, `tailscale${suffix}`))
+  }
+  candidates.push(...(KNOWN_PATHS[process.platform] ?? []))
+
+  for (const candidate of candidates) {
+    if (await exists(candidate)) {
+      resolved = { path: candidate }
+      return candidate
+    }
+  }
+  resolved = { path: null }
+  return null
+}
+
+/** For tests, and for nothing else: the cache is otherwise for the process. */
+export function forgetTailscaleBinary(): void {
+  resolved = null
+}
+
+/** One `tailscale` invocation. Never throws; stdout, or null. */
+async function tailscale(args: string[], timeout: number): Promise<string | null> {
+  const binary = await tailscaleBinary()
+  if (binary === null) return null
+  try {
+    const { stdout } = await run(binary, args, { timeout, maxBuffer: 8 * 1024 * 1024 })
+    return stdout
+  } catch {
+    // Every failure is the same answer to every caller here: not available, or
+    // not now. `tailscale` distinguishes "not installed", "not logged in",
+    // "daemon not running" and "this tailnet cannot do that" in its exit codes
+    // and its prose, and none of those changes what this application does -
+    // which is offer the tailnet or not offer it.
+    return null
+  }
+}
+
+/** One machine on the tailnet, as this install cares about it. */
+export interface TailnetPeer {
+  /** MagicDNS name with the trailing dot removed: `pc-wsl.tail688c0c.ts.net`. */
+  dnsName: string
+  /** The short name, for a label a person recognises. */
+  hostName: string
+  /** `Windows`, `linux`, `iOS`… as Tailscale spells it. Shown, never branched on. */
+  os: string
+  online: boolean
+}
+
+export interface TailnetIdentity {
+  /** This machine's MagicDNS name, without the trailing dot. */
+  dnsName: string
+  /**
+   * The login of whoever owns this node - `michal-wrzosek@github`.
+   *
+   * This is the whole of M6's authorisation: a request carrying
+   * `Tailscale-User-Login` equal to this is the owner, and anything else is
+   * refused before dispatch. The plan calls it "same Tailscale login as the
+   * owner" and it is deliberately not a list.
+   */
+  login: string
+  /** Every other node with the same owner. Unfiltered by OS - see `peers()`. */
+  peers: TailnetPeer[]
+}
+
+interface StatusNode {
+  DNSName?: string
+  HostName?: string
+  OS?: string
+  Online?: boolean
+  UserID?: number
+}
+
+/**
+ * Who this machine is on the tailnet, and which machines are its owner's.
+ *
+ * Null covers everything: no Tailscale, not logged in, daemon down, output this
+ * version does not produce. No caller can act on the distinction - the answer
+ * is "the tailnet is not available here" in all of them - which is the same
+ * shape `readLiveDaemonRuntime` settled on for its own file.
+ *
+ * Read fresh on every call rather than cached. A laptop joins and leaves
+ * networks, a node is renamed in the admin console, a peer comes online: all of
+ * those change this answer while the process runs, and a stale identity here
+ * would be a gate comparing against a login that is no longer the owner's.
+ */
+export async function readTailnetIdentity(): Promise<TailnetIdentity | null> {
+  const output = await tailscale(['status', '--json'], STATUS_TIMEOUT_MS)
+  if (output === null) return null
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(output)
+  } catch {
+    return null
+  }
+  const status = parsed as {
+    BackendState?: string
+    Self?: StatusNode
+    Peer?: Record<string, StatusNode>
+    User?: Record<string, { LoginName?: string }>
+  }
+
+  // `Running` is the only state in which any of this means anything. `Stopped`,
+  // `NeedsLogin` and `NoState` all produce a `Self` with a name in it, which is
+  // exactly the sort of half-answer that would make a gate compare against a
+  // login for a tailnet this machine is not currently on.
+  if (status.BackendState !== 'Running') return null
+
+  const self = status.Self
+  const userId = self?.UserID
+  if (!self?.DNSName || userId === undefined) return null
+
+  const login = status.User?.[String(userId)]?.LoginName
+  if (!login) return null
+
+  const peers: TailnetPeer[] = []
+  for (const peer of Object.values(status.Peer ?? {})) {
+    // Same owner only. A tailnet may be shared, and a node belonging to someone
+    // else is not a machine this install has any business proposing - the
+    // authorisation decision and the discovery decision read the same field, on
+    // purpose, so they cannot drift apart.
+    if (peer.UserID !== userId || !peer.DNSName) continue
+    peers.push({
+      dnsName: trimDot(peer.DNSName),
+      hostName: peer.HostName ?? trimDot(peer.DNSName).split('.')[0] ?? '',
+      os: peer.OS ?? '',
+      online: peer.Online === true
+    })
+  }
+
+  return { dnsName: trimDot(self.DNSName), login, peers }
+}
+
+/** MagicDNS names are fully qualified and end in a dot. URLs do not. */
+function trimDot(name: string): string {
+  return name.endsWith('.') ? name.slice(0, -1) : name
+}
+
+/**
+ * Whether this install is currently served on the tailnet, and at what origin.
+ *
+ * Read from `tailscale serve status --json` rather than remembered, because
+ * `tailscale serve` is machine state rather than application state: it survives
+ * a GitWarren restart, and a user may well turn it off from a terminal. A
+ * toggle that showed what this process last did would disagree with the machine
+ * and there would be no way for the user to tell which was lying.
+ */
+export async function tailnetServeOrigin(port: number): Promise<string | null> {
+  const output = await tailscale(['serve', 'status', '--json'], STATUS_TIMEOUT_MS)
+  if (output === null) return null
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(output)
+  } catch {
+    return null
+  }
+  const config = parsed as {
+    TCP?: Record<string, { HTTP?: boolean; HTTPS?: boolean }>
+    Web?: Record<string, { Handlers?: Record<string, { Proxy?: string }> }>
+  }
+
+  const target = `http://${LINK_SERVER_HOST}:${port}`
+  // `Web` is keyed by `<host>:<port>` and holds the handlers under it. The
+  // scheme is not in that key, so it comes from `TCP[port]` - which is the one
+  // place that says whether the listener terminates TLS.
+  for (const [authority, entry] of Object.entries(config.Web ?? {})) {
+    const proxies = Object.values(entry.Handlers ?? {}).some(
+      (handler) => handler.Proxy !== undefined && handler.Proxy.startsWith(target)
+    )
+    if (!proxies) continue
+    const listenPort = authority.slice(authority.lastIndexOf(':') + 1)
+    const scheme = config.TCP?.[listenPort]?.HTTPS === true ? 'https' : 'http'
+    return `${scheme}://${authority}`
+  }
+  return null
+}
+
+/**
+ * Put the loopback port on the tailnet, and say where it landed.
+ *
+ * HTTPS first and HTTP as the fallback, in that order, because the outcome is
+ * not knowable in advance - see the header. The HTTPS attempt is bounded by a
+ * timeout rather than by an error, since a tailnet without certificates
+ * enabled leaves `tailscale serve --https` waiting rather than refusing, which
+ * M6.0 found the hard way.
+ *
+ * Answers the origin actually being served, or null if neither worked. Never
+ * throws: a settings toggle that failed should say so on the panel, not take a
+ * window down.
+ */
+export async function serveTailnet(port: number): Promise<string | null> {
+  const target = `http://${LINK_SERVER_HOST}:${port}`
+
+  // `--bg` or the command holds the terminal forever. It is background state on
+  // the machine either way, which is why `tailnetServeOrigin` reads it back
+  // instead of this function remembering what it did.
+  await tailscale(['serve', '--bg', '--https', String(port), target], SERVE_TIMEOUT_MS)
+  const secure = await tailnetServeOrigin(port)
+  if (secure !== null) return secure
+
+  await tailscale(['serve', '--bg', '--http', String(port), target], SERVE_TIMEOUT_MS)
+  return tailnetServeOrigin(port)
+}
+
+/**
+ * Take it off the tailnet.
+ *
+ * Both spellings, because which one is live depends on what `serveTailnet`
+ * managed, and turning off the one that is not running is a no-op rather than
+ * an error. Answers whether anything is still served afterwards, so a caller
+ * reports the machine's state rather than its own intention.
+ */
+export async function unserveTailnet(port: number): Promise<boolean> {
+  await tailscale(['serve', '--https', String(port), 'off'], SERVE_TIMEOUT_MS)
+  await tailscale(['serve', '--http', String(port), 'off'], SERVE_TIMEOUT_MS)
+  return (await tailnetServeOrigin(port)) !== null
+}

--- a/src/core/web/__tests__/web-handler.test.ts
+++ b/src/core/web/__tests__/web-handler.test.ts
@@ -93,9 +93,21 @@ before(async () => {
     staticRoot,
     token: TOKEN,
     appInfo: () => APP_INFO,
-    port
+    port,
+    // Read per request by the handler, exactly as the real one reads
+    // `tailnetGate()`, so a test can turn exposure on and off between cases the
+    // way the settings switch does at runtime.
+    tailnet: () => exposed
   })
 })
+
+/** The tailnet gate, when these tests have turned it on. */
+let exposed: { authority: string; login: string; scheme: 'http' | 'https' } | null = null
+
+const OWNER = 'michal-wrzosek@github'
+function tailnetAuthority(): string {
+  return `pc-wsl.tail688c0c.ts.net:${port}`
+}
 
 after(async () => {
   handler.close()
@@ -147,6 +159,26 @@ async function post(
  * that exists because a *browser* is what sends the header - hence the raw
  * client for this case.
  */
+function rawPost(path: string, headers: Record<string, string>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(
+      {
+        host: '127.0.0.1',
+        port,
+        path,
+        method: 'POST',
+        headers: { ...headers, 'content-type': 'application/json', 'content-length': '2' }
+      },
+      (response) => {
+        response.resume()
+        resolve(response.statusCode ?? 0)
+      }
+    )
+    request.on('error', reject)
+    request.end('{}')
+  })
+}
+
 function rawGet(path: string, headers: Record<string, string>): Promise<number> {
   return new Promise((resolve, reject) => {
     const request = httpRequest(
@@ -542,4 +574,126 @@ test('a body with no end does not grow this process', async () => {
     [TOKEN_HEADER]: TOKEN
   })
   assert.equal(response.status, 413)
+})
+
+/**
+ * The second authority, and who is allowed through it.
+ *
+ * Every case here is a *refusal*, which is what makes them worth writing down:
+ * the happy path was proved against the real tailnet from a real second machine
+ * (`scripts/verify/m6-3.mjs`), and what a test can do that a demonstration
+ * cannot is show that the ways in which it should say no are all still shut.
+ *
+ * The headers are forged, and that is fine for exactly these questions.
+ * `Tailscale-User-Login` is set by `tailscaled` in life; here it is set by the
+ * test, which is the same position an attacker on this machine is in - and the
+ * module's header says plainly that such an attacker gains nothing, because it
+ * can already read the token file and open the database. What these check is
+ * the boundary that does matter: which authority a claim is believed on.
+ */
+test('a tailnet-shaped request is refused while exposure is off', async () => {
+  exposed = null
+  const status = await rawGet('/app/', {
+    host: tailnetAuthority(),
+    'tailscale-user-login': OWNER
+  })
+  // 403 rather than 401: the authority itself does not exist, so there is no
+  // question of identity to get wrong.
+  assert.equal(status, 403)
+})
+
+test('the owner gets in over the tailnet with no token at all', async () => {
+  exposed = { authority: tailnetAuthority(), login: OWNER, scheme: 'http' }
+  const status = await rawGet('/app/', {
+    host: tailnetAuthority(),
+    'tailscale-user-login': OWNER
+  })
+  assert.equal(status, 200)
+  exposed = null
+})
+
+test('another login on the tailnet is refused', async () => {
+  exposed = { authority: tailnetAuthority(), login: OWNER, scheme: 'http' }
+  assert.equal(
+    await rawGet('/app/', {
+      host: tailnetAuthority(),
+      'tailscale-user-login': 'someone-else@github'
+    }),
+    401
+  )
+  // And no header at all, which is what a request that did not come through
+  // `tailscale serve` looks like.
+  assert.equal(await rawGet('/app/', { host: tailnetAuthority() }), 401)
+  exposed = null
+})
+
+test('a token is not consulted on the tailnet authority', async () => {
+  // The thing this milestone was told not to collapse. A token minted on one
+  // machine is not evidence about a person on another, so the session cookie
+  // that opens loopback opens nothing here.
+  exposed = { authority: tailnetAuthority(), login: OWNER, scheme: 'http' }
+  const status = await rawGet('/app/', {
+    host: tailnetAuthority(),
+    cookie: `${SESSION_COOKIE}=${TOKEN}`
+  })
+  assert.equal(status, 401)
+  exposed = null
+})
+
+test('an identity header on loopback grants nothing', async () => {
+  // The mirror of the case above, and the one that would be easy to get wrong
+  // by checking the header before checking which authority was reached. A local
+  // process may set this header freely; it must only ever be read on the
+  // authority `tailscale serve` is proxying to.
+  exposed = { authority: tailnetAuthority(), login: OWNER, scheme: 'http' }
+  const status = await rawGet('/app/', {
+    host: `127.0.0.1:${port}`,
+    'tailscale-user-login': OWNER
+  })
+  assert.equal(status, 401)
+  exposed = null
+})
+
+test('a page on the tailnet origin may act, and a loopback page may not act on it', async () => {
+  exposed = { authority: tailnetAuthority(), login: OWNER, scheme: 'http' }
+  const socket = await connect({
+    host: tailnetAuthority(),
+    origin: `http://${tailnetAuthority()}`,
+    'tailscale-user-login': OWNER
+  })
+  socket.close()
+
+  // The cross-authority case: our own loopback origin, on the tailnet host. It
+  // is one of the two values this server mints and it is still not the right
+  // one, which is what comparing rather than parsing buys.
+  await assert.rejects(
+    connect({
+      host: tailnetAuthority(),
+      origin: origin(),
+      'tailscale-user-login': OWNER
+    }),
+    /403/
+  )
+  exposed = null
+})
+
+test('the poke endpoint does not exist on the tailnet authority', async () => {
+  // A peer telling this install that its own database changed would be asking
+  // it to believe a claim about something the peer cannot see. 404 rather than
+  // 403, because on that authority there is genuinely no such path.
+  exposed = { authority: tailnetAuthority(), login: OWNER, scheme: 'http' }
+  const seen: string[] = []
+  const stop = subscribeToEvents((event) => seen.push(event.event))
+
+  const status = await rawPost(WEB_PATHS.notify, {
+    host: tailnetAuthority(),
+    origin: `http://${tailnetAuthority()}`,
+    'tailscale-user-login': OWNER,
+    [TOKEN_HEADER]: TOKEN
+  })
+
+  stop()
+  assert.equal(status, 404)
+  assert.deepEqual(seen, [])
+  exposed = null
 })

--- a/src/core/web/__tests__/web-handler.test.ts
+++ b/src/core/web/__tests__/web-handler.test.ts
@@ -25,9 +25,10 @@ const dataDir = mkdtempSync(join(tmpdir(), 'gitwarren-web-'))
 process.env.GITWARREN_DATA_DIR = dataDir
 
 const { createWebHandler } = await import('../handler.js')
-const { SESSION_COOKIE, TOKEN_PARAM, WEB_PATHS, webAttachmentSrc } = await import(
+const { SESSION_COOKIE, TOKEN_HEADER, TOKEN_PARAM, WEB_PATHS, webAttachmentSrc } = await import(
   '../../../shared/web.js'
 )
+const { subscribeToEvents } = await import('../../events.js')
 const { attachmentsService } = await import('../../services/attachments.js')
 const { closeDatabase } = await import('../../db/client.js')
 
@@ -115,6 +116,26 @@ function withSession(headers: Record<string, string> = {}): Record<string, strin
 
 async function get(path: string, headers: Record<string, string> = {}): Promise<Response> {
   return fetch(`${origin()}${path}`, { headers, redirect: 'manual' })
+}
+
+/**
+ * A JSON `POST`, which until M6 nothing on this server would answer.
+ *
+ * `fetch` is right for this one where it was wrong for the `Host` check: the
+ * headers under test here - `Origin` and the token header - are ones a caller
+ * is allowed to set, and the whole question is what happens when it does.
+ */
+async function post(
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  return fetch(`${origin()}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+    redirect: 'manual'
+  })
 }
 
 /**
@@ -406,4 +427,119 @@ test('a frame that is not a request is refused under an id it can be read with',
 
   assert.equal(answer.id, 0)
   assert.equal(answer.error?.code, 'INVALID_INPUT')
+})
+
+/**
+ * The one write this server answers: the agent's process poking the owner.
+ *
+ * M6 breaks a property this file's header had held since M3 - that everything
+ * behind the gate is a read - so the exception gets the coverage the rule had.
+ * What each case is really asking is "which of the three locks is doing the
+ * work here", because a poke that got in without one of them would still look
+ * like it was working.
+ */
+test('a poke with the token puts the event on the bus', async () => {
+  const seen: string[] = []
+  const stop = subscribeToEvents((event) => seen.push(event.event))
+
+  const response = await post(WEB_PATHS.notify, { event: 'comments.changed' }, {
+    origin: origin(),
+    [TOKEN_HEADER]: TOKEN
+  })
+
+  stop()
+  assert.equal(response.status, 204)
+  assert.deepEqual(seen, ['comments.changed'])
+})
+
+test('an event from a local poke is not tagged with a host', async () => {
+  // A local process telling the local owner about the local database, which is
+  // what "absent means this install" means everywhere else. Tagging it would
+  // make the renderer look for `…@<id>` keys that do not exist.
+  const seen: { host?: string }[] = []
+  const stop = subscribeToEvents((event) => seen.push(event))
+
+  await post(WEB_PATHS.notify, { event: 'reviews.changed' }, {
+    origin: origin(),
+    [TOKEN_HEADER]: TOKEN
+  })
+
+  stop()
+  assert.equal(seen.length, 1)
+  assert.equal(seen[0]?.host, undefined)
+})
+
+test('the session cookie is not enough: the poke wants the header', async () => {
+  // Deliberate. `SameSite=Strict` already means a cross-site page's request
+  // arrives without the cookie, but a custom header is the lock that does not
+  // depend on a browser's cookie policy being what we think it is - a page
+  // cannot set one without a preflight this server never answers.
+  const seen: string[] = []
+  const stop = subscribeToEvents((event) => seen.push(event.event))
+
+  const response = await post(WEB_PATHS.notify, { event: 'comments.changed' }, withSession({
+    origin: origin()
+  }))
+
+  stop()
+  assert.equal(response.status, 401)
+  assert.deepEqual(seen, [])
+})
+
+test('a poke from another origin is refused before the token is looked at', async () => {
+  const seen: string[] = []
+  const stop = subscribeToEvents((event) => seen.push(event.event))
+
+  const response = await post(WEB_PATHS.notify, { event: 'comments.changed' }, {
+    origin: 'http://evil.example',
+    [TOKEN_HEADER]: TOKEN
+  })
+
+  stop()
+  assert.equal(response.status, 403)
+  assert.deepEqual(seen, [])
+})
+
+test('a poke with no origin at all is refused', async () => {
+  // A write is never a navigation, so an absent origin is not the "somebody
+  // clicked a link" case that reads tolerate - see `origin.ts`.
+  const response = await post(WEB_PATHS.notify, { event: 'comments.changed' }, {
+    [TOKEN_HEADER]: TOKEN
+  })
+  assert.equal(response.status, 403)
+})
+
+test('an event name outside the vocabulary is refused', async () => {
+  const seen: string[] = []
+  const stop = subscribeToEvents((event) => seen.push(event.event))
+
+  for (const event of ['host.state', 'anything.else', '', 42]) {
+    const response = await post(WEB_PATHS.notify, { event }, {
+      origin: origin(),
+      [TOKEN_HEADER]: TOKEN
+    })
+    assert.equal(response.status, 400, String(event))
+  }
+
+  stop()
+  // `host.state` is in the refused set on purpose: it is minted by this
+  // install's own pool from a connection it is holding, and nothing outside
+  // this process has any evidence about it.
+  assert.deepEqual(seen, [])
+})
+
+test('a GET to the notify path is refused, and says what it wanted', async () => {
+  const response = await get(WEB_PATHS.notify, withSession())
+  assert.equal(response.status, 405)
+  assert.equal(response.headers.get('allow'), 'POST')
+})
+
+test('a body with no end does not grow this process', async () => {
+  // The one path that reads a request body at all. The cap is the same
+  // reasoning as `onOverflow` in `core/rpc/ndjson.ts`, on a much smaller scale.
+  const response = await post(WEB_PATHS.notify, { event: 'x'.repeat(4096) }, {
+    origin: origin(),
+    [TOKEN_HEADER]: TOKEN
+  })
+  assert.equal(response.status, 413)
 })

--- a/src/core/web/exposure.ts
+++ b/src/core/web/exposure.ts
@@ -32,6 +32,7 @@ import {
   unserveTailnet
 } from '../tailnet.js'
 import { writeDaemonExposure } from '../daemon-runtime.js'
+import { AppError } from '../../shared/errors.js'
 import type { TailnetGate } from './origin.js'
 import type { TailnetExposure } from '../../shared/schemas.js'
 
@@ -124,9 +125,30 @@ export async function refreshExposure(): Promise<TailnetExposure> {
  * user they were reachable when they were not.
  */
 export async function setExposed(exposed: boolean): Promise<TailnetExposure> {
+  let refusal = ''
   if (servedPort !== 0) {
-    if (exposed) await serveTailnet(servedPort)
+    if (exposed) refusal = (await serveTailnet(servedPort)).failure
     else await unserveTailnet(servedPort)
   }
-  return refreshExposure()
+
+  const now = await refreshExposure()
+  // Asked for and did not get. Thrown rather than returned quietly, because the
+  // caller is a switch somebody just flipped: a control that springs back with
+  // no explanation is the worst version of this, and the remedy is usually one
+  // command that `tailscale` has already named.
+  //
+  // M6.4 found the case on a real Linux box. `tailscale serve` needs root there
+  // unless `tailscale set --operator=$USER` has been run once, and it refuses
+  // with *Access denied: serve config denied* plus that exact command. On macOS
+  // the same call succeeds as the user, so this is invisible until somebody
+  // runs GitWarren on the machine most likely to be a host.
+  if (exposed && !now.exposed) {
+    throw new AppError(
+      'INTERNAL',
+      refusal
+        ? `Tailscale would not put this machine on your tailnet. ${refusal}`
+        : 'Tailscale would not put this machine on your tailnet.'
+    )
+  }
+  return now
 }

--- a/src/core/web/exposure.ts
+++ b/src/core/web/exposure.ts
@@ -1,0 +1,132 @@
+/**
+ * Whether this install is on the tailnet, held in one place because three
+ * things need the same answer and they are in different layers.
+ *
+ * The gate in `core/web/handler.ts` needs it per request, to know which
+ * authority it may answer to and whose login counts. A settings panel needs it
+ * to draw a switch. And `daemon-runtime.json` needs it written down, because
+ * the MCP process is a *different process* and `webUrl` on a tool result is
+ * decided there - see `mcp/gui-link.ts`.
+ *
+ * Without this module each of those would shell out to `tailscale` on its own
+ * schedule and they would disagree, which on the gate would mean answering for
+ * an authority the panel says is off.
+ *
+ * ## The source of truth is the machine, and this is a cache with an owner
+ *
+ * `tailscale serve` is machine state: it survives a GitWarren restart, and the
+ * user may turn it off from a terminal without telling anybody. So `refresh()`
+ * re-reads it from `tailscale serve status` rather than remembering what this
+ * process last did, and it is called at startup - which is what makes a second
+ * launch pick up an exposure the first one left running instead of showing a
+ * switch that disagrees with the machine.
+ *
+ * What is cached is only the *last read*, and it is cached because the gate asks
+ * on every request and a process spawn per request is not a gate, it is a
+ * denial of service with good intentions.
+ */
+import {
+  readTailnetIdentity,
+  serveTailnet,
+  tailnetServeOrigin,
+  unserveTailnet
+} from '../tailnet.js'
+import { writeDaemonExposure } from '../daemon-runtime.js'
+import type { TailnetGate } from './origin.js'
+import type { TailnetExposure } from '../../shared/schemas.js'
+
+const UNAVAILABLE: TailnetExposure = {
+  available: false,
+  dnsName: null,
+  login: null,
+  exposed: false,
+  webRoot: null
+}
+
+let current: TailnetExposure = UNAVAILABLE
+/** The mount this install serves the app at: `/app/` or `/`. */
+let mount = '/'
+let servedPort = 0
+
+/**
+ * Tell this module which shell it is in, before anything asks.
+ *
+ * Called once by whichever process owns the port. It is a setter rather than a
+ * parameter on every call because the gate asks from inside a request handler
+ * that has no business knowing about mounts.
+ */
+export function configureExposure(options: { mount: string; port: number }): void {
+  mount = options.mount
+  servedPort = options.port
+}
+
+/** The last read. Synchronous, because a request handler cannot wait. */
+export function exposureNow(): TailnetExposure {
+  return current
+}
+
+/**
+ * The gate's view of it: the authority to accept and the login to demand.
+ *
+ * Null whenever this install is not exposed, which is what makes the whole
+ * tailnet half of `handler.ts` vanish for a machine with the switch off.
+ */
+export function tailnetGate(): TailnetGate | null {
+  if (!current.exposed || !current.dnsName || !current.login || !current.webRoot) return null
+  const url = new URL(current.webRoot)
+  return {
+    authority: url.host,
+    login: current.login,
+    scheme: url.protocol === 'https:' ? 'https' : 'http'
+  }
+}
+
+function rootFor(origin: string): string {
+  // `new URL` rather than concatenation, so a mount of `/` does not produce a
+  // double slash and `/app/` keeps its trailing one - which matters, because
+  // the web build's asset URLs are relative to the document's own path.
+  return new URL(mount, origin).toString()
+}
+
+/**
+ * Ask the machine what is true, and publish it.
+ *
+ * Everything that changes exposure goes through here rather than updating the
+ * cache itself, so there is one path from "the machine" to "what this process
+ * believes" and it cannot be skipped.
+ */
+export async function refreshExposure(): Promise<TailnetExposure> {
+  const identity = await readTailnetIdentity()
+  if (!identity) {
+    current = UNAVAILABLE
+    writeDaemonExposure(null)
+    return current
+  }
+
+  const origin = servedPort === 0 ? null : await tailnetServeOrigin(servedPort)
+  current = {
+    available: true,
+    dnsName: identity.dnsName,
+    login: identity.login,
+    exposed: origin !== null,
+    webRoot: origin === null ? null : rootFor(origin)
+  }
+  writeDaemonExposure(current.webRoot)
+  return current
+}
+
+/**
+ * Turn it on or off, and answer with what the machine then says.
+ *
+ * Deliberately not "answer with what was asked for". `tailscale serve --https`
+ * on a tailnet without certificates never returns (M6.0), so the request and
+ * the result genuinely differ, and a panel that showed the request would tell a
+ * user they were reachable when they were not.
+ */
+export async function setExposed(exposed: boolean): Promise<TailnetExposure> {
+  if (servedPort !== 0) {
+    if (exposed) await serveTailnet(servedPort)
+    else await unserveTailnet(servedPort)
+  }
+  return refreshExposure()
+}

--- a/src/core/web/handler.ts
+++ b/src/core/web/handler.ts
@@ -35,10 +35,19 @@
  *    to get in. Not a 404: pretending the app is not there would be a lie the
  *    user cannot act on, and the port is not a secret anyway - the token is.
  *
- * Everything behind the gate is a read: the web build, `app-info`, and since
- * M3.2 the attachment bytes an `<img>` in a comment body needs. Writes happen
- * over the socket and nowhere else, which is what keeps the whole of this file
- * answering `GET` and `HEAD` and refusing every other method outright.
+ * Almost everything behind the gate is a read: the web build, `app-info`, and
+ * since M3.2 the attachment bytes an `<img>` in a comment body needs. Writes to
+ * review data happen over the socket and nowhere else, which is what kept this
+ * file answering `GET` and `HEAD` and refusing every other method outright
+ * through M5.
+ *
+ * M6 adds exactly one exception and it is worth naming here rather than leaving
+ * to be discovered: `WEB_PATHS.notify` takes a `POST` from the *agent's*
+ * process, saying that it changed something so the window does not wait fifteen
+ * seconds to find out. It carries no data, names one event from a closed set,
+ * and requires the token in a header on top of the host and origin checks - a
+ * page cannot set one without a preflight this server never answers. The whole
+ * argument, including why it is not a channel of its own, is in `notify.ts`.
  *
  * The socket is upgraded only after the same three, with `Origin` required
  * rather than optional, because a WebSocket handshake is never a navigation.
@@ -48,12 +57,19 @@ import type { Duplex } from 'node:stream'
 import { WebSocketServer } from 'ws'
 import { serveWebSocket } from '../rpc/websocket.js'
 import { serveAttachment } from './attachments.js'
+import { serveNotify } from './notify.js'
 import { isAllowedHost, isAllowedOrigin, loopbackAuthority } from './origin.js'
 import { LINK_SERVER_PORT } from '../../shared/link-port.js'
 import { serveStatic } from './static.js'
 import { isWebToken } from './token.js'
 import { ATTACHMENT_HOST_PARAM } from '../../shared/attachments.js'
-import { SESSION_COOKIE, TOKEN_PARAM, WEB_PATHS, WEB_PREFIX } from '../../shared/web.js'
+import {
+  SESSION_COOKIE,
+  TOKEN_HEADER,
+  TOKEN_PARAM,
+  WEB_PATHS,
+  WEB_PREFIX
+} from '../../shared/web.js'
 import type { AppInfo } from '../../shared/api.js'
 
 export interface WebHandlerOptions {
@@ -106,6 +122,19 @@ function readCookie(header: string | undefined, name: string): string | undefine
     return decodeURIComponent(part.slice(separator + 1).trim())
   }
   return undefined
+}
+
+/**
+ * One request header as a string.
+ *
+ * Node lowercases header names and folds a repeated one into an array. An array
+ * here means a caller sent the token twice, which is not something the MCP
+ * process does and not something worth guessing about - so it is refused by
+ * coming back undefined rather than by picking one.
+ */
+function readHeader(request: IncomingMessage, name: string): string | undefined {
+  const value = request.headers[name]
+  return typeof value === 'string' ? value : undefined
 }
 
 /**
@@ -181,6 +210,26 @@ export function createWebHandler({
       const isRead = request.method === 'GET' || request.method === 'HEAD'
       if (!isAllowedOrigin(request.headers.origin, { required: !isRead, port })) {
         response.writeHead(403, NO_STORE).end()
+        return true
+      }
+
+      // The one write, and the only reason this file is no longer `GET` and
+      // `HEAD` and nothing else. See `notify.ts` for what it is for and the
+      // three independent reasons a web page cannot reach it. The token comes
+      // in a header rather than the cookie, because the caller is a local Node
+      // process and has no cookie jar - and a custom header is a lock of its
+      // own against a page, which cannot set one without a preflight this
+      // server never answers.
+      if (pathname === WEB_PATHS.notify) {
+        if (request.method !== 'POST') {
+          response.writeHead(405, { ...NO_STORE, Allow: 'POST' }).end()
+          return true
+        }
+        if (!isWebToken(token, readHeader(request, TOKEN_HEADER))) {
+          response.writeHead(401, NO_STORE).end()
+          return true
+        }
+        void serveNotify(request, response, NO_STORE)
         return true
       }
 

--- a/src/core/web/handler.ts
+++ b/src/core/web/handler.ts
@@ -67,6 +67,7 @@ import { WebSocketServer } from 'ws'
 import { serveWebSocket } from '../rpc/websocket.js'
 import { serveAttachment } from './attachments.js'
 import { serveNotify } from './notify.js'
+import { describeThisInstance } from '../rpc/dispatcher.js'
 import {
   isAllowedHost,
   isAllowedOrigin,
@@ -355,6 +356,17 @@ export function createWebHandler({
         // owner, and telling them how the owner gets in would be the wrong
         // help.
         response.writeHead(401, UNAUTHORIZED_HEADERS).end(UNAUTHORIZED_PAGE)
+        return true
+      }
+
+      // Who this install is, for a peer deciding whether to propose it. It is
+      // behind the same gate as everything else - on the tailnet that means the
+      // owner's login - so this is not an unauthenticated announcement, it is
+      // one machine of the owner's telling another. See `core/hosts/discover.ts`.
+      if (pathname === WEB_PATHS.discover) {
+        response
+          .writeHead(200, { ...NO_STORE, 'Content-Type': 'application/json; charset=utf-8' })
+          .end(request.method === 'HEAD' ? undefined : JSON.stringify(describeThisInstance()))
         return true
       }
 

--- a/src/core/web/handler.ts
+++ b/src/core/web/handler.ts
@@ -26,14 +26,23 @@
  *
  * ## The gate, in the order a request meets it
  *
- * 1. `Host` must be the loopback authority, and `Origin` - when there is one -
- *    must be ours. See `origin.ts`; neither check is about tokens.
+ * 1. `Host` must be an authority this install hands out, and `Origin` - when
+ *    there is one - must match it. See `origin.ts`; neither check is about
+ *    tokens.
  * 2. `?token=…` on any path under the mount is exchanged for a session cookie
  *    and redirected away, so the secret does not stay in the address bar, in
  *    the history, or in a `Referer`.
  * 3. Without a valid cookie, every path answers the same short page saying how
  *    to get in. Not a 404: pretending the app is not there would be a lie the
  *    user cannot act on, and the port is not a secret anyway - the token is.
+ *
+ * Since M6 there are *two* authorities, and step 3 is different on each. On
+ * loopback it is the token, unchanged. On the tailnet authority - which exists
+ * only while "Reachable on your tailnet" is on - it is
+ * `Tailscale-User-Login` equal to the owner's, and the token is not consulted
+ * at all. That is not a shortcut: the two are answering different questions,
+ * one about intent and one about principal, and `isTailnetOwner` in `origin.ts`
+ * is where the distinction is argued and must be kept.
  *
  * Almost everything behind the gate is a read: the web build, `app-info`, and
  * since M3.2 the attachment bytes an `<img>` in a comment body needs. Writes to
@@ -58,7 +67,15 @@ import { WebSocketServer } from 'ws'
 import { serveWebSocket } from '../rpc/websocket.js'
 import { serveAttachment } from './attachments.js'
 import { serveNotify } from './notify.js'
-import { isAllowedHost, isAllowedOrigin, loopbackAuthority } from './origin.js'
+import {
+  isAllowedHost,
+  isAllowedOrigin,
+  isTailnetHost,
+  isTailnetOwner,
+  loopbackAuthority,
+  TAILSCALE_USER_HEADER,
+  type TailnetGate
+} from './origin.js'
 import { LINK_SERVER_PORT } from '../../shared/link-port.js'
 import { serveStatic } from './static.js'
 import { isWebToken } from './token.js'
@@ -91,6 +108,20 @@ export interface WebHandlerOptions {
    * developer's machine is usually held by their own running GitWarren.
    */
   port?: number
+  /**
+   * How this install is exposed on the tailnet right now, or null when it is
+   * not. Read per request, like `appInfo`.
+   *
+   * A function rather than a value because the answer changes while the process
+   * runs - a settings toggle turns it on, and `tailscale serve` is machine
+   * state a user may also change from a terminal. A handler holding a snapshot
+   * would keep answering for an authority that had been withdrawn, which is the
+   * one staleness that matters here.
+   *
+   * Undefined and null mean the same thing and both mean "M5's gate": a machine
+   * that has never heard of a tailnet has exactly the server it had.
+   */
+  tailnet?: () => TailnetGate | null
 }
 
 export interface WebHandler {
@@ -173,7 +204,8 @@ export function createWebHandler({
   staticRoot,
   token,
   appInfo,
-  port = LINK_SERVER_PORT
+  port = LINK_SERVER_PORT,
+  tailnet = () => null
 }: WebHandlerOptions): WebHandler {
   if (!mount.endsWith('/')) throw new Error(`A web mount must end in "/", got ${mount}`)
 
@@ -191,8 +223,27 @@ export function createWebHandler({
     // app's own mount typed without its slash, which is redirected below.
     (mount === '/' && pathname === '')
 
-  const authorised = (request: IncomingMessage): boolean =>
-    isWebToken(token, readCookie(request.headers.cookie, SESSION_COOKIE))
+  /**
+   * Whether this request may be answered at all, and on which of the two
+   * grounds.
+   *
+   * Exactly one applies, decided by the authority the request arrived at - and
+   * the two are answering different questions, which is why neither falls back
+   * to the other. See `isTailnetOwner` for the argument; the short version is
+   * that the token is about *intent* on a machine where every process is
+   * already the user, and the header is about *principal* on a network where
+   * intent cannot be checked.
+   *
+   * So a token on a tailnet request is not consulted. A token minted on the PC
+   * says nothing about the person holding a phone, and honouring it would be
+   * the collapse this milestone was told not to make.
+   */
+  const authorised = (request: IncomingMessage, gate: TailnetGate | null): boolean => {
+    if (isTailnetHost(request.headers.host, gate)) {
+      return isTailnetOwner(request.headers[TAILSCALE_USER_HEADER], gate)
+    }
+    return isWebToken(token, readCookie(request.headers.cookie, SESSION_COOKIE))
+  }
 
   return {
     request(request, response) {
@@ -200,7 +251,12 @@ export function createWebHandler({
       const pathname = decodeURIComponent(url.pathname)
       if (!mine(pathname)) return false
 
-      if (!isAllowedHost(request.headers.host, port)) {
+      // Read once per request rather than per check, so the three questions
+      // below cannot disagree about whether this install is exposed.
+      const gate = tailnet()
+      const overTailnet = isTailnetHost(request.headers.host, gate)
+
+      if (!isAllowedHost(request.headers.host, port, gate)) {
         response.writeHead(403, NO_STORE).end()
         return true
       }
@@ -208,7 +264,14 @@ export function createWebHandler({
       // Reads may arrive as a navigation, which carries no Origin. Anything
       // else is a page acting on its own behalf and must name itself.
       const isRead = request.method === 'GET' || request.method === 'HEAD'
-      if (!isAllowedOrigin(request.headers.origin, { required: !isRead, port })) {
+      if (
+        !isAllowedOrigin(request.headers.origin, {
+          required: !isRead,
+          port,
+          tailnet: gate,
+          overTailnet
+        })
+      ) {
         response.writeHead(403, NO_STORE).end()
         return true
       }
@@ -221,6 +284,15 @@ export function createWebHandler({
       // own against a page, which cannot set one without a preflight this
       // server never answers.
       if (pathname === WEB_PATHS.notify) {
+        // Loopback only, whatever the gate says. A poke is a statement about
+        // *this machine's* processes; a peer asking this install to re-read
+        // something would be asking it to believe a claim about a database it
+        // cannot see. What a remote install does instead is emit on its own bus
+        // and let it travel as an `RpcEvent` on the carrier already open.
+        if (overTailnet) {
+          response.writeHead(404, NO_STORE).end()
+          return true
+        }
         if (request.method !== 'POST') {
           response.writeHead(405, { ...NO_STORE, Allow: 'POST' }).end()
           return true
@@ -242,7 +314,18 @@ export function createWebHandler({
       // URL. `SameSite=Strict` is what makes a cross-site page unable to use
       // the session even when it can guess the port; `HttpOnly` keeps the value
       // out of reach of anything that manages to run script on the page.
-      const presented = url.searchParams.get(TOKEN_PARAM)
+      // A token on the tailnet authority is dropped rather than exchanged: see
+      // `authorised` above. It is taken out of the URL all the same, so that a
+      // loopback link forwarded to a phone lands on the app instead of leaving
+      // a secret in that phone's address bar and history.
+      const presented = overTailnet ? null : url.searchParams.get(TOKEN_PARAM)
+      if (overTailnet && url.searchParams.has(TOKEN_PARAM)) {
+        url.searchParams.delete(TOKEN_PARAM)
+        response
+          .writeHead(302, { ...NO_STORE, Location: `${url.pathname}${url.search}` })
+          .end()
+        return true
+      }
       if (presented !== null) {
         if (!isWebToken(token, presented)) {
           response.writeHead(403, UNAUTHORIZED_HEADERS).end(UNAUTHORIZED_PAGE)
@@ -265,7 +348,12 @@ export function createWebHandler({
         return true
       }
 
-      if (!authorised(request)) {
+      if (!authorised(request, gate)) {
+        // The same page either way, and the sentence it carries is about the
+        // token because that is the only one a person can do anything about. A
+        // tailnet request that is refused was made by somebody who is not the
+        // owner, and telling them how the owner gets in would be the wrong
+        // help.
         response.writeHead(401, UNAUTHORIZED_HEADERS).end(UNAUTHORIZED_PAGE)
         return true
       }
@@ -325,6 +413,8 @@ export function createWebHandler({
       const url = new URL(request.url ?? '/', `http://${loopbackAuthority(port)}`)
       if (decodeURIComponent(url.pathname) !== WEB_PATHS.socket) return false
 
+      const gate = tailnet()
+
       // A refusal here is a socket write, not a response object: the connection
       // has already left HTTP behind. Every one of them ends the connection
       // rather than leaving a half-upgraded socket around.
@@ -334,12 +424,22 @@ export function createWebHandler({
         return true
       }
 
-      if (!isAllowedHost(request.headers.host, port)) return refuse('403 Forbidden')
+      if (!isAllowedHost(request.headers.host, port, gate)) return refuse('403 Forbidden')
       // Required, unlike on a read: an upgrade is never a top-level navigation,
       // so a browser always sends it and a missing one is not a browser.
-      if (!isAllowedOrigin(request.headers.origin, { required: true, port }))
+      if (
+        !isAllowedOrigin(request.headers.origin, {
+          required: true,
+          port,
+          tailnet: gate,
+          overTailnet: isTailnetHost(request.headers.host, gate)
+        })
+      )
         return refuse('403 Forbidden')
-      if (!authorised(request)) return refuse('401 Unauthorized')
+      // The identity header survives an upgrade, which is the half of M6.0 that
+      // could have failed silently: a proxy that stamped requests and dropped
+      // upgrades would have left the phone working and every carrier refused.
+      if (!authorised(request, gate)) return refuse('401 Unauthorized')
 
       sockets.handleUpgrade(request, socket, head, (websocket) => {
         serveWebSocket(websocket)

--- a/src/core/web/notify.ts
+++ b/src/core/web/notify.ts
@@ -1,0 +1,165 @@
+/**
+ * The one write this server answers, and the reason it is allowed to exist.
+ *
+ * `core/web/handler.ts` says, in as many words, that everything behind its gate
+ * is a read and that this is what keeps the whole file answering `GET` and
+ * `HEAD` and refusing every other method outright. That was true through M5 and
+ * it stops being true here, so the exception is written down rather than
+ * slipped in.
+ *
+ * ## What it is for
+ *
+ * An agent writing a comment does it in the *MCP process*, which is a different
+ * OS process from the GUI: `core/daemon-runtime.ts` explains at length why the
+ * MCP server opens SQLite directly and never routes reads through the owner -
+ * quit GitWarren and the agent keeps working, which is a property worth more
+ * than a push. But that also means `emitEvent` in the MCP process reaches
+ * nobody, and a window that has to wait fifteen seconds to see what an agent
+ * just wrote is the thing this milestone exists to fix.
+ *
+ * So the agent's process dials the owner. Everything it needs is already
+ * published: `daemon-runtime.json` names the owning pid and the port it is
+ * serving on, and `core/web/token.ts` writes the session token next to it with
+ * mode 0600. The channel is this handler. Nothing new is bound, nothing new is
+ * watched, and the poke is one request that either lands or does not.
+ *
+ * ## Why this is not a hole
+ *
+ * Three locks, and the interesting part is what each one is *for*.
+ *
+ *  - **The token.** The same 0600 file, read by a process running as the user.
+ *    That is not authentication of a person - `token.ts` is explicit that the
+ *    principal on loopback is "whoever is at this machine" - it is the check
+ *    that the caller was pointed at GitWarren rather than merely knowing the
+ *    port.
+ *  - **A loopback `Host` and our own `Origin`, both required.** This is the
+ *    lock that matters, because the attacker worth worrying about on a loopback
+ *    port is a web page (see `origin.ts` on DNS rebinding). A page cannot set
+ *    `Host`, cannot set a custom header without a preflight this server never
+ *    answers, and `SameSite=Strict` means its request would arrive without the
+ *    cookie anyway. Three independent reasons it fails, which is the right
+ *    number for the only endpoint that is not a read.
+ *  - **A closed vocabulary.** The body may name an event and nothing else. Not
+ *    because a bad name would be dangerous, but because "the set of things that
+ *    can be put on the bus" should be decided here rather than by whatever
+ *    string a caller sent.
+ *
+ * And the honest bound on all of it: a local process running as the user can
+ * already open the database. The worst this endpoint grants is making a window
+ * re-read something it could have caused by writing a row.
+ *
+ * ## Tailnet requests are refused here, always
+ *
+ * The gate in `handler.ts` admits a request on either of two grounds from M6.3
+ * - loopback with the token, or the tailnet with the owner's login. This
+ * endpoint takes only the first. A poke is a statement about *this machine's*
+ * processes; a peer on the tailnet that wanted this install to re-read
+ * something would be asking it to believe a claim about a database it cannot
+ * see. What a remote install does instead is emit on its own bus, which travels
+ * as an `RpcEvent` on the carrier that is already open.
+ */
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { emitEvent } from '../events.js'
+import { RPC_EVENTS, type RpcEventName } from '../../shared/rpc.js'
+
+/** The names this endpoint will put on the bus. Everything else is refused. */
+const ACCEPTED: ReadonlySet<string> = new Set<RpcEventName>([
+  RPC_EVENTS.reviewsChanged,
+  RPC_EVENTS.commentsChanged
+  // `host.state` is deliberately absent. It is minted by this install's own
+  // pool from a connection it is holding, and nothing outside this process has
+  // any evidence about it.
+])
+
+/**
+ * How much of a body to read before giving up.
+ *
+ * A poke is about sixty bytes. The cap is here because this is the one path
+ * that reads a request body at all, and a body with no end is otherwise a
+ * process that grows until it dies - the same reasoning as `onOverflow` in
+ * `core/rpc/ndjson.ts`, on a much smaller scale.
+ */
+const MAX_BODY_BYTES = 1024
+
+/**
+ * The request body, or null if it was too large or the connection failed.
+ *
+ * The oversized case **stops accumulating but does not hang up**, and that
+ * ordering was found by a test rather than by reading. Destroying the request
+ * the moment the cap is passed takes the socket down before the `413` can be
+ * written, so the caller sees a connection reset - "other side closed" - where
+ * it should have seen a status it could read. A refusal nobody receives is not
+ * a refusal; hanging up is the caller's answer, and it comes after the answer.
+ *
+ * So `overflowed` guards the accumulation, which is what bounds the memory, and
+ * the promise settles immediately rather than waiting for an `end` an endless
+ * body will never send. `serveNotify` destroys the connection once it has
+ * replied.
+ */
+function readBody(request: IncomingMessage): Promise<string | null> {
+  return new Promise((resolve) => {
+    let body = ''
+    let overflowed = false
+
+    request.on('data', (chunk: Buffer) => {
+      if (overflowed) return
+      body += chunk.toString('utf8')
+      if (body.length > MAX_BODY_BYTES) {
+        overflowed = true
+        resolve(null)
+      }
+    })
+    request.on('end', () => {
+      if (!overflowed) resolve(body)
+    })
+    request.on('error', () => {
+      if (!overflowed) resolve(null)
+    })
+  })
+}
+
+/**
+ * Take one poke. The caller has already checked the token, the host and the
+ * origin - this decides only whether the body names something real.
+ *
+ * Answers 204 for a name it accepted and 400 for anything else. Deliberately
+ * not 200-with-a-body: there is nothing to say, and a caller that waits for a
+ * payload here would be a caller doing something wrong.
+ */
+export async function serveNotify(
+  request: IncomingMessage,
+  response: ServerResponse,
+  headers: Record<string, string>
+): Promise<void> {
+  const body = await readBody(request)
+  if (body === null) {
+    // Answer, then hang up - in that order, and `Connection: close` so the
+    // client is not left waiting for a keep-alive turn on a socket carrying the
+    // rest of a body nobody is reading.
+    response.writeHead(413, { ...headers, Connection: 'close' }).end()
+    request.destroy()
+    return
+  }
+
+  let event: unknown
+  try {
+    event = (JSON.parse(body) as { event?: unknown }).event
+  } catch {
+    response.writeHead(400, headers).end()
+    return
+  }
+
+  if (typeof event !== 'string' || !ACCEPTED.has(event)) {
+    response.writeHead(400, headers).end()
+    return
+  }
+
+  // No host on it. This is a local process telling the local owner about the
+  // local database, which is exactly what "absent means this install" means
+  // everywhere else - see `RpcEvent.host`.
+  emitEvent({ event, data: null })
+  response.writeHead(204, headers).end()
+}
+
+/** Exported for the test, which is about what the vocabulary is. */
+export const ACCEPTED_EVENTS = ACCEPTED

--- a/src/core/web/origin.ts
+++ b/src/core/web/origin.ts
@@ -22,6 +22,19 @@
  * accepting both would mean a user who typed the wrong one got an unexplained
  * "no session" page. One authority, named in every URL this app mints.
  *
+ * ## The second authority, since M6
+ *
+ * An install with "Reachable on your tailnet" turned on has exactly one more:
+ * its own MagicDNS name and the same port. `tailscale serve` proxies from the
+ * tailnet *to loopback*, so such a request arrives on 127.0.0.1 and the only
+ * thing distinguishing it is the `Host` header - which is why this is a second
+ * accepted value rather than a second listener. Everything above still holds
+ * for it: a browser cannot change `Host`, so requiring it to be one of the two
+ * we hand out is what forecloses rebinding on both.
+ *
+ * What is *different* about the tailnet authority is how a request on it is
+ * authorised, and that is deliberately not a token. See `isTailnetOwner`.
+ *
  * ## `Origin`, against a page that already knows the port
  *
  * A cross-site page cannot read a response it is not allowed to read, but it
@@ -40,13 +53,56 @@
  */
 import { LINK_SERVER_HOST, LINK_SERVER_PORT } from '../../shared/link-port.js'
 
-/** The one authority this server answers to. */
+/** The loopback authority. Until M6 this was the only one. */
 export function loopbackAuthority(port: number = LINK_SERVER_PORT): string {
   return `${LINK_SERVER_HOST}:${port}`
 }
 
-export function isAllowedHost(host: string | undefined, port?: number): boolean {
-  return host === loopbackAuthority(port)
+/**
+ * What a tailnet-exposed install answers to, and who it answers for.
+ *
+ * Null means "not exposed", which is the default and stays the default: a
+ * machine with the toggle off has exactly the gate it had in M5.
+ *
+ * ## Why this is a second authority rather than a second server
+ *
+ * `tailscale serve` proxies from the tailnet *to loopback*, so a request from
+ * a phone arrives on 127.0.0.1 with `Host: pc-wsl.tail688c0c.ts.net:41427`.
+ * There is no socket to tell the two apart by - the only difference is the
+ * header - which is why this is an addition to the Host check rather than a
+ * listener beside it. Measured in M6.0 against the real tailnet.
+ */
+export interface TailnetGate {
+  /** `pc-wsl.tail688c0c.ts.net:41427`, exactly as the proxy will spell `Host`. */
+  authority: string
+  /** The owner's Tailscale login. Anything else is refused before dispatch. */
+  login: string
+  /** `http` or `https`, whichever `tailscale serve` managed. See `core/tailnet.ts`. */
+  scheme: 'http' | 'https'
+}
+
+/**
+ * Which authorities this server may be reached at.
+ *
+ * Both checks exist for the same attack and neither is about tokens - a browser
+ * cannot change `Host`, so requiring it to be one we handed out is what
+ * forecloses DNS rebinding on either authority.
+ */
+export function isAllowedHost(
+  host: string | undefined,
+  port?: number,
+  tailnet?: TailnetGate | null
+): boolean {
+  if (host === loopbackAuthority(port)) return true
+  return tailnet !== undefined && tailnet !== null && host === tailnet.authority
+}
+
+/** Whether a request arrived at the tailnet authority rather than at loopback. */
+export function isTailnetHost(
+  host: string | undefined,
+  tailnet: TailnetGate | null | undefined
+): boolean {
+  return tailnet !== undefined && tailnet !== null && host === tailnet.authority
 }
 
 /**
@@ -55,14 +111,105 @@ export function isAllowedHost(host: string | undefined, port?: number): boolean 
  * `required` is what separates a navigation from a fetch: reads that a person
  * can reach by typing a URL tolerate an absent origin, and anything a page
  * could have initiated on its own does not.
+ *
+ * A page served over the tailnet has the tailnet origin, and it is exactly as
+ * entitled as a loopback page: it is the same renderer, served by the same
+ * process, to a browser that got through the same gate. What neither may be is
+ * *the other one* - a loopback page must not act on the tailnet authority and
+ * the reverse - which is what comparing against the two values we mint, rather
+ * than parsing, keeps true.
  */
 export function isAllowedOrigin(
   origin: string | undefined,
-  { required, port }: { required: boolean; port?: number } = { required: false }
+  {
+    required,
+    port,
+    tailnet,
+    overTailnet = false
+  }: {
+    required: boolean
+    port?: number
+    tailnet?: TailnetGate | null
+    /** Whether this request arrived at the tailnet authority. */
+    overTailnet?: boolean
+  } = { required: false }
 ): boolean {
   if (origin === undefined || origin === '') return !required
+  // Exactly one origin is acceptable, decided by which authority the request
+  // arrived at - not "either of the two we mint". That distinction was a
+  // comment before it was code, and a test caught the difference: a page on
+  // loopback could act on the tailnet authority, because both values were
+  // accepted everywhere. Nothing escalated, since both pages are ours, but the
+  // shape was wrong and the next authority added would have been wrong the same
+  // way. A page acts on the server it was served by.
+  //
   // `null` is what a sandboxed iframe or a `data:` document sends. It is an
   // origin, it is not ours, and it is never allowed - which is why this is a
-  // string comparison against the one value we mint rather than a parse.
+  // string comparison against a value we mint rather than a parse.
+  if (overTailnet) {
+    return (
+      tailnet !== undefined &&
+      tailnet !== null &&
+      origin === `${tailnet.scheme}://${tailnet.authority}`
+    )
+  }
   return origin === `http://${loopbackAuthority(port)}`
+}
+
+/**
+ * The header `tailscale serve` stamps on everything it proxies.
+ *
+ * Lowercase because Node lowercases header names, and named here because two
+ * files read it and one of them is a test that has to forge it.
+ */
+export const TAILSCALE_USER_HEADER = 'tailscale-user-login'
+
+/**
+ * Whether a request that arrived over the tailnet is the owner's.
+ *
+ * This is the whole of M6's authorisation, and it is a different question from
+ * the one `core/web/token.ts` answers - a distinction worth keeping in front of
+ * whoever changes this next.
+ *
+ * The token asks **"was this request made by something the user pointed at
+ * GitWarren, or by a page that merely knows the port?"**. That is a question
+ * about *intent*, and it is the right one on loopback, where the principal is
+ * uninteresting because every process the user runs is already the user.
+ *
+ * This asks **"is the person at the other end the owner?"**. That is a question
+ * about *principal*, and it is the only one available over a network, where
+ * intent cannot be checked at all.
+ *
+ * So a request satisfies one or the other and never both, and in particular a
+ * token presented on a tailnet request is ignored rather than honoured: a token
+ * minted on the PC is not evidence about the person holding a phone, and
+ * treating it as though it were would collapse two mechanisms that are answering
+ * different questions. That also leaves `token.ts`'s three properties exactly as
+ * they were.
+ *
+ * ## What this does and does not protect against
+ *
+ * `tailscaled` sets the header, and it proxies to loopback - so a *local*
+ * process could send the header itself with a `Host` naming the tailnet
+ * authority and get in without the token. That grants it nothing: a local
+ * process running as the user can already read the 0600 token file and open the
+ * database directly, which is the principal `token.ts` says loopback has.
+ *
+ * The door that matters stays shut. A web page cannot set `Host` and cannot set
+ * `Tailscale-User-Login` - both are forbidden header names - so the DNS
+ * rebinding attack `isAllowedHost` exists for is closed on this authority
+ * exactly as it is on the other.
+ */
+export function isTailnetOwner(
+  login: string | string[] | undefined,
+  tailnet: TailnetGate | null | undefined
+): boolean {
+  if (tailnet === undefined || tailnet === null) return false
+  // An array means the header arrived twice, which a proxy does not do and this
+  // is not the place to guess about. Refused by not being a string.
+  if (typeof login !== 'string') return false
+  // Tailscale logins are case-insensitive in practice and Tailscale lowercases
+  // them; compared as given rather than folded, because the value being
+  // compared against came from the same command on the same machine.
+  return login === tailnet.login
 }

--- a/src/daemon/listen.ts
+++ b/src/daemon/listen.ts
@@ -38,6 +38,7 @@ import { getInstanceId } from '../core/instance.js'
 import { describeMcpLaunch } from '../core/mcp-launcher.js'
 import { getDatabasePath, getDataDirectory } from '../core/paths.js'
 import { createWebHandler } from '../core/web/handler.js'
+import { configureExposure, refreshExposure, tailnetGate } from '../core/web/exposure.js'
 import { clearWebToken, mintWebToken, publishWebToken } from '../core/web/token.js'
 import { LINK_SERVER_HOST, LINK_SERVER_PORT } from '../shared/link-port.js'
 import { TOKEN_PARAM } from '../shared/web.js'
@@ -165,11 +166,15 @@ export function runListen(): boolean {
   publishWebToken(token)
 
   let linkPort: number | null = null
+  configureExposure({ mount: '/', port: LINK_SERVER_PORT })
+  void refreshExposure()
+
   const handler = createWebHandler({
     mount: '/',
     staticRoot: webRoot,
     token,
-    appInfo: () => describeInstall(linkPort)
+    appInfo: () => describeInstall(linkPort),
+    tailnet: tailnetGate
   })
 
   const server = createServer((request, response) => {

--- a/src/main/deep-link.ts
+++ b/src/main/deep-link.ts
@@ -27,7 +27,7 @@ import { resolve } from 'node:path'
 import { getInstanceId } from '../core/instance.js'
 import { IPC_CHANNELS } from '../shared/api.js'
 import { DEEP_LINK_SCHEME, parseDeepLink } from '../shared/deep-link.js'
-import { HOME, hrefFor, type Route } from '../shared/routes.js'
+import { hrefFor, type Route } from '../shared/routes.js'
 
 /**
  * A route that arrived before there was a window to show it in.
@@ -130,11 +130,23 @@ function show(route: Route): void {
  *    "local" now;
  *  - our own id - the same thing, said explicitly; the segment is dropped so
  *    the renderer is handed the route it would have been handed anyway;
- *  - somebody else's id - a review on another machine. There is no way to reach
- *    another machine until M4, and the one thing that must not happen is
- *    opening *our* review 4 because the link said 4. The user lands on the home
- *    screen and the id is logged, which is the honest failure until there is a
- *    hosts table to look it up in.
+ *  - somebody else's id - a review on another machine, which since M6 is an
+ *    ordinary thing for a link to be. The route keeps its host segment and the
+ *    window opens `#/h/<id>/reviews/4`.
+ *
+ * That last case used to land on the home screen, with a log line saying
+ * reviews on other hosts arrived in M4. They did, and this function went on
+ * discarding them for three milestones - M4.3, M4.4 and M5.3 each deferred it,
+ * reasonably, because nothing before the tailnet produced a link that named
+ * another machine in the first place.
+ *
+ * Handing the route over *with* its host is what preserves the rule the old
+ * behaviour existed for. Ids are per host, so opening our review 4 because the
+ * link said 4 would show the wrong review with no sign of it; keeping the
+ * segment makes that impossible rather than merely avoided. A machine this
+ * install does not know is not checked for here - `requireInstance` already
+ * refuses by name when the reads go out, and its sentence names the id, which
+ * is the only thing a person can compare against their Hosts screen.
  */
 function localise(route: Route): Route {
   if (route.host === undefined) return route
@@ -145,11 +157,8 @@ function localise(route: Route): Route {
     return local
   }
 
-  console.log(
-    `[deep-link] ignoring a link for instance ${route.host}, which is not this install. ` +
-      `Reviews on other hosts arrive in M4.`
-  )
-  return HOME
+  // Another machine's review. Left host-scoped; the screens do the rest.
+  return route
 }
 
 /** Handle one URL from any of the three doors. Unrecognised URLs are ignored. */

--- a/src/main/events.ts
+++ b/src/main/events.ts
@@ -1,0 +1,55 @@
+/**
+ * The core's events, delivered to this app's windows.
+ *
+ * The Electron half of what `core/rpc/websocket.ts` does for a browser tab, and
+ * it is four lines of work for the same reason the window's `ShellConnection`
+ * is a constant `true`: the other end of this carrier is the main process of
+ * the same application, so there is no socket to lose, no reconnect to survive
+ * and nothing to queue. The bus is in this process; the window is in the next
+ * one over.
+ *
+ * A module rather than a line in `main/index.ts` because the subscription has a
+ * lifetime, and the one thing that could go wrong here is a leak: an event
+ * emitted after quit began, into a `webContents` that is being torn down, is an
+ * exception thrown from inside a database write. Hence the `isDestroyed` check
+ * and `stopForwardingEvents`.
+ *
+ * Broadcast to every window, not to a focused one. Two windows on one machine
+ * are two views of the same database, and a comment written in one is news in
+ * both - which is also the first thing M6.1 is verified against, because it
+ * needs no second machine.
+ */
+import { BrowserWindow } from 'electron'
+import { subscribeToEvents } from '../core/events.js'
+import { IPC_CHANNELS } from '../shared/api.js'
+
+let unsubscribe: (() => void) | null = null
+
+/**
+ * Start forwarding. Idempotent, so a second call cannot double every event.
+ *
+ * Called once at startup rather than per window: `BrowserWindow.getAllWindows`
+ * is read at delivery time, so a window opened later is included without
+ * anything having to notice it was created. That is the same choice
+ * `updater.ts` makes, and for the same reason - a per-window subscription would
+ * need a matching teardown on every path a window can close by, including a
+ * crash.
+ */
+export function startForwardingEvents(): void {
+  if (unsubscribe) return
+
+  unsubscribe = subscribeToEvents((event) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      // A window closing while a write is in flight is ordinary, and `send` on
+      // a destroyed one throws. Checked rather than caught, because the throw
+      // would surface as an `INTERNAL` from a method that actually succeeded.
+      if (!window.isDestroyed()) window.webContents.send(IPC_CHANNELS.rpcEvent, event)
+    }
+  })
+}
+
+/** Stop. Safe when it never started. */
+export function stopForwardingEvents(): void {
+  unsubscribe?.()
+  unsubscribe = null
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -40,6 +40,7 @@ import {
   setWindowFactory,
   takePendingRoute
 } from './deep-link.js'
+import { startForwardingEvents, stopForwardingEvents } from './events.js'
 import { registerIpcHandlers } from './ipc.js'
 import { startLinkServer, stopLinkServer } from './link-server.js'
 import { wasOpenedAtLogin } from './login-item.js'
@@ -248,6 +249,12 @@ if (process.argv.includes('--serve')) {
     registerAttachmentProtocol()
     registerIpcHandlers()
 
+    // Before the first window, so that a write which happens during startup -
+    // an agent already running against this data directory - is not announced
+    // into a silence. The forwarder reads the window list at delivery time, so
+    // there is nothing here that depends on a window existing yet.
+    startForwardingEvents()
+
     // Written before anything else needs it. An agent may be configured against
     // this path already and start the moment the user does, so the file should
     // be current before the window is even up.
@@ -316,6 +323,7 @@ if (process.argv.includes('--serve')) {
 
   app.on('before-quit', () => {
     quitting = true
+    stopForwardingEvents()
     disposeUpdater()
     destroyTray()
     stopLinkServer()

--- a/src/main/web-view.ts
+++ b/src/main/web-view.ts
@@ -29,6 +29,7 @@ import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { app } from 'electron'
 import { createWebHandler, type WebHandler } from '../core/web/handler.js'
+import { configureExposure, refreshExposure, tailnetGate } from '../core/web/exposure.js'
 import { clearWebToken, mintWebToken, publishWebToken } from '../core/web/token.js'
 import { LINK_SERVER_HOST, LINK_SERVER_PORT } from '../shared/link-port.js'
 import { TOKEN_PARAM, WEB_APP_MOUNT } from '../shared/web.js'
@@ -77,11 +78,22 @@ export function startWebHandler(): WebHandler | null {
     `http://${LINK_SERVER_HOST}:${LINK_SERVER_PORT}${WEB_APP_MOUNT}/` +
     `?${TOKEN_PARAM}=${token}`
 
+  // Which mount and which port, so `webRoot` in the exposure names a URL that
+  // actually lands in the app rather than on the link page one level up.
+  configureExposure({ mount: `${WEB_APP_MOUNT}/`, port: LINK_SERVER_PORT })
+  // Read once at startup rather than assumed off: `tailscale serve` is machine
+  // state and survives a restart, so an install that was exposed yesterday is
+  // exposed now and its gate has to know before the first request. Not awaited -
+  // nothing is reachable until this server is listening anyway, and the gate
+  // reads a snapshot that is simply "not exposed" until the answer lands.
+  void refreshExposure()
+
   handler = createWebHandler({
     mount: `${WEB_APP_MOUNT}/`,
     staticRoot,
     token,
-    appInfo: describeInstall
+    appInfo: describeInstall,
+    tailnet: tailnetGate
   })
 
   console.log(`[web] the web view is at ${entryUrl}`)

--- a/src/mcp/gui-link.ts
+++ b/src/mcp/gui-link.ts
@@ -34,10 +34,33 @@
  * on.
  */
 import type { CommentLocation } from '../core/services/comments.js'
+import { readLiveDaemonRuntime } from '../core/daemon-runtime.js'
 import { getInstanceId } from '../core/instance.js'
 import { loopbackFragmentFor } from '../shared/deep-link.js'
 import { linkServerOrigin } from '../shared/link-port.js'
-import type { ReviewRoute } from '../shared/routes.js'
+import { hrefFor, type ReviewRoute } from '../shared/routes.js'
+
+/**
+ * The other sentence, appended only when this install is actually listening.
+ *
+ * Conditional rather than always present, and that is the same decision
+ * `guiUrl` made in the opposite direction. A `guiUrl` is always there because
+ * loopback depends on nothing and a dead link costs one refused connection; a
+ * `webUrl` names a machine on a network, and one that is not being served is a
+ * URL that will never work for anybody, not just "not right now".
+ *
+ * The distinction it has to teach an agent is *which machine the person is
+ * at*, because that is the only thing that decides which link is useful and
+ * the MCP server has no way to know it. So the text says what each one is for
+ * rather than ranking them.
+ */
+export const WEB_URL_NOTE =
+  '\n\nWhen this machine is reachable on the user\'s tailnet, results also carry `webUrl`. ' +
+  'The two links are for two situations and neither replaces the other: `guiUrl` opens ' +
+  'GitWarren on the machine the user is sitting at, which is the right one when that is this ' +
+  'machine; `webUrl` opens the same review in a browser from any of their devices - a phone, a ' +
+  'laptop across the room - because it names this machine on their tailnet. Offer `webUrl` when ' +
+  'the user is not at this machine, and both when you do not know.'
 
 /**
  * The sentence appended to every tool that returns one of these.
@@ -59,17 +82,23 @@ export const GUI_URL_NOTE =
   'makes the same link work.'
 
 /** With the link attached. Kept as a type so the tool payloads stay honest. */
-export type WithGuiUrl<T> = T & { guiUrl: string }
+export type WithGuiUrl<T> = T & { guiUrl: string; webUrl?: string }
+
+/** The links for one place, however many of them there are. */
+export interface ReviewLinks {
+  guiUrl: string
+  webUrl?: string
+}
 
 export interface GuiLinker {
   /** The review's conversation, which is where a review as a whole lives. */
-  review(reviewId: number): string
+  review(reviewId: number): ReviewLinks
   /**
    * A thread, at its line of the diff where it has one. A line comment links
    * into the files tab so the user lands on the code being discussed rather
    * than on a list of discussions.
    */
-  comment(location: CommentLocation): string
+  comment(location: CommentLocation): ReviewLinks
 }
 
 /**
@@ -83,20 +112,52 @@ export interface GuiLinker {
  */
 export function guiLinker(): GuiLinker {
   const instanceId = getInstanceId()
+  // Read per linker, which is per tool call. The owner publishes it when the
+  // user flips the switch, and it disappears when the owner quits - which is
+  // correct rather than unfortunate: a `webUrl` for a machine that is not
+  // serving anything is a link that cannot work, and the whole rule is that it
+  // is added *when a host listens*. `guiUrl` is unaffected, because loopback
+  // depends on nothing.
+  const webRoot = readLiveDaemonRuntime()?.webRoot ?? null
 
   const link = (route: ReviewRoute): string =>
     // The route rides in the fragment, which the browser never sends. The
     // server is not told which review this is for and has no use for it.
     `${linkServerOrigin()}/#${loopbackFragmentFor(instanceId, route)}`
 
-  const conversation = (reviewId: number): string =>
-    link({ name: 'review', reviewId, tab: 'conversation' })
+  /**
+   * The same review, as a browser on the tailnet reaches it.
+   *
+   * A plain app route rather than the `h=` loopback fragment, and the
+   * difference is the whole of what those two notations were separated for in
+   * M2. A loopback URL's fragment is a *deep link waiting to be assembled* -
+   * the page at that address hands it to a local GitWarren, which then decides
+   * whose review it is. A tailnet URL is not waiting for anything: the server
+   * answering it is the machine that owns the review, so the fragment is an
+   * ordinary route into the app it is already serving, with no host segment
+   * because there is no other machine in the story.
+   */
+  const webLink = (route: ReviewRoute): string | undefined =>
+    webRoot === null ? undefined : `${webRoot}${hrefFor(route)}`
+
+  const both = (route: ReviewRoute): { guiUrl: string; webUrl?: string } => {
+    const web = webLink(route)
+    return { guiUrl: link(route), ...(web === undefined ? {} : { webUrl: web }) }
+  }
+
+  const conversation = (reviewId: number): ReviewRoute => ({
+    name: 'review',
+    reviewId,
+    tab: 'conversation'
+  })
 
   return {
-    review: conversation,
+    review: (reviewId) => both(conversation(reviewId)),
     comment: ({ reviewId, filePath, side, line }) =>
-      filePath === null || side === null || line === null
-        ? conversation(reviewId)
-        : link({ name: 'review', reviewId, tab: 'files', focus: { filePath, side, line } })
+      both(
+        filePath === null || side === null || line === null
+          ? conversation(reviewId)
+          : { name: 'review', reviewId, tab: 'files', focus: { filePath, side, line } }
+      )
   }
 }

--- a/src/mcp/poke.ts
+++ b/src/mcp/poke.ts
@@ -1,0 +1,110 @@
+/**
+ * Telling the owner of this data directory that an agent just wrote something.
+ *
+ * The MCP server opens SQLite directly and never routes reads through a running
+ * GUI - `core/daemon-runtime.ts` argues that at length, and the property it buys
+ * is that quitting GitWarren does not stop an agent working. The cost is that
+ * `emitEvent` in this process reaches nobody: the bus is per process, and the
+ * window that wants to know about this comment is in another one.
+ *
+ * So the poke goes out over the channel that is already there. The owner
+ * publishes its pid and port in `daemon-runtime.json`, `core/web/token.ts`
+ * writes the session token beside it with mode 0600, and this process runs as
+ * the same user. One `POST`, one event name, no payload.
+ *
+ * ## Everything about this is best-effort, deliberately
+ *
+ * Nothing here may fail a tool call. The comment is already in the database
+ * when this runs; a window that does not hear about it is fifteen seconds
+ * behind, and a window that is not running is not behind at all. So every path
+ * - no owner, no token, a refused connection, a 401 from an owner that restarted
+ * and minted a new token - is the same answer: nothing happened, carry on. That
+ * is also why it is not awaited by the caller.
+ *
+ * It is read fresh every time rather than resolved once at startup, and that is
+ * not caution: an MCP server routinely outlives several GUI launches, so a port
+ * or a token cached at startup would be wrong within the hour. `daemon-runtime.ts`
+ * makes the same point about its own file.
+ *
+ * ## A host with no owner has no push, and that is the design rather than a gap
+ *
+ * A daemon spawned over `ssh` or `wsl.exe` binds nothing and writes no runtime
+ * file - by design since M2, because a data directory has one owner and a stdio
+ * daemon is not competing to be it. So an agent on a machine reached that way
+ * finds no owner here, pokes nobody, and the GUI on the other end notices on its
+ * next poll. The remedy is not a second mechanism: it is turning on "Reachable
+ * on your tailnet", which gives that machine an owner and a socket to push down.
+ */
+import { readFileSync } from 'node:fs'
+import { request as httpRequest } from 'node:http'
+import { readLiveDaemonRuntime } from '../core/daemon-runtime.js'
+import { getWebTokenPath } from '../core/web/token.js'
+import { LINK_SERVER_HOST } from '../shared/link-port.js'
+import type { RpcEventName } from '../shared/rpc.js'
+import { TOKEN_HEADER, WEB_PATHS } from '../shared/web.js'
+
+/**
+ * How long to give the owner before giving up.
+ *
+ * It is a request to a process on this machine that is already listening, so
+ * the realistic range is single-digit milliseconds. The timeout exists for the
+ * case the number cannot describe: a pid that is alive and a port that is held
+ * by something that accepts connections and never answers. Short, because
+ * nothing is waiting for the result and a hung socket per comment would
+ * accumulate.
+ */
+const POKE_TIMEOUT_MS = 1_000
+
+/**
+ * Tell the owner, if there is one. Never throws, never rejects, never waited on.
+ *
+ * Called after the write has already succeeded, which is the same placement the
+ * dispatcher uses for its own emit and for the same reason: an announcement
+ * that something changed must not be able to report a failure for something
+ * that worked.
+ */
+export function pokeOwner(event: RpcEventName): void {
+  let owner: ReturnType<typeof readLiveDaemonRuntime>
+  let token: string
+  try {
+    owner = readLiveDaemonRuntime()
+    // No owner is the common case rather than an error: the GUI is not running,
+    // or this daemon was spawned over a pipe and owns nothing.
+    if (!owner || owner.linkPort === null) return
+    token = readFileSync(getWebTokenPath(), 'utf8').trim()
+  } catch {
+    // An unreadable token file means the owner is mid-start or mid-quit. There
+    // is nothing to report and nobody to report it to.
+    return
+  }
+
+  const body = JSON.stringify({ event })
+  const outgoing = httpRequest({
+    host: LINK_SERVER_HOST,
+    port: owner.linkPort,
+    path: WEB_PATHS.notify,
+    method: 'POST',
+    timeout: POKE_TIMEOUT_MS,
+    headers: {
+      // Named explicitly because the gate requires it and a Node client sends
+      // none by default. It is our own loopback origin, which is what
+      // `origin.ts` demands of anything that is not a navigation - and a value
+      // a web page could never forge onto its own request.
+      Origin: `http://${LINK_SERVER_HOST}:${owner.linkPort}`,
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(body),
+      [TOKEN_HEADER]: token
+    }
+  })
+
+  // Three ways to get nothing, all of them fine. A 401 is the interesting one:
+  // it means the owner restarted and minted a new token since this file was
+  // read, which is `token.ts` behaving exactly as designed.
+  outgoing.on('error', () => {})
+  outgoing.on('timeout', () => outgoing.destroy())
+  // The response is consumed rather than ignored, so the socket is released
+  // instead of being held by an unread body until the agent exits.
+  outgoing.on('response', (response) => response.resume())
+
+  outgoing.end(body)
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -310,7 +310,7 @@ server.registerTool(
     run(async () => {
       const links = guiLinker()
       const reviews = await reviewsService.list(input)
-      return reviews.map((review) => ({ ...review, guiUrl: links.review(review.id) }))
+      return reviews.map((review) => ({ ...review, ...links.review(review.id) }))
     })
 )
 
@@ -435,7 +435,7 @@ server.registerTool(
     run(async () => {
       const links = guiLinker()
       const threads = await commentsService.listAnchored(input)
-      return threads.map((thread) => ({ ...thread, guiUrl: links.comment(thread) }))
+      return threads.map((thread) => ({ ...thread, ...links.comment(thread) }))
     })
 )
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -18,7 +18,16 @@
  * those changes, and that is what the comment tools carry.
  *
  * No authentication: this is a local, single-user app, the transport is a pipe
- * owned by the agent the user launched, and there is no network surface.
+ * owned by the agent the user launched, and nothing listens.
+ *
+ * Since M6 it does *dial* one thing, and the distinction is worth keeping: after
+ * a write, it opens a loopback connection to whichever process owns this data
+ * directory and says that something changed, so a window does not wait fifteen
+ * seconds to find out. It sends a name and no data, it is never awaited, and
+ * every way of failing - no owner, no token, nothing listening - is the same
+ * answer, which is that nothing happened. Rule 6 is untouched: the agent still
+ * never crosses a network, and quitting GitWarren still leaves it working. See
+ * `poke.ts`.
  *
  * There is, however, *attribution*, which is a different thing. Every comment
  * written through this server is marked as machine-written and named after the
@@ -47,7 +56,9 @@ import { repositoriesService } from '../core/services/repositories.js'
 import { reviewsService } from '../core/services/reviews.js'
 import { authorDisplayName, type CommentAuthor } from '../shared/actors.js'
 import { AppError } from '../shared/errors.js'
+import { RPC_EVENTS, type RpcEventName } from '../shared/rpc.js'
 import { GUI_URL_NOTE, guiLinker, type WithGuiUrl } from './gui-link.js'
+import { pokeOwner } from './poke.js'
 import { agentAuthor, getSessionId, getSessionLabel, setSessionLabel } from './identity.js'
 import {
   addRepositoryInputSchema,
@@ -121,6 +132,28 @@ async function run<T>(operation: () => Promise<T>): Promise<CallToolResult> {
   } catch (error) {
     return fail(error)
   }
+}
+
+/**
+ * A tool that changes something, and tells the owner it did.
+ *
+ * The poke is here rather than inside the services for the same reason
+ * `HUMAN_AUTHOR` is in the dispatcher rather than in `commentsService`: the
+ * *boundary* is what knows who is acting, and this file is the agent boundary.
+ * A service that announced its own writes would announce them once per process
+ * and be unable to say which process that was.
+ *
+ * After the operation, never before - an announcement that something changed
+ * must not outrun the thing changing. Not awaited, and `pokeOwner` cannot
+ * reject: the write is already committed, so nothing about telling a window
+ * may turn a successful tool call into a failed one. See `poke.ts`.
+ */
+function runWrite<T>(event: RpcEventName, operation: () => Promise<T>): Promise<CallToolResult> {
+  return run(async () => {
+    const result = await operation()
+    pokeOwner(event)
+    return result
+  })
 }
 
 const server = new McpServer({ name: 'gitwarren', version: VERSION })
@@ -221,7 +254,7 @@ server.registerTool(
     inputSchema: addRepositoryInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false }
   },
-  (input) => run(() => repositoriesService.add(input))
+  (input) => runWrite(RPC_EVENTS.reviewsChanged, () => repositoriesService.add(input))
 )
 
 server.registerTool(
@@ -235,7 +268,7 @@ server.registerTool(
     inputSchema: updateRepositoryInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true }
   },
-  (input) => run(() => repositoriesService.update(input))
+  (input) => runWrite(RPC_EVENTS.reviewsChanged, () => repositoriesService.update(input))
 )
 
 server.registerTool(
@@ -248,7 +281,7 @@ server.registerTool(
     inputSchema: removeRepositoryInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true }
   },
-  (input) => run(() => repositoriesService.remove(input))
+  (input) => runWrite(RPC_EVENTS.reviewsChanged, () => repositoriesService.remove(input))
 )
 
 server.registerTool(
@@ -304,7 +337,7 @@ server.registerTool(
     inputSchema: createReviewInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false }
   },
-  (input) => run(() => linkedReview(reviewsService.create(input)))
+  (input) => runWrite(RPC_EVENTS.reviewsChanged, () => linkedReview(reviewsService.create(input)))
 )
 
 server.registerTool(
@@ -319,7 +352,7 @@ server.registerTool(
     inputSchema: updateReviewInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true }
   },
-  (input) => run(() => linkedReview(reviewsService.update(input)))
+  (input) => runWrite(RPC_EVENTS.reviewsChanged, () => linkedReview(reviewsService.update(input)))
 )
 
 server.registerTool(
@@ -333,7 +366,7 @@ server.registerTool(
     inputSchema: removeReviewInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true }
   },
-  (input) => run(() => reviewsService.remove(input))
+  (input) => runWrite(RPC_EVENTS.reviewsChanged, () => reviewsService.remove(input))
 )
 
 /* -------------------------------------------------------------------------- */
@@ -416,7 +449,10 @@ server.registerTool(
     inputSchema: withLabel(createThreadInputSchema.shape),
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false }
   },
-  (input) => run(() => linkedThread(commentsService.createThread(input, adoptLabel(input))))
+  (input) =>
+    runWrite(RPC_EVENTS.commentsChanged, () =>
+      linkedThread(commentsService.createThread(input, adoptLabel(input)))
+    )
 )
 
 server.registerTool(
@@ -432,7 +468,8 @@ server.registerTool(
     inputSchema: withLabel(replyToThreadInputSchema.shape),
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false }
   },
-  (input) => run(() => linkedComment(commentsService.reply(input, adoptLabel(input))))
+  (input) =>
+    runWrite(RPC_EVENTS.commentsChanged, () => linkedComment(commentsService.reply(input, adoptLabel(input))))
 )
 
 server.registerTool(
@@ -447,7 +484,10 @@ server.registerTool(
     inputSchema: setThreadResolvedInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true }
   },
-  (input) => run(() => linkedThread(commentsService.setResolved(input, currentAuthor())))
+  (input) =>
+    runWrite(RPC_EVENTS.commentsChanged, () =>
+      linkedThread(commentsService.setResolved(input, currentAuthor()))
+    )
 )
 
 server.registerTool(
@@ -461,7 +501,10 @@ server.registerTool(
     inputSchema: updateCommentInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true }
   },
-  (input) => run(() => linkedComment(commentsService.update(input, currentAuthor())))
+  (input) =>
+    runWrite(RPC_EVENTS.commentsChanged, () =>
+      linkedComment(commentsService.update(input, currentAuthor()))
+    )
 )
 
 server.registerTool(
@@ -474,7 +517,7 @@ server.registerTool(
     inputSchema: removeCommentInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true }
   },
-  (input) => run(() => commentsService.remove(input, currentAuthor()))
+  (input) => runWrite(RPC_EVENTS.commentsChanged, () => commentsService.remove(input, currentAuthor()))
 )
 
 async function main(): Promise<void> {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -43,6 +43,15 @@
  * before showing it, and the descriptions say what a refused connection means
  * instead. See `gui-link.ts`.
  *
+ * Since M6 a payload may also carry a `webUrl`, and the two are not a fallback
+ * pair. `guiUrl` is loopback and opens GitWarren on the machine the person is
+ * sitting at; `webUrl` names *this* machine on their tailnet and opens the same
+ * review in a browser on any of their devices. Which one is useful depends on
+ * where the person is, and this server has no way to know that - so both are
+ * offered and the tool text explains what each is for rather than ranking them.
+ * `webUrl` is present only while this install is actually being served, which
+ * is why it is conditional where `guiUrl` never is.
+ *
  * One hard rule: stdout belongs to the protocol. Diagnostics go to stderr.
  */
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
@@ -57,7 +66,7 @@ import { reviewsService } from '../core/services/reviews.js'
 import { authorDisplayName, type CommentAuthor } from '../shared/actors.js'
 import { AppError } from '../shared/errors.js'
 import { RPC_EVENTS, type RpcEventName } from '../shared/rpc.js'
-import { GUI_URL_NOTE, guiLinker, type WithGuiUrl } from './gui-link.js'
+import { GUI_URL_NOTE, WEB_URL_NOTE, guiLinker, type WithGuiUrl } from './gui-link.js'
 import { pokeOwner } from './poke.js'
 import { agentAuthor, getSessionId, getSessionLabel, setSessionLabel } from './identity.js'
 import {
@@ -193,14 +202,14 @@ function adoptLabel(input: { agentLabel?: string }): CommentAuthor {
 
 async function linkedReview<T extends { id: number }>(result: Promise<T>): Promise<WithGuiUrl<T>> {
   const review = await result
-  return { ...review, guiUrl: guiLinker().review(review.id) }
+  return { ...review, ...guiLinker().review(review.id) }
 }
 
 async function linkedThread<T extends CommentLocation>(
   result: Promise<T>
 ): Promise<WithGuiUrl<T>> {
   const thread = await result
-  return { ...thread, guiUrl: guiLinker().comment(thread) }
+  return { ...thread, ...guiLinker().comment(thread) }
 }
 
 /**
@@ -213,7 +222,7 @@ async function linkedComment<T extends { id: number }>(
   const comment = await result
   return {
     ...comment,
-    guiUrl: guiLinker().comment(commentsService.locate({ commentId: comment.id }))
+    ...guiLinker().comment(commentsService.locate({ commentId: comment.id }))
   }
 }
 
@@ -293,7 +302,7 @@ server.registerTool(
       '("open" or "closed"); omit both to list every review across all tracked repositories. ' +
       'A review records the two refs being compared, not the commits they resolved to - ' +
       'read the repository with git to see the actual changes.' +
-      GUI_URL_NOTE,
+      GUI_URL_NOTE + WEB_URL_NOTE,
     inputSchema: listReviewsInputSchema.shape,
     annotations: { readOnlyHint: true, openWorldHint: false }
   },
@@ -312,7 +321,7 @@ server.registerTool(
     description:
       'Fetch one review by id, with the repository it belongs to attached (including the ' +
       'repository path, so the changes can be inspected with git directly).' +
-      GUI_URL_NOTE,
+      GUI_URL_NOTE + WEB_URL_NOTE,
     inputSchema: getReviewInputSchema.shape,
     annotations: { readOnlyHint: true, openWorldHint: false }
   },
@@ -333,7 +342,7 @@ server.registerTool(
       'the same ref as both endpoints is allowed and does exactly that: the review then holds ' +
       'only the uncommitted work on that ref, and its title defaults to "Uncommitted work on ' +
       '<ref>".' +
-      GUI_URL_NOTE,
+      GUI_URL_NOTE + WEB_URL_NOTE,
     inputSchema: createReviewInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false }
   },
@@ -348,7 +357,7 @@ server.registerTool(
       'Change a review\'s title, description or endpoints, or set its `status` to "closed" or ' +
       '"open" again. Provide at least one field. New refs are validated exactly as they are on ' +
       'creation.' +
-      GUI_URL_NOTE,
+      GUI_URL_NOTE + WEB_URL_NOTE,
     inputSchema: updateReviewInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true }
   },
@@ -418,7 +427,7 @@ server.registerTool(
       'on disk: read it with your own image tools. `alt` is the description whoever attached it ' +
       'wrote, and is worth reading first - it is often enough on its own, and it is all you get ' +
       'if you cannot see images.' +
-      GUI_URL_NOTE,
+      GUI_URL_NOTE + WEB_URL_NOTE,
     inputSchema: listCommentsInputSchema.shape,
     annotations: { readOnlyHint: true, openWorldHint: false }
   },
@@ -445,7 +454,7 @@ server.registerTool(
       'returned thread says whether it could be anchored to a visible line. ' +
       'Comments are attributed automatically from the MCP handshake - see `agent_identity`.\n\n' +
       ATTACHMENT_GUIDANCE +
-      GUI_URL_NOTE,
+      GUI_URL_NOTE + WEB_URL_NOTE,
     inputSchema: withLabel(createThreadInputSchema.shape),
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false }
   },
@@ -464,7 +473,7 @@ server.registerTool(
       'responding to something someone already raised, so the discussion stays in one place. ' +
       'Thread ids come from `list_review_comments`.\n\n' +
       ATTACHMENT_GUIDANCE +
-      GUI_URL_NOTE,
+      GUI_URL_NOTE + WEB_URL_NOTE,
     inputSchema: withLabel(replyToThreadInputSchema.shape),
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false }
   },
@@ -480,7 +489,7 @@ server.registerTool(
       'Mark a discussion settled, or reopen one. Set `resolved` to true once the point has been ' +
       'addressed, false to bring it back. Resolving records who did it; it never deletes the ' +
       'messages, which stay readable.' +
-      GUI_URL_NOTE,
+      GUI_URL_NOTE + WEB_URL_NOTE,
     inputSchema: setThreadResolvedInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true }
   },
@@ -497,7 +506,7 @@ server.registerTool(
     description:
       'Replace the text of one message. An agent can only edit messages written by its own tool - ' +
       'correcting yourself is expected, rewriting someone else\'s review is not.' +
-      GUI_URL_NOTE,
+      GUI_URL_NOTE + WEB_URL_NOTE,
     inputSchema: updateCommentInputSchema.shape,
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true }
   },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -51,6 +51,7 @@ import {
   isReadMethod,
   resultOf,
   type BridgeCarrier,
+  type RpcEvent,
   type RpcMethod,
   type RpcOutcome,
   type RpcParams,
@@ -103,6 +104,25 @@ const carrier: BridgeCarrier = {
     const pending = send().finally(() => inFlight.delete(key))
     inFlight.set(key, pending)
     return pending
+  },
+
+  /**
+   * Events from this window's own main process.
+   *
+   * `ipcRenderer.on` hands the listener an `IpcRendererEvent` first, which must
+   * not reach the renderer - it carries a `sender` and a `ports` array, and
+   * passing structured clone's idea of those across `contextBridge` is at best
+   * noise. So the payload is unwrapped here, exactly as the two pushes in
+   * `shell` below do it.
+   *
+   * The event object itself is a plain `{event, data}` built by `core/events.ts`
+   * and crosses the bridge intact, which is the property `BridgeCarrier` exists
+   * to respect for the request half too.
+   */
+  onEvent(listener: (event: RpcEvent) => void): () => void {
+    const handler = (_: unknown, event: RpcEvent): void => listener(event)
+    ipcRenderer.on(IPC_CHANNELS.rpcEvent, handler)
+    return () => ipcRenderer.off(IPC_CHANNELS.rpcEvent, handler)
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -32,6 +32,7 @@ import { HostsCard } from './features/hosts/hosts-card'
 import { HostsPage } from './features/hosts/hosts-page'
 import { useRefetchOnReconnect } from './features/hosts/use-reconnect'
 import { SettingsPanel } from './features/settings/settings-panel'
+import { TailnetPanel } from './features/settings/tailnet-panel'
 import { RepositoryDetail } from './features/repositories/repository-detail'
 import { RepositoryList } from './features/repositories/repository-list'
 import { ReviewDetail } from './features/reviews/review-detail'
@@ -156,6 +157,7 @@ function HomeScreen() {
         <RepositoryList />
         <HostsCard />
         <AgentAccessCard />
+        <TailnetPanel />
         <SettingsPanel />
       </div>
     </>

--- a/src/renderer/src/features/hosts/discovered-hosts.tsx
+++ b/src/renderer/src/features/hosts/discovered-hosts.tsx
@@ -1,0 +1,133 @@
+/**
+ * Machines on the tailnet that are not in the list yet.
+ *
+ * The visible half of "the PC appears on the Mac with no configuration", and
+ * the whole of what this component is careful about is that *appears* must not
+ * become *is added*. `isLocalOnly` refuses the whole `hosts.` prefix so a hub
+ * cannot be talked into becoming a mesh; a discovery that inserted rows would
+ * walk around that from the other side. So each peer is a proposal with a
+ * button, and pressing it is a person deciding.
+ *
+ * ## Why it only asks when this screen is open
+ *
+ * `useSWR` with no `refreshInterval` and no revalidation on focus, which is
+ * unusual in this app and deliberate here: `hosts.discover` is the one read
+ * that costs a connection attempt per peer on the tailnet. A key that anything
+ * else subscribed to would turn opening any screen into a scan, and a poll
+ * would make this application a thing that quietly connects to every machine
+ * you own. M4.3 refused to do that to render a home screen.
+ *
+ * So it runs when the Hosts screen mounts, and again when somebody presses
+ * "Look again" - which is the same argument as `hosts.probe` ignoring the
+ * backoff: a person pressing a button knows something a timer does not.
+ *
+ * ## A machine you already have is shown, not hidden
+ *
+ * `pc-wsl` is already an `ssh` row on this Mac from M4, and it is the same box.
+ * Dropping it from the list would be the same mistake M5.2 refused for
+ * distributions: a listing that silently omits rows is one you cannot trust
+ * when the thing you wanted is not in it. So it is shown, greyed, naming the
+ * row it is already in the list as - which is M4.1's collision report said one
+ * step earlier, before an insert rather than after a connection.
+ */
+import { useState } from 'react'
+import useSWR from 'swr'
+import { Radar, Plus, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Breakable } from '@/components/breakable'
+import { api, CACHE_KEYS } from '@/lib/api'
+import { errorMessage } from '@/lib/errors'
+import { useHostMutations } from './use-hosts'
+import type { DiscoveredPeer } from '@shared/schemas'
+
+export function DiscoveredHosts() {
+  const {
+    data: peers,
+    isLoading,
+    isValidating,
+    mutate
+  } = useSWR<DiscoveredPeer[], unknown>(CACHE_KEYS.discovered, () => api.hosts.discover(), {
+    // See the header. This read connects to machines, so it happens when a
+    // person is looking at the screen that shows it and at no other time.
+    revalidateOnFocus: false,
+    revalidateIfStale: false,
+    refreshInterval: 0
+  })
+  const { addHost } = useHostMutations()
+  const [adding, setAdding] = useState<string | null>(null)
+  const [failure, setFailure] = useState<string | null>(null)
+
+  // Nothing at all until there is something to say. A machine with no Tailscale
+  // gets an empty answer - the same shape `hosts.distros` uses so that no code
+  // anywhere asks what platform it is on - and an empty section with a heading
+  // would be a permanent question the user cannot answer.
+  if (isLoading || !peers || peers.length === 0) return null
+
+  async function add(peer: DiscoveredPeer): Promise<void> {
+    setAdding(peer.dnsName)
+    setFailure(null)
+    try {
+      // The origin the probe actually answered at, not the name it was asked
+      // under. Nothing is guessed about the scheme or the port, which is M6.0's
+      // finding applied: whether a tailnet can do HTTPS is a property of the
+      // tailnet, so it is a fact to carry rather than a default to apply.
+      await addHost({ target: peer.origin, kind: 'websocket', label: peer.dnsName.split('.')[0] })
+      await mutate()
+    } catch (error) {
+      setFailure(errorMessage(error))
+    } finally {
+      setAdding(null)
+    }
+  }
+
+  return (
+    <Card className="flex flex-col gap-3 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Radar className="size-4 shrink-0 text-muted-foreground" />
+          <h2 className="text-sm font-medium">On your tailnet</h2>
+        </div>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => void mutate()}
+          disabled={isValidating}
+          aria-label="Look again"
+        >
+          <RefreshCw className={isValidating ? 'animate-spin' : undefined} />
+        </Button>
+      </div>
+
+      <ul className="flex flex-col gap-2">
+        {peers.map((peer) => (
+          <li key={peer.instanceId} className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span className="min-w-40 flex-1 text-sm">
+              <span className="font-mono text-xs">
+                <Breakable text={peer.dnsName} />
+              </span>
+              {peer.version ? (
+                <span className="ml-2 text-xs text-muted-foreground">{peer.version}</span>
+              ) : null}
+            </span>
+            {peer.alreadyAdded === null ? (
+              <Button size="sm" onClick={() => void add(peer)} disabled={adding !== null}>
+                <Plus />
+                Add
+              </Button>
+            ) : (
+              // Named rather than just disabled: "you have this already" is not
+              // useful without "as what", and one machine reached two ways is
+              // exactly the case a person is confused by.
+              <span className="text-xs text-muted-foreground">
+                Already added as {peer.alreadyAdded}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {failure ? <p className="text-xs text-destructive">{failure}</p> : null}
+    </Card>
+  )
+}

--- a/src/renderer/src/features/hosts/host-form-dialog.tsx
+++ b/src/renderer/src/features/hosts/host-form-dialog.tsx
@@ -5,7 +5,7 @@
  * the same schemas the service re-parses on the other side - so nothing can be
  * accepted here that the service would reject.
  *
- * ## Two carriers, and only one of them has anything to type
+ * ## Three carriers, and each has a different relationship with typing
  *
  * M5 gave this form a choice, and the two halves of it are deliberately not
  * symmetrical. An `ssh` target is free text, because every `~/.ssh/config` alias
@@ -16,12 +16,21 @@
  * machine, caught only later by the instance id. Offering the machine's own
  * spelling removes the question.
  *
+ * M6 adds a third, and it is the one a person should usually not have to reach
+ * for at all: a machine that is *listening* on the tailnet is found by
+ * discovery and proposed on the Hosts screen with an Add button, so the form is
+ * the fallback for a machine discovery could not see - one that is asleep right
+ * now, or reachable by an address rather than by a MagicDNS name. Its field is
+ * free text like the ssh one, for the same reason: what somebody already has in
+ * their head is a machine name, and no validator here knows which names resolve.
+ *
  * The choice appears only when there is something to choose. `hosts.distros`
- * answers empty on a Mac, on Linux, and on a Windows box with no WSL, and an
- * empty answer means this is the SSH form with no tabs on it - which is what it
- * was before M5, for everyone it was already right for. Nothing here asks what
- * platform it is on: the question is about the machine the *core* runs on, and
- * asking it is the only way a browser tab gets the right answer.
+ * answers empty on a Mac, on Linux, and on a Windows box with no WSL, and
+ * `hosts.tailnet` answers `available: false` on a machine with no Tailscale -
+ * so a machine with neither gets the SSH form with no tabs on it, which is what
+ * it was before M5 for everyone it was already right for. Nothing here asks what
+ * platform it is on: both questions are about the machine the *core* runs on,
+ * and asking them is the only way a browser tab gets the right answer.
  *
  * ## There is no "test connection" button
  *
@@ -32,6 +41,7 @@
  * it.
  */
 import { useState, type FormEvent } from 'react'
+import useSWR from 'swr'
 import { Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -49,7 +59,8 @@ import { cn } from '@/lib/utils'
 import { useHostMutations, useWslDistros } from './use-hosts'
 import { addHostInputSchema, updateHostInputSchema } from '@shared/schemas'
 import { parseWithSchema } from '@shared/validation'
-import type { Host, WslDistro } from '@shared/schemas'
+import { api, CACHE_KEYS } from '@/lib/api'
+import type { Host, HostKind, WslDistro } from '@shared/schemas'
 
 interface HostFormDialogProps {
   open: boolean
@@ -78,8 +89,15 @@ function HostForm({ host, onDone }: { host: Host | undefined; onDone: () => void
   // Only asked while adding. Editing cannot change a carrier, so the list would
   // be a request nobody reads.
   const { distros, isLoading: loadingDistros } = useWslDistros(!isEditing)
+  // Only to decide whether to offer the choice. Whether *this* machine is on a
+  // tailnet is a good proxy for whether its owner has others on one, and it is
+  // the same read the settings switch makes - so the answer is usually already
+  // in the cache by the time this dialog opens.
+  const { data: tailnet } = useSWR(isEditing ? null : CACHE_KEYS.tailnet, () =>
+    api.hosts.tailnet()
+  )
 
-  const [kind, setKind] = useState<'ssh' | 'wsl'>(host?.kind ?? 'ssh')
+  const [kind, setKind] = useState<HostKind>(host?.kind ?? 'ssh')
   const [target, setTarget] = useState(host?.target ?? '')
   const [label, setLabel] = useState(host?.label ?? '')
   const [editorTarget, setEditorTarget] = useState(host?.editorTarget ?? '')
@@ -87,8 +105,10 @@ function HostForm({ host, onDone }: { host: Host | undefined; onDone: () => void
   const [error, setError] = useState<unknown>(null)
 
   const canAddWsl = !isEditing && distros !== undefined && distros.length > 0
+  const canAddTailnet = !isEditing && tailnet?.available === true
+  const showCarrierChoice = canAddWsl || canAddTailnet
 
-  function chooseKind(next: 'ssh' | 'wsl'): void {
+  function chooseKind(next: HostKind): void {
     if (next === kind) return
     setKind(next)
     // The two targets are different kinds of string and share no spelling, so
@@ -141,6 +161,7 @@ function HostForm({ host, onDone }: { host: Host | undefined; onDone: () => void
   const generalError = error && !targetError && !labelError ? errorMessage(error) : null
 
   const isWsl = kind === 'wsl'
+  const isTailnet = kind === 'websocket'
   // A WSL host is identified by its distribution, so the target is not something
   // an edit may change - the service refuses it, and a field that could produce
   // only an error is not a field worth drawing.
@@ -161,27 +182,36 @@ function HostForm({ host, onDone }: { host: Host | undefined; onDone: () => void
             : isWsl
               ? 'A Linux distribution running on this PC. GitWarren talks to it through ' +
                 'wsl.exe — nothing to configure, and nothing listening on a port.'
-              : 'Anything your own ssh can reach: a config alias, a tailnet name, user@address. ' +
-                'GitWarren never asks for a password — your SSH agent and config do the ' +
-                'authenticating.'}
+              : isTailnet
+                ? 'A machine on your tailnet with "Reachable on your tailnet" turned on in its ' +
+                  'own GitWarren. Nothing is installed onto it from here — it is already ' +
+                  'running, and Tailscale is what says you are its owner.'
+                : 'Anything your own ssh can reach: a config alias, a tailnet name, ' +
+                  'user@address. GitWarren never asks for a password — your SSH agent and ' +
+                  'config do the authenticating.'}
         </DialogDescription>
       </DialogHeader>
 
       <div className="flex flex-col gap-4">
-        {canAddWsl && (
+        {showCarrierChoice && (
           <Field>
             <FieldLabel>Connect by</FieldLabel>
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <CarrierChoice
                 selected={kind === 'ssh'}
                 label="SSH"
                 onSelect={() => chooseKind('ssh')}
               />
-              <CarrierChoice
-                selected={isWsl}
-                label="WSL"
-                onSelect={() => chooseKind('wsl')}
-              />
+              {canAddTailnet && (
+                <CarrierChoice
+                  selected={isTailnet}
+                  label="Tailnet"
+                  onSelect={() => chooseKind('websocket')}
+                />
+              )}
+              {canAddWsl && (
+                <CarrierChoice selected={isWsl} label="WSL" onSelect={() => chooseKind('wsl')} />
+              )}
             </div>
           </Field>
         )}
@@ -205,12 +235,12 @@ function HostForm({ host, onDone }: { host: Host | undefined; onDone: () => void
             </Field>
           ) : (
             <Field>
-              <FieldLabel htmlFor="host-target">SSH host</FieldLabel>
+              <FieldLabel htmlFor="host-target">{isTailnet ? 'Machine' : 'SSH host'}</FieldLabel>
               <Input
                 id="host-target"
                 value={target}
                 onChange={(event) => setTarget(event.target.value)}
-                placeholder="user@machine"
+                placeholder={isTailnet ? 'pc-wsl' : 'user@machine'}
                 className="font-mono text-xs"
                 data-invalid={targetError ? '' : undefined}
                 autoComplete="off"
@@ -219,7 +249,14 @@ function HostForm({ host, onDone }: { host: Host | undefined; onDone: () => void
               <FieldError>{targetError}</FieldError>
               {!targetError && (
                 <FieldDescription>
-                  Include the user name: a bare tailnet name asks for your local one.
+                  {isTailnet
+                    ? // No user name, and that is the whole difference from the
+                      // field above. Spike S1 found that a bare MagicDNS name over
+                      // ssh asks for the *client's* Unix user; there is no such
+                      // negotiation here, because the machine authorises the
+                      // person rather than a Unix account.
+                      'Its name on your tailnet. No user name — Tailscale already knows who you are.'
+                    : 'Include the user name: a bare tailnet name asks for your local one.'}
                 </FieldDescription>
               )}
             </Field>

--- a/src/renderer/src/features/hosts/hosts-page.tsx
+++ b/src/renderer/src/features/hosts/hosts-page.tsx
@@ -38,6 +38,7 @@ import { api, CACHE_KEYS } from '@/lib/api'
 import { errorMessage } from '@/lib/errors'
 import { navigate } from '@/lib/router'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
+import { DiscoveredHosts } from './discovered-hosts'
 import { HostCard } from './host-card'
 import { HostFormDialog } from './host-form-dialog'
 import { InstallResultDialog, type InstallOutcome } from './install-result-dialog'
@@ -164,6 +165,12 @@ export function HostsPage() {
           </div>
         </div>
       </div>
+
+      {/* Above the list rather than below it: a machine you have not added yet
+          is the thing you came here to do something about, and a proposal
+          under twelve rows is a proposal nobody sees. It draws nothing at all
+          when there is nothing to propose. */}
+      <DiscoveredHosts />
 
       {isLoading && <LoadingState />}
 

--- a/src/renderer/src/features/settings/tailnet-panel.tsx
+++ b/src/renderer/src/features/settings/tailnet-panel.tsx
@@ -1,0 +1,106 @@
+/**
+ * The switch that puts this machine on its owner's tailnet.
+ *
+ * A panel of its own rather than a row on `settings-panel.tsx`, and the reason
+ * is the same one that made that file a panel: the two answer different
+ * questions. "When is GitWarren running" is about this computer's login items
+ * and is absent in a browser tab, which has no OS to ask. "Is this machine
+ * reachable by my other machines" is about the *core*, and is exactly as real
+ * in a tab as in the window - more so, since the person running `gitwarren
+ * serve` on a headless box is the one who most needs it.
+ *
+ * ## It says what the machine says, not what was asked for
+ *
+ * `tailscale serve` is machine state. It survives a GitWarren restart, and the
+ * user can turn it off from a terminal without telling anybody - so the switch
+ * shows what `core/tailnet.ts` read back, and a toggle is followed by another
+ * read rather than by an optimistic value that sticks. The same instinct as the
+ * login-item switch next door, for the same reason: a control that remembers
+ * what it was told will eventually disagree with the machine, and the user has
+ * no way to know which one is lying.
+ *
+ * That also covers the case M6.0 found. A tailnet without HTTPS certificates
+ * leaves `tailscale serve --https` hanging rather than refusing, so asking for
+ * exposure and *getting* it are genuinely different events, and the URL under
+ * the switch is the one the machine reported - `http` or `https`, whichever
+ * happened.
+ *
+ * ## Absent rather than disabled when there is no Tailscale
+ *
+ * Rule 3: Tailscale is discovery and identity, never a dependency. A machine
+ * without it is an ordinary machine with one fewer option, not a machine with a
+ * greyed-out switch implying it is missing something - which is the same
+ * argument `ShellCapabilities` makes about a control that explains itself when
+ * pressed.
+ */
+import { useState } from 'react'
+import useSWR from 'swr'
+import { Globe } from 'lucide-react'
+import { Switch } from '@/components/ui/switch'
+import { Card } from '@/components/ui/card'
+import { Breakable } from '@/components/breakable'
+import { api, CACHE_KEYS } from '@/lib/api'
+import { errorMessage } from '@/lib/errors'
+
+export function TailnetPanel() {
+  const { data: tailnet, mutate } = useSWR(CACHE_KEYS.tailnet, () => api.hosts.tailnet())
+  const [busy, setBusy] = useState(false)
+  const [failure, setFailure] = useState<string | null>(null)
+
+  // Nothing until the first read lands, and nothing at all on a machine with no
+  // Tailscale. A switch that appeared and then vanished would be worse than one
+  // that arrived a moment late.
+  if (!tailnet?.available) return null
+
+  async function toggle(next: boolean): Promise<void> {
+    setBusy(true)
+    setFailure(null)
+    try {
+      // No optimistic value, deliberately - see the header. `tailscale serve`
+      // can take a second or two, and showing "on" during it would be showing
+      // the request rather than the machine.
+      await mutate(api.hosts.setTailnetExposure({ exposed: next }), { revalidate: false })
+    } catch (error) {
+      setFailure(errorMessage(error))
+      void mutate()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Card className="flex flex-col gap-3 p-4">
+      <div className="flex items-center gap-3">
+        <Globe className="size-4 shrink-0 text-muted-foreground" />
+        <label htmlFor="tailnet-exposed" className="min-w-40 flex-1 cursor-pointer">
+          <span className="block text-sm font-medium">Reachable on your tailnet</span>
+          <span className="block text-xs text-muted-foreground">
+            Your other machines can add this one as a host, and you can open its reviews in a
+            browser on any device signed in as {tailnet.login}.
+          </span>
+        </label>
+        <Switch
+          id="tailnet-exposed"
+          checked={tailnet.exposed}
+          disabled={busy}
+          onCheckedChange={(checked) => void toggle(checked)}
+        />
+      </div>
+
+      {tailnet.exposed && tailnet.webRoot ? (
+        // Shown rather than described, because it is the thing a person types
+        // into a phone. `Breakable` so it wraps at its separators and stays
+        // selectable at 390 px - the rule M3.5 set and M4.5 found the hard
+        // edge of.
+        <p className="text-xs text-muted-foreground">
+          Open it at{' '}
+          <span className="font-mono">
+            <Breakable text={tailnet.webRoot} />
+          </span>
+        </p>
+      ) : null}
+
+      {failure ? <p className="text-xs text-destructive">{failure}</p> : null}
+    </Card>
+  )
+}

--- a/src/renderer/src/lib/__tests__/event-scope.test.ts
+++ b/src/renderer/src/lib/__tests__/event-scope.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Which cache keys an event is news about.
+ *
+ * The subtle half of the renderer's event handling is not the fan-out, it is
+ * the *scope*. An event from `pc-wsl` must refresh `pc-wsl`'s keys and leave
+ * this Mac's alone, and getting that wrong would not have been visible on any
+ * screen: everything would still be correct, just re-reading every machine's
+ * SQLite whenever an agent typed anything. That is the kind of wrong a test is
+ * for and a demonstration is not, which is why the rule lives in a module with
+ * no imports and this file exists next to it.
+ *
+ * The prefixes are written out here rather than read from `CACHE_PREFIXES`,
+ * because `lib/api.ts` throws at import time without `window.gitwarren` - see
+ * the header of `lib/event-scope.ts`. They are a handful of literals whose
+ * exact spelling is the thing under test anyway.
+ */
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { eventClaimsKey, keyBelongsTo } from '../event-scope'
+
+const HOST = '4e0b0adb00004000800000000000abcd'
+const OTHER = 'aaaaaaaa00004000800000000000bbbb'
+const REVIEWS = ['reviews:', 'review:', 'review-commits:', 'review-diff:']
+
+test('a key with no host is this install’s own', () => {
+  assert.equal(keyBelongsTo('review:4', undefined), true)
+  assert.equal(keyBelongsTo(`review:4@${HOST}`, undefined), false)
+})
+
+test('a key belongs to the machine named on its end, and to no other', () => {
+  assert.equal(keyBelongsTo(`review:4@${HOST}`, HOST), true)
+  assert.equal(keyBelongsTo(`review:4@${OTHER}`, HOST), false)
+  assert.equal(keyBelongsTo('review:4', HOST), false)
+})
+
+test('an event from a host claims that host’s reviews and nothing local', () => {
+  const claimed = [
+    'reviews:all:any',
+    `reviews:all:any@${HOST}`,
+    'review:4',
+    `review:4@${HOST}`,
+    `review-diff:4:all@${HOST}`,
+    `review:4@${OTHER}`
+  ].filter((key) => eventClaimsKey(key, HOST, REVIEWS))
+
+  assert.deepEqual(claimed, [
+    `reviews:all:any@${HOST}`,
+    `review:4@${HOST}`,
+    `review-diff:4:all@${HOST}`
+  ])
+})
+
+test('a local event leaves every host’s keys alone', () => {
+  const claimed = ['reviews:all:any', 'review:4', `review:4@${HOST}`].filter((key) =>
+    eventClaimsKey(key, undefined, REVIEWS)
+  )
+  assert.deepEqual(claimed, ['reviews:all:any', 'review:4'])
+})
+
+test('a family nobody named is not claimed, however close the spelling', () => {
+  // `repositories` and `app-info` are not in the reviews family, and
+  // `reviewed-somethings` would be a new key rather than a `review:` one - the
+  // prefixes carry their separator for exactly this reason.
+  for (const key of ['repositories', 'app-info', 'hosts', 'editors']) {
+    assert.equal(eventClaimsKey(key, undefined, REVIEWS), false, key)
+  }
+})
+
+test('a key that is not a string is never claimed', () => {
+  // SWR keys may be arrays or objects. This app uses strings throughout, and a
+  // predicate that assumed so would throw inside `mutate` rather than say no.
+  for (const key of [null, undefined, 4, ['review:4'], { key: 'review:4' }]) {
+    assert.equal(eventClaimsKey(key, undefined, REVIEWS), false)
+  }
+})

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -162,6 +162,7 @@ function buildApi(host: string | undefined): GitWarrenApi {
       // actively wrong rather than merely refused: this is about the
       // reachability of the machine holding the core, which in a browser tab
       // is the machine that served the tab and never the one a route names.
+      discover: () => ask('hosts.discover', undefined),
       tailnet: () => ask('hosts.tailnet', undefined),
       setTailnetExposure: (input) => ask('hosts.setTailnetExposure', input)
     },
@@ -296,6 +297,15 @@ export const CACHE_KEYS = {
    * this window is driving, not about any machine a route happens to name.
    */
   tailnet: 'tailnet',
+  /**
+   * What is on the tailnet that is not in the list yet.
+   *
+   * Unscoped like the other `hosts.` keys, and deliberately *not* fetched
+   * anywhere but the Hosts screen: this is the one read in the app that costs a
+   * connection attempt per peer, so a key that something else subscribed to
+   * would turn opening any screen into a scan. See `core/hosts/discover.ts`.
+   */
+  discovered: 'discovered-peers',
   repositories: (host?: string) => scoped('repositories', host),
   repository: (repositoryId: number, host?: string) =>
     scoped(`repository:${repositoryId}`, host),

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -157,7 +157,13 @@ function buildApi(host: string | undefined): GitWarrenApi {
       remove: (input) => ask('hosts.remove', input),
       probe: (input) => ask('hosts.probe', input),
       install: (input) => ask('hosts.install', input),
-      distros: () => ask('hosts.distros', undefined)
+      distros: () => ask('hosts.distros', undefined),
+      // Unbound like the rest of `hosts`, and here the binding would be
+      // actively wrong rather than merely refused: this is about the
+      // reachability of the machine holding the core, which in a browser tab
+      // is the machine that served the tab and never the one a route names.
+      tailnet: () => ask('hosts.tailnet', undefined),
+      setTailnetExposure: (input) => ask('hosts.setTailnetExposure', input)
     },
     fs: {
       list: (input) => ask('fs.list', input, host)
@@ -283,6 +289,13 @@ export const CACHE_KEYS = {
   hosts: 'hosts',
   /** What could become a host here. Unscoped, like the host list itself. */
   distros: 'wsl-distros',
+  /**
+   * Whether this machine is reachable on its tailnet.
+   *
+   * Unscoped for the same reason as the two above: it is about the install
+   * this window is driving, not about any machine a route happens to name.
+   */
+  tailnet: 'tailnet',
   repositories: (host?: string) => scoped('repositories', host),
   repository: (repositoryId: number, host?: string) =>
     scoped(`repository:${repositoryId}`, host),

--- a/src/renderer/src/lib/event-scope.ts
+++ b/src/renderer/src/lib/event-scope.ts
@@ -1,0 +1,57 @@
+/**
+ * Whether a cache key is one an event is news about.
+ *
+ * Three lines of string matching, in a file of their own, for the same reason
+ * `lib/host-reachability.ts` has no React in it: this is the part worth
+ * testing, and a test of it should be a node program. `lib/events.ts` - which
+ * holds the table of which event names mean which key families - cannot be one,
+ * because it reads `CACHE_PREFIXES` from `lib/api.ts` and that module throws at
+ * import time without `window.gitwarren`, deliberately. So the rule moved out
+ * and the table stayed.
+ *
+ * No imports at all, which is the property that makes that work.
+ *
+ * ## The scope is a suffix, and that is not an accident of spelling
+ *
+ * `scoped()` in `lib/api.ts` puts `@<instance>` on the *end* of every key that
+ * names something a host owns, so that the family-wide `startsWith`
+ * invalidation at the front still works. Asking from the other end gives
+ * "everything about that machine", which is the question an event from a host
+ * is asking - and the same trick `features/hosts/use-reconnect.ts` already uses
+ * to bring a whole screen back when one read succeeds.
+ *
+ * Getting this wrong is invisible on screen. An event from `pc-wsl` that
+ * matched this Mac's keys too would leave every screen correct and simply
+ * re-read six machines' worth of SQLite every time an agent typed anything -
+ * which is the kind of wrong a demo cannot show and this file exists to pin
+ * down.
+ */
+
+/**
+ * Does `key` belong to the install an event came from?
+ *
+ * `host` absent means the event is this install's own, and a key with no `@` in
+ * it is this install's own - the same asymmetry every host-aware thing in this
+ * app has, arriving from both ends at once.
+ */
+export function keyBelongsTo(key: string, host: string | undefined): boolean {
+  return host === undefined ? !key.includes('@') : key.endsWith(`@${host}`)
+}
+
+/**
+ * The whole decision: is this key in one of these families, on that machine?
+ *
+ * The host test comes first because it is the cheap one and it rejects most
+ * keys on a screen that is looking at a different machine.
+ */
+export function eventClaimsKey(
+  key: unknown,
+  host: string | undefined,
+  prefixes: readonly string[]
+): boolean {
+  return (
+    typeof key === 'string' &&
+    keyBelongsTo(key, host) &&
+    prefixes.some((prefix) => key.startsWith(prefix))
+  )
+}

--- a/src/renderer/src/lib/events.ts
+++ b/src/renderer/src/lib/events.ts
@@ -1,0 +1,120 @@
+/**
+ * What a screen does when the core says something changed: ask again.
+ *
+ * This is the whole of the renderer's side of M6's event channel, and its
+ * shortness is the design rather than an accident. An event carries a name and
+ * a scope and never data (`core/events.ts`), so there is no state to apply, no
+ * ordering to respect and no conflict to resolve - there is a cache key family
+ * to invalidate, and SWR does the rest.
+ *
+ * ## Why this is not new behaviour, only earlier behaviour
+ *
+ * A write made in *this* window already invalidates by family:
+ * `mutate(key => key.startsWith('reviews:'))` after creating a review, and the
+ * same for comments. What an event does is run that same invalidation for a
+ * write made somewhere else - another window, a browser tab, an agent's MCP
+ * session, a person on a phone. One behaviour rather than two, which is what
+ * makes it hard to get subtly wrong: if a local write refreshes the right
+ * screens, a remote one now does too, by the same code path.
+ *
+ * And because it is only an invalidation, everything that was already true
+ * stays true. The fifteen-second poll still runs; `onErrorRetry` in `main.tsx`
+ * still governs a host that has gone away; `LIVE_READ_OPTIONS` reads that
+ * deliberately never retry are not re-run behind anybody's back by an event
+ * either, because `mutate` on a key with no subscriber does nothing at all.
+ *
+ * ## The host on the event is the whole of the scoping
+ *
+ * `scoped()` in `lib/api.ts` puts `@<instance>` on the end of every key that
+ * names something a host owns, so "everything about that machine" is a suffix
+ * test - which is exactly what `use-reconnect.ts` already leans on from the
+ * other direction. An event from `pc-wsl` therefore refreshes `pc-wsl`'s
+ * reviews and leaves this Mac's alone, and a local event refreshes the keys
+ * with no suffix at all. Getting this wrong would not have been visible: the
+ * screens would still be correct, just re-reading six machines' worth of SQLite
+ * every time an agent typed anything.
+ *
+ * ## `host.state` is not the banner
+ *
+ * It invalidates the host list and nothing else. M4.5's banner is raised by
+ * request *outcomes* in `lib/host-reachability.ts` and is deliberately left
+ * alone: a request that failed is evidence about the screen in front of
+ * someone, while an event is a hint that something changed somewhere. What this
+ * adds is the row for a machine nobody is looking at, on the Hosts screen,
+ * which had no way to learn anything until the pool had an ear.
+ */
+import { mutate } from 'swr'
+import { RPC_EVENTS, type RpcEvent } from '@shared/rpc'
+import { CACHE_KEYS, CACHE_PREFIXES } from './api'
+import { eventClaimsKey } from './event-scope'
+
+/**
+ * Which key families each event invalidates.
+ *
+ * `comments.changed` lists the review prefix rather than a prefix of its own,
+ * because threads are not a key: they arrive inside `reviews.open` under
+ * `review:<id>`, which is the coarse endpoint S5 argued for. So "a comment
+ * changed" and "the review changed" refresh the same thing, and the two names
+ * exist because the *senders* know which they did - the distinction is worth
+ * keeping on the wire even where the receiver spends it the same way.
+ */
+const PREFIXES_FOR_EVENT: Readonly<Record<string, readonly string[]>> = {
+  [RPC_EVENTS.reviewsChanged]: [
+    CACHE_PREFIXES.reviews,
+    CACHE_PREFIXES.review,
+    CACHE_PREFIXES.reviewCommits,
+    CACHE_PREFIXES.reviewDiff
+  ],
+  [RPC_EVENTS.commentsChanged]: [CACHE_PREFIXES.review]
+}
+
+/**
+ * Where an invalidation goes. SWR's `mutate` in the app; a spy in the test.
+ *
+ * A parameter rather than a module the test replaces, because what is worth
+ * checking here is *which keys an event claims*, and that is a decision made
+ * before SWR is involved at all. Handing the sink in makes the decision
+ * observable without a cache, a provider or a React tree - the same instinct
+ * that kept `lib/host-reachability.ts` free of React so its rules could be
+ * tested as a node program.
+ */
+export type Invalidate = (matcher: string | ((key: unknown) => boolean)) => unknown
+
+/**
+ * Act on one event. Exported for the test; `startListeningForEvents` is the
+ * thing the app calls.
+ *
+ * An unknown name is ignored rather than treated as a fault. A daemon newer
+ * than this window will announce names it has not heard of, and the protocol's
+ * rule has been "unknown fields are ignored" since `RPC_PROTOCOL_VERSION` was
+ * written - an event is the first thing to travel in this direction, and it
+ * would be a poor moment to invent a stricter rule. The cost of ignoring one is
+ * fifteen seconds.
+ */
+export function applyEvent(event: RpcEvent, invalidate: Invalidate = mutate): void {
+  if (event.event === RPC_EVENTS.hostState) {
+    // One key, unscoped, because the host list is one list - see the note on
+    // `CACHE_KEYS.hosts` about why there is deliberately no per-host key.
+    void invalidate(CACHE_KEYS.hosts)
+    return
+  }
+
+  const prefixes = PREFIXES_FOR_EVENT[event.event]
+  if (!prefixes) return
+
+  void invalidate((key: unknown) => eventClaimsKey(key, event.host, prefixes))
+}
+
+/**
+ * Subscribe for the life of the window. Returns an unsubscribe.
+ *
+ * Installed in `main.tsx` beside the deep-link listener rather than in a
+ * component, and for the same reason: it belongs to the window rather than to
+ * anything React renders, and a subscription that came and went with a mount
+ * would drop events during a navigation.
+ */
+export function startListeningForEvents(
+  onEvent: (listener: (event: RpcEvent) => void) => () => void
+): () => void {
+  return onEvent(applyEvent)
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -4,6 +4,7 @@ import { SWRConfig } from 'swr'
 import { App } from './App'
 import { api } from './lib/api'
 import { isDisconnection } from './lib/errors'
+import { startListeningForEvents } from './lib/events'
 import './index.css'
 
 /**
@@ -41,6 +42,17 @@ applyColourScheme()
 api.navigation.onDeepLink((hash) => {
   window.location.hash = hash
 })
+
+/**
+ * Live updates, subscribed for the life of the window.
+ *
+ * Beside the deep-link listener for the same two reasons: it belongs to the
+ * window rather than to anything React renders, and it has to be listening
+ * before the first paint so that a comment written while the app was starting
+ * is not missed. What arrives is a name, never data - see `lib/events.ts` - so
+ * this line cannot put anything on screen that a read did not answer.
+ */
+startListeningForEvents((listener) => window.gitwarren.carrier.onEvent(listener))
 
 const container = document.getElementById('root')
 if (!container) throw new Error('Root element is missing from index.html')

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -30,6 +30,7 @@ import type {
   InstallOnHostInput,
   InstallReport,
   WslDistro,
+  DiscoveredPeer,
   RemoveHostInput,
   SetTailnetExposureInput,
   TailnetExposure,
@@ -336,6 +337,8 @@ export interface GitWarrenApi {
      * on a headless box needs; a GUI looking at a remote host cannot reach
      * across and start `tailscale serve` there.
      */
+    /** Machines on this tailnet running GitWarren. Proposals, never rows. */
+    discover(): Promise<DiscoveredPeer[]>
     tailnet(): Promise<TailnetExposure>
     setTailnetExposure(input: SetTailnetExposureInput): Promise<TailnetExposure>
   }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -31,6 +31,8 @@ import type {
   InstallReport,
   WslDistro,
   RemoveHostInput,
+  SetTailnetExposureInput,
+  TailnetExposure,
   UpdateHostInput,
   Comment,
   CommentThread,
@@ -322,6 +324,20 @@ export interface GitWarrenApi {
      * on `hosts.distros` in `shared/rpc.ts`.
      */
     distros(): Promise<WslDistro[]>
+    /**
+     * Whether the machine answering is reachable on its tailnet, and where.
+     *
+     * Here for the same reason `distros` is, and it survives the harder version
+     * of the same test. Turning exposure on is genuinely an *act* on a machine,
+     * which is the thing `shared/rpc.ts` says must never travel - and it does
+     * not: `isLocalOnly` refuses the whole `hosts.` prefix, so what this acts on
+     * is always the machine whose core is answering. A browser tab gets its own
+     * server's switch, which is exactly what a person running `gitwarren serve`
+     * on a headless box needs; a GUI looking at a remote host cannot reach
+     * across and start `tailscale serve` there.
+     */
+    tailnet(): Promise<TailnetExposure>
+    setTailnetExposure(input: SetTailnetExposureInput): Promise<TailnetExposure>
   }
   /**
    * What is inside a folder, on the machine this api is pointed at.

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -121,7 +121,18 @@ export const IPC_CHANNELS = {
    * Main -> renderer push carrying a hash to move to, sent when a
    * `gitwarren://` deep link arrives while the app is already running.
    */
-  navigationDeepLink: 'navigation:deepLink'
+  navigationDeepLink: 'navigation:deepLink',
+  /**
+   * Main -> renderer push carrying an `RpcEvent`: something changed, go and
+   * re-read it.
+   *
+   * The window's half of what a browser tab gets as a frame on its socket. It
+   * is a *carrier* channel rather than a shell one - see `BridgeCarrier.onEvent`
+   * - which is why it is here next to `rpcRequest` rather than beside the two
+   * pushes above, both of which are about this shell (an update downloading, a
+   * link the OS handed us) rather than about the core's data.
+   */
+  rpcEvent: 'rpc:event'
 } as const
 
 /**
@@ -185,7 +196,8 @@ export const SHELL_CHANNELS = [
 /** Main -> renderer pushes. Nothing handles these; they are sent. */
 export const PUSH_CHANNELS = [
   IPC_CHANNELS.updatesChanged,
-  IPC_CHANNELS.navigationDeepLink
+  IPC_CHANNELS.navigationDeepLink,
+  IPC_CHANNELS.rpcEvent
 ] as const
 
 export interface AppInfo {

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -149,15 +149,69 @@ export type RpcOutcome<T = unknown> = { result: T } | { error: SerializedAppErro
 export type RpcResponse<T = unknown> = RpcOutcome<T> & { id: number }
 
 /**
+ * The three things that are ever announced.
+ *
+ * A closed set, and small on purpose. An event is a *reason to re-ask* and
+ * never the answer (see `core/events.ts`), so the vocabulary only has to be
+ * fine enough to name a family of cache keys - which is the same granularity
+ * the renderer already invalidates at after one of its own writes.
+ *
+ * `host.state` is the odd one and is the reason the channel exists at all. The
+ * other two are about data and are known only to the machine that owns it;
+ * this one is about a *machine* and is minted by the pool of whichever install
+ * is doing the reaching. It therefore never travels a wire - see the note on
+ * `RpcEvent.host`.
+ */
+export const RPC_EVENTS = {
+  /** A review, a repository or a reviewed mark changed on the sender. */
+  reviewsChanged: 'reviews.changed',
+  /** A comment or a thread changed on the sender. */
+  commentsChanged: 'comments.changed',
+  /** A host this install reaches became reachable, or stopped being. */
+  hostState: 'host.state'
+} as const
+
+export type RpcEventName = (typeof RPC_EVENTS)[keyof typeof RPC_EVENTS]
+
+/**
  * A push from whoever owns the data. Carries no id: nobody asked for it.
  *
- * Nothing emits one yet - the renderer polls, and M6 is where events replace
- * that - but the shape belongs next to the other two, because a carrier reading
- * a stream has to be able to tell an event from an answer.
+ * Reserved at M1 with nothing emitting on it, and the comment then said the
+ * shape was here so that "the message simply arrives". That turned out to be
+ * true and to be worth most of a slice: `core/rpc/stdio-client.ts` was written
+ * against this shape in M4 and routes an event to its `onEvent` hook rather
+ * than looking for a request to answer, so the stdio carrier needed no change
+ * at all in M6.
+ *
+ * `data` is `null` today for every name. It is kept in the shape rather than
+ * removed because leaving it out would make adding a scope later a protocol
+ * change, and because a frame with no payload field is the sort of thing a
+ * hand-written peer gets wrong. What it must never become is the *content* that
+ * changed - `core/events.ts` has the argument.
  */
 export interface RpcEvent<T = unknown> {
+  /**
+   * One of `RPC_EVENTS` - but typed as a plain string, deliberately.
+   *
+   * `RpcEventName` is the vocabulary this install *emits*. What it *receives*
+   * comes off a wire from a separately installed peer that may be newer, and
+   * narrowing this would make the receiving side's "ignore what you do not
+   * recognise" look like dead code to the compiler rather than like the
+   * protocol rule it has been since `RPC_PROTOCOL_VERSION` was written.
+   */
   event: string
   data: T
+  /**
+   * Which install this is news about. Added on arrival, never on the wire.
+   *
+   * A daemon announcing `comments.changed` is saying "on me", and it has no
+   * idea what instance id the *listener* files it under - it may be reached by
+   * two GitWarrens at once. So the carrier that received it stamps the host it
+   * had already resolved, which is the only side that knows, and the renderer
+   * then invalidates `…@<host>` rather than every machine's keys at once. The
+   * same asymmetry as `RpcRequest.host`: absent means this install.
+   */
+  host?: string
 }
 
 export type RpcMessage = RpcRequest | RpcResponse | RpcEvent
@@ -498,6 +552,21 @@ export interface BridgeCarrier {
     params: RpcParams<M>,
     host?: string
   ): Promise<RpcOutcome<RpcResult<M>>>
+  /**
+   * Events from the core this bridge is attached to. Returns an unsubscribe.
+   *
+   * On the carrier rather than on `ShellApi`, because an event is a message
+   * from the *core* and the carrier is the renderer's door to it - the two
+   * shells differ in how it arrives (an IPC channel, a frame on the socket) in
+   * exactly the way they already differ for a request. It is the same reason
+   * `ShellConnection` is on the shell and this is not: one is a fact about the
+   * transport, the other is news from the far end of it.
+   *
+   * Deliberately not typed per event name. Every subscriber wants all of them -
+   * see `subscribeToEvents` in `core/events.ts` - and a bridge that had to be
+   * edited to add a name would be another list to keep in step.
+   */
+  onEvent(listener: (event: RpcEvent) => void): () => void
 }
 
 /**

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -31,6 +31,8 @@ import type {
   InstallOnHostInput,
   InstallReport,
   RemoveHostInput,
+  SetTailnetExposureInput,
+  TailnetExposure,
   UpdateHostInput,
   WslDistro,
   Comment,
@@ -330,6 +332,32 @@ export interface RpcMethods {
   'hosts.distros': { params: void; result: WslDistro[] }
 
   /**
+   * Whether the machine that answers is reachable on its tailnet, and where.
+   *
+   * Under `hosts.` for the same reason `hosts.distros` is, and the reason is
+   * worth restating because this one looks much more like a capability. It is
+   * a fact - and an *act*, in the setter's case - about the machine the core
+   * runs on, which is the machine being exposed. A browser tab must be able to
+   * ask and to set it, because the person who will not install Electron is
+   * exactly the person running `gitwarren serve` on a headless box.
+   *
+   * What the prefix buys is that `isLocalOnly` refuses to forward either of
+   * them without anybody having to remember. That refusal is the important
+   * half: a GUI on the Mac must not be able to reach across and start
+   * `tailscale serve` on the PC. A request that could start a process on
+   * another machine is the thing `core/rpc/dispatcher.ts` says would make this
+   * very different software, and "the method is about the machine holding the
+   * list" is the rule that keeps it out.
+   *
+   * `available: false` on a machine with no Tailscale, rather than an error, so
+   * a settings panel offers the switch when the answer says it can and no code
+   * anywhere asks what is installed. The same shape `hosts.distros` uses to
+   * make a Mac not offer a WSL host.
+   */
+  'hosts.tailnet': { params: void; result: TailnetExposure }
+  'hosts.setTailnetExposure': { params: SetTailnetExposureInput; result: TailnetExposure }
+
+  /**
    * What is inside a folder, on the machine that answers.
    *
    * The one method here that exists because of a *capability* rather than a
@@ -467,6 +495,7 @@ export const READ_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   'hosts.list',
   'hosts.get',
   'hosts.distros',
+  'hosts.tailnet',
   // `hosts.probe` is deliberately absent. It reads in the sense that it changes
   // no host row a caller can see, but it opens a connection and clears a
   // backoff, and two people pressing "try now" at the same moment should mean

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -30,6 +30,7 @@ import type {
   HostWithState,
   InstallOnHostInput,
   InstallReport,
+  DiscoveredPeer,
   RemoveHostInput,
   SetTailnetExposureInput,
   TailnetExposure,
@@ -354,6 +355,19 @@ export interface RpcMethods {
    * anywhere asks what is installed. The same shape `hosts.distros` uses to
    * make a Mac not offer a WSL host.
    */
+  /**
+   * Machines on this install's tailnet that are running GitWarren.
+   *
+   * Under `hosts.` with the others, and the prefix is doing the same work: what
+   * peers a machine can see is that machine's own business, and a GUI must not
+   * be able to ask a host to go scanning on its behalf.
+   *
+   * A *read* in the sense that matters - it adds nothing and changes nothing -
+   * but not a cheap one, which is why it is in `READ_METHODS` for coalescing
+   * and is asked only when a screen that shows it is opened. See
+   * `core/hosts/discover.ts` for when it runs and what it costs.
+   */
+  'hosts.discover': { params: void; result: DiscoveredPeer[] }
   'hosts.tailnet': { params: void; result: TailnetExposure }
   'hosts.setTailnetExposure': { params: SetTailnetExposureInput; result: TailnetExposure }
 
@@ -495,6 +509,7 @@ export const READ_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   'hosts.list',
   'hosts.get',
   'hosts.distros',
+  'hosts.discover',
   'hosts.tailnet',
   // `hosts.probe` is deliberately absent. It reads in the sense that it changes
   // no host row a caller can see, but it opens a connection and clears a

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -883,3 +883,57 @@ export const directoryListingSchema = z.object({
 export type ListDirectoryInput = z.input<typeof listDirectoryInputSchema>
 export type DirectoryEntry = z.infer<typeof directoryEntrySchema>
 export type DirectoryListing = z.infer<typeof directoryListingSchema>
+
+/**
+ * Whether this machine is reachable on its tailnet, and where.
+ *
+ * In `shared/` rather than beside the implementation in `core/web/exposure.ts`
+ * because the renderer draws the switch and the renderer may not import
+ * `core/`. It is the same split `HostWithState` has: the shape is everyone's,
+ * and the machinery for producing it is one side's.
+ *
+ * A schema and not just a type, even though nothing validates an *outgoing*
+ * one, so that a screen on the other end of a carrier has the same guarantee
+ * about this answer as it has about every other.
+ */
+export const tailnetExposureSchema = z.object({
+  /**
+   * Whether this machine has a working Tailscale at all: installed, logged in,
+   * daemon running. False covers all three failures because no screen can act
+   * on the difference - the switch is not offered, and rule 3 says Tailscale is
+   * never a dependency.
+   */
+  available: z.boolean(),
+  /** This machine's MagicDNS name, or null. */
+  dnsName: z.string().nullable(),
+  /** The owner's Tailscale login, so a person can see whose tailnet this is. */
+  login: z.string().nullable(),
+  /** Whether the loopback port is being served on the tailnet right now. */
+  exposed: z.boolean(),
+  /**
+   * Where the web view is for a phone, mount included:
+   * `http://pc-wsl.tail688c0c.ts.net:41427/app/`. Null when not exposed.
+   *
+   * The mount is part of it because the two shells serve the app at different
+   * paths - a URL naming only the origin would land a phone on the Electron
+   * link page rather than in the app. The scheme is whatever `tailscale serve`
+   * actually managed, never assumed: see `core/tailnet.ts`.
+   */
+  webRoot: z.string().nullable()
+})
+
+export type TailnetExposure = z.infer<typeof tailnetExposureSchema>
+
+/**
+ * Turning "Reachable on your tailnet" on or off.
+ *
+ * One boolean, and it is a schema rather than a bare argument for the reason
+ * every other input here is: whoever answers re-parses what it was sent, and a
+ * method whose params were a naked value would be the one place that rule did
+ * not hold.
+ */
+export const setTailnetExposureInputSchema = z.object({
+  exposed: z.boolean()
+})
+
+export type SetTailnetExposureInput = z.infer<typeof setTailnetExposureInputSchema>

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -984,3 +984,35 @@ export const setTailnetExposureInputSchema = z.object({
 })
 
 export type SetTailnetExposureInput = z.infer<typeof setTailnetExposureInputSchema>
+
+/**
+ * A machine on the tailnet that answered a probe.
+ *
+ * Not a host row and deliberately shaped so it could never be mistaken for one:
+ * it has no `id`, because nothing has been added. Discovery proposes and a
+ * person decides - see `core/hosts/discover.ts` on why that line matters more
+ * than it looks.
+ */
+export const discoveredPeerSchema = z.object({
+  /** Its MagicDNS name: `pc-wsl.tail688c0c.ts.net`. */
+  dnsName: z.string(),
+  /** Where it answered, which is what becomes `hosts.target` if it is added. */
+  origin: z.string(),
+  /** Who it said it is. The only field that can tell two names for one box apart. */
+  instanceId: z.string(),
+  /** What it is running, for a person to compare against their own. */
+  version: z.string().nullable(),
+  /**
+   * The label of the row this machine is already in the list as, or null.
+   *
+   * A *label* rather than a boolean, because "you have this already" is not
+   * useful without "as what": `pc-wsl` reached over SSH and `pc-wsl` reached
+   * over the tailnet are one machine, and the question a person has is which
+   * row it is. M4.1's collision report says the same thing after an insert and
+   * a connection; this says it before either, because the probe already carried
+   * the instance id.
+   */
+  alreadyAdded: z.string().nullable()
+})
+
+export type DiscoveredPeer = z.infer<typeof discoveredPeerSchema>

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -106,7 +106,8 @@ export type RemoveRepositoryInput = z.input<typeof removeRepositoryInputSchema>
 export const MAX_TARGET_LENGTH = 255
 
 export const hostIdSchema = z.number().int().positive()
-export const hostKindSchema = z.enum(['ssh', 'wsl'])
+export const hostKindSchema = z.enum(['ssh', 'wsl', 'websocket'])
+export type HostKind = z.infer<typeof hostKindSchema>
 
 /**
  * An SSH destination.
@@ -162,9 +163,55 @@ export const wslDistroNameSchema = z
     message: 'That is not a WSL distribution name.'
   })
 
-/** Whichever of the two a host of this kind is addressed by. */
-export function hostTargetSchemaFor(kind: 'ssh' | 'wsl'): z.ZodType<string> {
-  return kind === 'wsl' ? wslDistroNameSchema : sshTargetSchema
+/**
+ * A machine that is listening, addressed as a name or as a whole origin.
+ *
+ * Looser than the two above and deliberately so, because what is on the other
+ * side is different in kind. An `ssh` target and a distribution name both
+ * become *arguments to a program this machine runs*, so the metacharacter
+ * refusals there are about what a string in a form can be talked into doing
+ * locally. This one becomes a URL handed to `new URL`, which parses rather than
+ * executes; there is no shell anywhere on that path.
+ *
+ * So the check is that it parses at all and names a host - and that it is not
+ * loopback, which is the one mistake worth catching in the form. Adding
+ * `localhost` as a host of *this* install would be a machine describing itself,
+ * and what it would produce is an instance-id collision with a row that does
+ * not exist yet: M4.1's report fires on connect, which is late enough to be
+ * confusing when the answer is simply "that is this computer".
+ */
+export const tailnetTargetSchema = z
+  .string()
+  .trim()
+  .min(1, 'Enter the machine, like pc-wsl or pc-wsl.tail0123.ts.net.')
+  .max(MAX_TARGET_LENGTH)
+  .refine((value) => !value.startsWith('-'), {
+    message: 'A machine name cannot start with "-".'
+  })
+  .refine(
+    (value) => {
+      try {
+        const url = new URL(/^https?:\/\//i.test(value) ? value : `http://${value}`)
+        return url.hostname.length > 0
+      } catch {
+        return false
+      }
+    },
+    { message: 'That is not a machine name or an address.' }
+  )
+  .refine(
+    (value) => {
+      const host = value.replace(/^https?:\/\//i, '').split(/[:/]/)[0]?.toLowerCase() ?? ''
+      return host !== 'localhost' && host !== '127.0.0.1' && host !== '::1'
+    },
+    { message: 'That is this computer. A host is another machine.' }
+  )
+
+/** Whichever of the three a host of this kind is addressed by. */
+export function hostTargetSchemaFor(kind: HostKind): z.ZodType<string> {
+  if (kind === 'wsl') return wslDistroNameSchema
+  if (kind === 'websocket') return tailnetTargetSchema
+  return sshTargetSchema
 }
 
 /**

--- a/src/shared/web.ts
+++ b/src/shared/web.ts
@@ -61,8 +61,42 @@ export const WEB_PATHS = {
    * dispatcher, which is where the size limit and the format sniff live. There
    * is no upload endpoint here and there should not be one.
    */
-  attachments: `${WEB_PREFIX}/attachments/`
+  attachments: `${WEB_PREFIX}/attachments/`,
+  /**
+   * The one thing under here that is written to rather than read: an agent's
+   * process telling the owner of this data directory that it changed something.
+   *
+   * It is the M6 answer to "how does the MCP process poke the owner", and the
+   * argument for it being *here* rather than a channel of its own is that the
+   * channel already exists. `daemon-runtime.json` names the owning process and
+   * its `linkPort`; that process is already serving this handler on it; and the
+   * 0600 token beside the runtime file is readable by exactly the principal
+   * that may poke - the user. The alternative the plan offered was a counter in
+   * a file, which is a poll with extra steps: something would have to watch it,
+   * and `fs.watch` is per platform, unreliable on network filesystems and a
+   * timer underneath on several of them.
+   *
+   * `POST`, and it is the only non-idempotent request this server answers. What
+   * it accepts is a *name* from a closed vocabulary and nothing else, so the
+   * most a local process can do with it is make a window re-read something -
+   * which it could already cause by writing to the database it can already
+   * open. See `core/web/notify.ts`.
+   */
+  notify: `${WEB_PREFIX}/notify`
 } as const
+
+/**
+ * How a non-browser presents the session token.
+ *
+ * The cookie exchange in `core/web/handler.ts` is built for a browser arriving
+ * by navigation, and the MCP process is neither. A header is the natural
+ * spelling for it - and it is a *stronger* lock rather than a convenience,
+ * because a cross-origin page cannot set a custom header without a preflight
+ * this server never answers. So the notify endpoint takes the token here and
+ * nowhere else: not in the query, where it would end up in a log, and not in
+ * the cookie, which only a browser has.
+ */
+export const TOKEN_HEADER = 'x-gitwarren-token'
 
 /**
  * The same image, addressed the way a browser tab can fetch it.

--- a/src/shared/web.ts
+++ b/src/shared/web.ts
@@ -82,7 +82,25 @@ export const WEB_PATHS = {
    * which it could already cause by writing to the database it can already
    * open. See `core/web/notify.ts`.
    */
-  notify: `${WEB_PREFIX}/notify`
+  notify: `${WEB_PREFIX}/notify`,
+  /**
+   * "Is there a GitWarren here, and which one?" - the one question a machine
+   * this install has no relationship with is allowed to ask.
+   *
+   * A `GET` rather than `app.instance` over the carrier, because a probe is
+   * asked of peers there is no connection to yet and opening one is a stronger
+   * act than asking whether anybody is home. It also has to be cheap: discovery
+   * asks every online peer at once, and most of them are phones that will
+   * refuse the TCP connect.
+   *
+   * Behind the same gate as everything else, which is what makes it safe to
+   * answer at all: on the tailnet authority it requires the owner's login, so
+   * only the owner's own devices can learn that this machine runs GitWarren.
+   * What comes back is `HostIdentity` - the same shape `app.instance` returns,
+   * because it is the same question asked before there is a carrier rather than
+   * after.
+   */
+  discover: `${WEB_PREFIX}/discover`
 } as const
 
 /**

--- a/src/web/__tests__/loopback-fragment.test.ts
+++ b/src/web/__tests__/loopback-fragment.test.ts
@@ -52,11 +52,27 @@ test('a file path with slashes in it survives the round trip', () => {
 })
 
 test("a link for another install does not open this one's review of that number", () => {
-  // The failure this rule exists to prevent: review ids are per host, so
-  // honouring the number would show the wrong review with no sign of it.
+  // The failure this rule exists to prevent, and it is still prevented: review
+  // ids are per host, so honouring the number *as ours* would show the wrong
+  // review with no sign of it.
+  //
+  // What changed at M6 is the remedy. Until then there was no way to reach
+  // another machine from a link, so the honest answer was the home screen; now
+  // the route keeps its host segment and opens that machine's review 2 - which
+  // is a stronger version of the same guarantee, because the wrong review stops
+  // being avoided and starts being unrepresentable.
   const route = routeForLoopbackFragment(`#h=${THEIRS}/review/2/files`, OURS)
 
-  assert.deepEqual(route, { name: 'repositories' })
+  assert.deepEqual(route, { name: 'review', reviewId: 2, tab: 'files', host: THEIRS })
+})
+
+test('and what it produces is a host-scoped location, never a bare one', () => {
+  const route = routeForLoopbackFragment(`#h=${THEIRS}/review/2/files`, OURS)
+
+  assert.equal(hrefFor(route!), `#/h/${THEIRS}/reviews/2/files`)
+  // The assertion that matters: nothing in that string could be read as a local
+  // review 2 by any screen that sees it.
+  assert.notEqual(hrefFor(route!), '#/reviews/2/files')
 })
 
 test('a fragment addressed to us but malformed inside lands somewhere harmless', () => {

--- a/src/web/bootstrap.ts
+++ b/src/web/bootstrap.ts
@@ -12,11 +12,11 @@
  * throws if it is missing. The socket underneath it is still connecting at that
  * moment, which is fine and deliberate - see `carrier.ts` on queueing.
  */
-import { createWebCarrier } from './carrier'
+import { createWebCarrier, type WebCarrier } from './carrier'
 import { createWebShell } from './shell'
 import { isLoopbackFragment, routeForLoopbackFragment } from './loopback-fragment'
 import { hrefFor } from '@shared/routes'
-import { outcomeOf, type BridgeCarrier, type Carrier } from '@shared/rpc'
+import { outcomeOf, type BridgeCarrier } from '@shared/rpc'
 import type { GitWarrenBridge } from '@shared/api'
 
 /**
@@ -32,9 +32,14 @@ import type { GitWarrenBridge } from '@shared/api'
  * The round trip through `toSerialized` and back is the price, and it is a
  * plain object copy on a path that is already a network request.
  */
-function asBridgeCarrier(carrier: Carrier): BridgeCarrier {
+function asBridgeCarrier(carrier: WebCarrier): BridgeCarrier {
   return {
-    request: (method, params, host) => outcomeOf(() => carrier.request(method, params, host))
+    request: (method, params, host) => outcomeOf(() => carrier.request(method, params, host)),
+    // Passed straight through. An event crosses no boundary here - there is no
+    // `contextBridge` in a tab - so unlike the request half there is nothing to
+    // repackage, and the listener the renderer registers is the one the socket
+    // calls.
+    onEvent: (listener) => carrier.onEvent(listener)
   }
 }
 

--- a/src/web/carrier.ts
+++ b/src/web/carrier.ts
@@ -34,8 +34,10 @@
 import { AppError } from '@shared/errors'
 import {
   isReadMethod,
+  isRpcEvent,
   resultOf,
   type Carrier,
+  type RpcEvent,
   type RpcMethod,
   type RpcOutcome,
   type RpcParams,
@@ -68,6 +70,17 @@ export interface WebCarrier extends Carrier {
   connected(): boolean
   /** Notified whenever that changes. Returns an unsubscribe function. */
   onConnectionChange(listener: (connected: boolean) => void): () => void
+  /**
+   * Events pushed by the server on the other end. Returns an unsubscribe.
+   *
+   * Nothing is replayed after a reconnect, deliberately: an event is a hint
+   * that something changed, and a hint about a change that happened while this
+   * tab could not ask anything is worth nothing. What covers that gap is the
+   * revalidation SWR does on its own once requests start succeeding again -
+   * evidence rather than a replayed rumour, which is the same choice
+   * `failAllPending` makes above about requests.
+   */
+  onEvent(listener: (event: RpcEvent) => void): () => void
 }
 
 export function createWebCarrier(): WebCarrier {
@@ -78,6 +91,15 @@ export function createWebCarrier(): WebCarrier {
   const pending = new Map<number, Pending>()
   const queued: RpcRequest[] = []
   const listeners = new Set<(connected: boolean) => void>()
+  /**
+   * Kept apart from `listeners` above, because the two are answers to different
+   * questions and joining them would be the mistake M4.5 spent a slice on. A
+   * connection listener hears about *this tab's socket*; an event listener
+   * hears about *the data on the other end of it*. A socket that drops fires
+   * the first and must not fire the second - there is nothing to re-read while
+   * nothing can be asked.
+   */
+  const eventListeners = new Set<(event: RpcEvent) => void>()
 
   const announce = (connected: boolean): void => {
     for (const listener of listeners) listener(connected)
@@ -124,8 +146,24 @@ export function createWebCarrier(): WebCarrier {
         return
       }
 
+      if (typeof decoded !== 'object' || decoded === null) return
+
+      // An event, which is anything on this socket that is not an answer. The
+      // discriminator is shared (`isRpcEvent`) rather than "has no id", because
+      // the two ends of this socket must agree about what a frame is and one of
+      // them is a Node process - see `shared/rpc.ts`.
+      //
+      // No `host` is stamped. The server on the other end is the install that
+      // served this page, which is what "no host" means everywhere else in this
+      // app; a tab looking at a review on `pc-wsl` learns about *that* machine
+      // from the carrier the core holds to it, not from here.
+      if (isRpcEvent(decoded as RpcEvent)) {
+        for (const listener of eventListeners) listener(decoded as RpcEvent)
+        return
+      }
+
       const response = decoded as RpcResponse
-      if (!response || typeof response.id !== 'number') return
+      if (typeof response.id !== 'number') return
 
       const entry = pending.get(response.id)
       // No entry means an answer to a request this page has already given up
@@ -201,6 +239,10 @@ export function createWebCarrier(): WebCarrier {
     onConnectionChange(listener) {
       listeners.add(listener)
       return () => listeners.delete(listener)
+    },
+    onEvent(listener) {
+      eventListeners.add(listener)
+      return () => eventListeners.delete(listener)
     }
   }
 }

--- a/src/web/loopback-fragment.ts
+++ b/src/web/loopback-fragment.ts
@@ -20,8 +20,8 @@
  *    nothing an outside party wrote is ever assigned to `location.hash`;
  *  - this install's own id is dropped, so the router is handed the route it
  *    would have been handed anyway;
- *  - another install's id lands on the home screen rather than opening *our*
- *    review 4 because the link said 4. Reviews on other hosts arrive in M4.
+ *  - another install's id keeps its host segment, so the link opens *that*
+ *    machine's review 4 and never this one's.
  */
 // Relative rather than through the `@shared` alias, unlike its neighbours in
 // this directory. They are only ever built by Vite; this one is also *run* by
@@ -53,10 +53,39 @@ export function routeForLoopbackFragment(hash: string, instanceId: string): Rout
   // rather than swallowing the click.
   if (!route) return HOME
   if (route.host === undefined) return route
-  if (route.host !== instanceId) return HOME
 
-  // Rebuilt without the key rather than set to undefined - `hrefFor` and route
-  // equality both read the presence of the property, not its value.
-  const { host: _host, ...local } = route
-  return local
+  if (route.host === instanceId) {
+    // Rebuilt without the key rather than set to undefined - `hrefFor` and
+    // route equality both read the presence of the property, not its value.
+    const { host: _host, ...local } = route
+    return local
+  }
+
+  /**
+   * Another install's review, opened where it was clicked.
+   *
+   * Until M6 this landed on the home screen, and the comment said "reviews on
+   * other hosts arrive in M4" - which they did, three milestones ago, while
+   * this line went on discarding them. M4.3, M4.4 and M5.3 each noticed and
+   * each deferred it, reasonably: nothing in those milestones produced a link
+   * that named another machine, because a link is minted by the install that
+   * owns the review and until the tailnet there was no ordinary way for one to
+   * travel.
+   *
+   * The route is handed over *with* its host segment, which is the whole of the
+   * change and is also what preserves the rule this line was written for. The
+   * thing that must never happen is opening our own review 4 because the link
+   * said 4 - ids are per host, so that would show the wrong review with no sign
+   * of it. Keeping the segment makes that structurally impossible: the route
+   * says whose review it is, and `core/hosts/router.ts` sends the reads to that
+   * machine or fails naming it.
+   *
+   * No check that the host is *known*, deliberately. This runs before the app
+   * has asked the core anything, and the question is asynchronous; more to the
+   * point, "that machine is not in your list" is a sentence
+   * `requireInstance` already writes, naming the id - which is the only thing a
+   * person can compare against their Hosts screen. Guessing here would replace
+   * a specific answer with a shrug.
+   */
+  return route
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -35,6 +35,8 @@
     "src/renderer/src/lib/__tests__/fuzzy.test.ts",
     "src/renderer/src/lib/host-reachability.ts",
     "src/renderer/src/lib/__tests__/host-reachability.test.ts",
+    "src/renderer/src/lib/event-scope.ts",
+    "src/renderer/src/lib/__tests__/event-scope.test.ts",
     "src/renderer/src/features/reviews/diff-search.ts",
     "src/renderer/src/features/reviews/__tests__/diff-search.test.ts",
     "src/web/loopback-fragment.ts",


### PR DESCRIPTION
M6 is seven slices, sliced into `docs/across-hosts.md` before any code as M4 and
M5 were, each verified against the real tailnet — Mac, `pc-wsl`, and a phone on
the same tailnet — rather than against a mock.

**The verify line, run end to end on 11 September**

| | |
| --- | --- |
| PC appears on the Mac with no configuration | `hosts.discover` found `pc-wsl.tail688c0c.ts.net` with an empty host list and nothing typed. |
| An agent comment shows on the Mac within a second | **261 ms**, four hops, tagged with the PC's instance id, on the open review with nobody touching the window. |
| Turn the PC off: greyed within seconds | **173 ms**, from the pool noticing its own socket rather than from a failed request. |
| Phone opens a `webUrl`, comments, the agent reads it | The URL serves the PC's web build to a *different device* with no token. **Opening it in a phone browser is the one step nothing here could drive** — recorded as unverified rather than claimed. |

**The slices**

- **M6.0 — spike.** The identity header survives a WebSocket upgrade. And the
  finding that shaped the rest: this tailnet has no HTTPS at all, so a `webUrl`
  spelled by convention would be a URL that does not open.
- **M6.1 — the event channel.** One bus carrying names and never data. The M1
  claim held: `stdio-client.ts` already routed events, so the stdio carrier
  needed no change. The *browser's* carrier silently dropped every event frame.
- **M6.2 — the poke.** The agent's process dials the owner over the port
  `daemon-runtime.json` already publishes. 12 ms. A counter in a file was the
  other candidate and is a poll with extra steps.
- **M6.3 — exposure, identity, `webUrl`.** A second authority, and a *different
  question* on it. The token is about intent where every process is already the
  user; the header is about principal over a network. Neither stands in for the
  other.
- **M6.4 — the listening carrier.** The third `HostConnection`. M5's extraction
  held: the pool gained a `case`.
- **M6.5 — events across a host, `host.state`.** `onStateChange` rendered four
  milestones after it was written, and the delay is the point.
- **M6.6 — discovery.** Proposes, never adds; names the row a machine is already
  in the list as.
- **M6.7 — links across installs, and the words.** Tagline, Known limitations,
  and a `gitwarren://<other-id>/…` link that finally opens something.

**Four things a reviewer might want to look at**

- **Two of the bugs were already documented in this repo.** The socket refused
  the request that caused it to exist — which `web/carrier.ts` names as the
  first thing a socket has that an IPC channel does not, and has since M3. And
  `isAllowedOrigin` accepted either authority's origin on either authority while
  the comment above it said "what neither may be is *the other one*". A prose
  invariant and a predicate drift apart silently.
- **`core/web/handler.ts` answers its first non-`GET` since M3.** Argued in
  `core/web/notify.ts`; three independent locks, each for a different question.
- **A host with no owner has no push, by design.** A daemon spawned over `ssh`
  binds nothing, so an agent there pokes nobody and the poll notices. The remedy
  is the toggle, not a second channel.
- **An estimate in the doc was wrong and is left visible.** Discovery's cost is
  one probe timeout for the whole scan (1046 ms measured), not "single-digit
  millisecond refusals" — a peer with nothing on the port takes ~800 ms to
  refuse on a tailnet, because refusing means being reached first.

**Gap table** — re-read rather than glanced at. Four rows changed; the one that
was not a formality is *Version skew*, where M6 found a mechanism gap:
`hosts.install` decides by version *string*, so a host running a same-versioned
build from before a milestone answers `already-current` and is not upgraded.
`force` was needed twice here.

**Deliberately not in this PR**

- **The site copy.** `gitwarren-site` is a separate repository; the files still
  carrying "no server, no account" are named in the doc.
- **A cross-platform CI job.** `ci.yml` runs ubuntu only. M5 recorded four
  Windows-shaped failures found by a person rather than the suite; M6 adds a
  Linux-shaped one (`tailscale serve` needs `--operator` there and succeeds
  silently as the user on macOS). It is a change to how this project is tested
  rather than to what it does.

Nothing is released. Verified from a local tarball through
`GITWARREN_DAEMON_TARBALL_DIR`, as M4.2–M4.4 and M5.2 did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBM96vTKB5zGTVrLjz32sf
