### PR TITLE
Release 0.1.7-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitwarren",
-  "version": "0.1.7-beta.1",
+  "version": "0.1.7-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitwarren",
-      "version": "0.1.7-beta.1",
+      "version": "0.1.7-beta.2",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitwarren",
   "productName": "GitWarren",
-  "version": "0.1.7-beta.1",
+  "version": "0.1.7-beta.2",
   "description": "Code review for your own machines and your own agents",
   "author": {
     "name": "Klarluft B.V.",


### PR DESCRIPTION
Bumps the version to `0.1.7-beta.2` so a test build can be cut from current
`main` — everything since `0.1.7-beta.1`, which is now around fifty commits
behind: M3's web view and CLI, M4's remote hosts over SSH, M5's WSL carrier,
and M6's tailnet live updates and Windows pass. None of that has been
exercised from a real installer yet.

The tag `v0.1.7-beta.2` has been pushed against this branch's commit rather
than waiting on a merge, so the installers are building now. Merging this is
what puts the tagged commit back on `main`; a merge commit (this repository's
habit) keeps the tag reachable, a squash would orphan it.

### The release stays a draft

`release.yml` uploads into a draft, and it should stay one until the beta has
been tried. `gitwarren-site` reads the releases API rather than
`/releases/latest` — deliberately, so it can see a prerelease — which means
publishing this would repoint every download button on gitwarren.com at a
beta. A draft's assets are invisible to that API, and to
`homebrew-tap.yml`'s bump, so nothing moves until someone publishes.

`0.1.7-beta.1` was left as a draft for the same reason, and remains one.

### What the build produces

Signed and notarized on macOS (the `CSC_*` and `APPLE_*` secrets are set);
unsigned on Windows, since no `WINDOWS_CSC_LINK` is configured, so the
installer raises a SmartScreen warning that has to be clicked through. No
`NPM_TOKEN` either, so the npm publish step skips itself rather than putting
a beta on the registry.

Verified against `main` before cutting: lint clean (one pre-existing
`exhaustive-deps` warning), typecheck clean, 541 of 545 tests passing with 4
skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtYeGGtUkxUo1Y44b6nba6
