### PR TITLE
M6 on Windows: run it, and write down what that proved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1663,9 +1663,11 @@ these two are unrelated and both need updating if the branding moves.
   rather than the moment it goes. Keeping a socket open to every host would mean
   connecting to every machine you own, which is the thing the pool exists to
   avoid.
-- **`tailscale serve` needs to be allowed to run.** On Linux it refuses without
+- **On Linux, `tailscale serve` needs to be allowed to run.** It refuses without
   root unless `sudo tailscale set --operator=$USER` has been run once; GitWarren
   reports what Tailscale said rather than silently failing to turn the switch on.
+  macOS and Windows both apply it as the ordinary user, so this is a Linux-only
+  step.
   HTTPS is a tailnet-wide setting: with it off, your machines are reachable over
   plain HTTP inside the tailnet, which WireGuard is encrypting either way.
 - **Repo-relative images are not rendered.** `![](docs/arch.png)` in a comment

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -4035,6 +4035,78 @@ one platform is the honest fix, it is a change to how this project is tested
 rather than to what it does, and it is still deliberately not part of a
 milestone.
 
+**M6 on Windows, done from the Mac against `pc-win`, 11 September.** M6 was
+built and verified entirely from the Mac, against a Linux daemon inside WSL. The
+Windows *app* had never run a line of it, and M5.0's lesson is that "probably
+fine on Windows" was wrong four times in a day. So it was run.
+
+It needed no code changes, which is the headline. What it did find was a
+dependency that had been missing for three milestones, and a security property
+that had been asserted in a comment without ever being measured.
+
+**Everything platform-specific in `core/tailnet.ts` behaves identically.**
+`tailscale.exe` is at the first entry of `KNOWN_PATHS.win32`
+(`C:\Program Files\Tailscale\tailscale.exe`); `status --json` carries every
+field `readTailnetIdentity` reads, trailing dot included; and `serve status
+--json` has the same `TCP`/`Web`/`Handlers`/`Proxy` shape the parser expects.
+
+**`tailscale serve` needs no elevation on Windows**, which makes M6.4's finding
+narrower than it was written. Linux is the odd platform, not Windows: macOS and
+Windows both apply a serve config as the ordinary user, and only Linux requires
+`tailscale set --operator=$USER` first. The error-surfacing added in M6.4 is
+therefore carrying its weight on exactly one of the three, which is still the
+right call - it is the platform most likely to *be* a host.
+
+**Verified end to end through the Windows app's own socket.** Typecheck and
+build clean; **576 tests, 571 pass, 0 fail, 5 skipped** - one more skip than the
+Mac, which is M5.0's symlink test skipping itself. Then, against the running
+Electron app on a scratch data directory: `hosts.tailnet` reported
+`pc-win.tail688c0c.ts.net` and the owner login; the switch turned exposure on
+and answered `http://pc-win.tail688c0c.ts.net:41427/app/` - the *app* mount
+rather than the daemon's `/`, which is the distinction `configureExposure`
+exists for; discovery from Windows found `pc-wsl` and did not propose itself;
+and the Windows app opened a WebSocket carrier to `pc-wsl` and read its two
+repositories over it. From the Mac, that Windows app then answered `/app/` with
+200 and the discovery probe with its instance id.
+
+So all three machines now reach each other, and the carrier has been driven from
+two of them.
+
+**The thing that was actually broken had nothing to do with M6.** The Windows
+checkout could not build at all: `ws` was absent from `node_modules` - 478
+packages present, that one missing - so `tsc` failed on `core/rpc/websocket.ts`
+as well as on M6's files. `ws` has been a dependency since **M3**. That checkout
+has therefore been unable to build anything from M3 onward, and nothing noticed,
+because the only machine that builds this project is the one the developer is
+sitting at and it had not been sitting at that one. `npm install` added two
+packages and everything went green.
+
+`package-lock.json` was unchanged between the Windows checkout's HEAD and
+`main`, which is what made the missing package invisible to the obvious check -
+"dependencies have not changed" is true and "node_modules is complete" does not
+follow from it. That is the fifth platform-shaped failure in this repository
+found by a person rather than by the suite, and the first that was not a bug in
+the code at all but in an environment nobody could see.
+
+**And one property was proved that the code had only been asserting.**
+`core/web/origin.ts` said "`tailscaled` sets the header" and built M6's entire
+authorisation on it, without anything ever having established that `tailscaled`
+*overwrites* a header a client supplies. If it merely added one where none
+existed, any peer on the tailnet could have claimed to be the owner - which
+matters for the case a single-user tailnet does not exercise, a node shared from
+somebody else's account.
+
+Measured: a request from `pc-wsl` to the Mac carrying
+`Tailscale-User-Login: attacker@evil.example` arrived with
+`michal-wrzosek@github`. The client's value is discarded, not merged or
+appended. The header is now documented as measured rather than assumed, in the
+function that depends on it.
+
+It is worth noticing how close this came to being missed. The first observation
+was a `200` where a refusal was expected, from a deliberately forged header sent
+through the proxy - which looks exactly like a hole and is in fact the mechanism
+working. The difference between those two readings is one experiment.
+
 ## Agent setup
 
 One sentence instead of a snippet per harness. Agents know their own

--- a/src/core/web/origin.ts
+++ b/src/core/web/origin.ts
@@ -189,11 +189,26 @@ export const TAILSCALE_USER_HEADER = 'tailscale-user-login'
  *
  * ## What this does and does not protect against
  *
- * `tailscaled` sets the header, and it proxies to loopback - so a *local*
- * process could send the header itself with a `Host` naming the tailnet
- * authority and get in without the token. That grants it nothing: a local
- * process running as the user can already read the 0600 token file and open the
- * database directly, which is the principal `token.ts` says loopback has.
+ * The whole check rests on one property of `tailscale serve`, and it was
+ * measured rather than assumed, because everything here is worthless without
+ * it: **`tailscaled` overwrites a client-supplied `Tailscale-User-Login` with
+ * the authenticated peer's real identity.** A request sent from `pc-wsl` to
+ * this Mac carrying `Tailscale-User-Login: attacker@evil.example` arrived with
+ * `michal-wrzosek@github` - the header the client set was discarded, not merged
+ * or appended. So a peer on the tailnet cannot claim to be the owner, which is
+ * what makes "the same login as the owner" an authorisation decision rather
+ * than a request for a password nobody checks.
+ *
+ * That matters most for a *shared* tailnet node, which is the case this would
+ * fail open on: another person's machine on the same tailnet is refused because
+ * `tailscaled` tells us who they actually are, not because they were polite
+ * about it.
+ *
+ * `tailscaled` also proxies to loopback, so a *local* process could send the
+ * header itself with a `Host` naming the tailnet authority and get in without
+ * the token. That grants it nothing: a local process running as the user can
+ * already read the 0600 token file and open the database directly, which is the
+ * principal `token.ts` says loopback has.
  *
  * The door that matters stays shut. A web page cannot set `Host` and cannot set
  * `Tailscale-User-Login` - both are forbidden header names - so the DNS


### PR DESCRIPTION
M6 was built and verified entirely from the Mac, against a Linux daemon inside
WSL. The Windows *app* had never run a line of it, and M5.0's lesson was that
"probably fine on Windows" was wrong four times in a day. So it was run.

**It needed no code changes.** Everything platform-specific in `core/tailnet.ts`
behaves identically on Windows: `tailscale.exe` is at the first entry of
`KNOWN_PATHS.win32`, and both `status --json` and `serve status --json` have the
shape the parsers expect. Typecheck and build are clean; **576 tests, 571 pass,
0 fail** (one more skip than the Mac, which is M5.0's symlink test skipping
itself).

Driven through the Windows app's own socket: the switch turned exposure on and
reported the `/app/` mount rather than the daemon's `/`; discovery found
`pc-wsl` and did not propose itself; and the Windows app opened a WebSocket
carrier to `pc-wsl` and read its repositories over it. From the Mac, that app
then answered `/app/` with 200 and the discovery probe with its instance id. All
three machines now reach each other and the carrier has been driven from two.

**Three things this changes.**

- **`tailscale serve` needs no elevation on Windows.** Linux is the odd
  platform, not Windows — macOS and Windows both apply a serve config as the
  ordinary user. M6.4 wrote that caveat as though it were general; the README now
  says Linux-only.
- **`ws` was missing from the Windows `node_modules`** — 478 packages present,
  that one absent — so the checkout could not typecheck `core/rpc/websocket.ts`
  either. `ws` has been a dependency since **M3**, so that checkout has been
  unable to build anything from M3 onward and nothing noticed. `package-lock.json`
  was unchanged since its HEAD, which is what made it invisible: *"dependencies
  have not changed"* is true and *"node_modules is complete"* does not follow
  from it. Fifth platform-shaped failure found by a person rather than the suite.
- **A security property was proved that the code had only asserted.**
  `core/web/origin.ts` built M6's entire authorisation on "`tailscaled` sets the
  header" without anything establishing that it *overwrites* one a client
  supplies. If it merely added a header where none existed, any peer on the
  tailnet could have claimed to be the owner — which a single-user tailnet never
  exercises, and which matters for a node shared from someone else's account.
  Measured: a request from `pc-wsl` carrying
  `Tailscale-User-Login: attacker@evil.example` arrived as
  `michal-wrzosek@github`. The client's value is discarded, not merged. The
  comment now says measured rather than assumed.

Worth noting how close that last one came to being missed: the first observation
was a `200` where a refusal was expected, which looks exactly like a hole and is
in fact the mechanism working. One experiment separates those two readings.

Docs only plus one comment — no behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBM96vTKB5zGTVrLjz32sf
