### PR TITLE
Answer the tailnet toggle at once, and show the wait when there is one

### DIFF
--- a/src/core/tailnet.ts
+++ b/src/core/tailnet.ts
@@ -28,8 +28,9 @@
  * does not open, handed to an agent to hand to a person, with nothing anywhere
  * having warned.
  *
- * So `serveTailnet` asks for HTTPS, falls back to plain HTTP, and **reports
- * which one it got**. It is the rule `core/mcp-launcher.ts` follows for the
+ * So `serveTailnet` asks the machine whether a certificate is even possible,
+ * attempts HTTPS only when it is, falls back to plain HTTP, and **reports which
+ * one it got**. It is the rule `core/mcp-launcher.ts` follows for the
  * launcher path: a fact from the machine that knows it beats a string that is
  * usually right. A tailnet that turns HTTPS on later gets it on the next toggle
  * with no code change, because nothing here decided in advance.
@@ -61,9 +62,13 @@ const run = promisify(execFile)
  * `status` and `serve status` talk to a local daemon over a socket and answer
  * in milliseconds. `serve` itself may have to provision a certificate, which is
  * a network round trip to Let's Encrypt - and on a tailnet without HTTPS
- * enabled it simply never returns, which is exactly what M6.0 found. So the
- * timeout is not a safety net here, it is the mechanism by which "HTTPS is not
- * available" is discovered.
+ * enabled it simply never returns, which is exactly what M6.0 found.
+ *
+ * That "never returns" used to be how `serveTailnet` *learned* HTTPS was off,
+ * which meant every toggle on such a tailnet cost the full twenty seconds
+ * before anything visibly happened. It asks `status` first now, so this is
+ * back to being what a timeout should be: a backstop for a certificate
+ * provision that is genuinely slow, not the happy path.
  */
 const STATUS_TIMEOUT_MS = 5_000
 const SERVE_TIMEOUT_MS = 20_000
@@ -208,6 +213,15 @@ export interface TailnetIdentity {
   login: string
   /** Every other node with the same owner. Unfiltered by OS - see `peers()`. */
   peers: TailnetPeer[]
+  /**
+   * Whether this tailnet can issue a TLS certificate for this node.
+   *
+   * HTTPS is a tailnet-wide switch rather than a property of the machine, and
+   * `status` reports it as `CertDomains`: a list when certificates are on,
+   * null when they are not. It is the M6.0 condition, named in advance instead
+   * of discovered by waiting - see `serveTailnet`.
+   */
+  httpsAvailable: boolean
 }
 
 interface StatusNode {
@@ -243,6 +257,7 @@ export async function readTailnetIdentity(): Promise<TailnetIdentity | null> {
   }
   const status = parsed as {
     BackendState?: string
+    CertDomains?: string[] | null
     Self?: StatusNode
     Peer?: Record<string, StatusNode>
     User?: Record<string, { LoginName?: string }>
@@ -276,7 +291,12 @@ export async function readTailnetIdentity(): Promise<TailnetIdentity | null> {
     })
   }
 
-  return { dnsName: trimDot(self.DNSName), login, peers }
+  return {
+    dnsName: trimDot(self.DNSName),
+    login,
+    peers,
+    httpsAvailable: (status.CertDomains?.length ?? 0) > 0
+  }
 }
 
 /** MagicDNS names are fully qualified and end in a dot. URLs do not. */
@@ -327,11 +347,15 @@ export async function tailnetServeOrigin(port: number): Promise<string | null> {
 /**
  * Put the loopback port on the tailnet, and say where it landed.
  *
- * HTTPS first and HTTP as the fallback, in that order, because the outcome is
- * not knowable in advance - see the header. The HTTPS attempt is bounded by a
- * timeout rather than by an error, since a tailnet without certificates
- * enabled leaves `tailscale serve --https` waiting rather than refusing, which
- * M6.0 found the hard way.
+ * HTTPS first and HTTP as the fallback, in that order, because which one a
+ * given tailnet ends up on is not knowable from this side - see the header.
+ *
+ * What *is* knowable, in milliseconds, is whether HTTPS is possible at all, and
+ * asking is the difference between a toggle that answers at once and one that
+ * appears to do nothing for twenty seconds. A tailnet with certificates off
+ * leaves `tailscale serve --https` waiting rather than refusing (M6.0), so the
+ * attempt is skipped entirely on the tailnets where it can only ever time out.
+ * The timeout stays, for a certificate provision that is real but slow.
  *
  * Answers the origin actually being served, or null if neither worked. Never
  * throws: a settings toggle that failed should say so on the panel, not take a
@@ -340,12 +364,19 @@ export async function tailnetServeOrigin(port: number): Promise<string | null> {
 export async function serveTailnet(port: number): Promise<ServeResult> {
   const target = `http://${LINK_SERVER_HOST}:${port}`
 
-  // `--bg` or the command holds the terminal forever. It is background state on
-  // the machine either way, which is why `tailnetServeOrigin` reads it back
-  // instead of this function remembering what it did.
-  await runTailscale(['serve', '--bg', '--https', String(port), target], SERVE_TIMEOUT_MS)
-  const secure = await tailnetServeOrigin(port)
-  if (secure !== null) return { origin: secure, failure: '' }
+  // `!== false` rather than `=== true`: a null identity means `status` itself
+  // did not answer, and that is not evidence about certificates. Skipping is
+  // for the case the machine positively reported - anything else keeps the old
+  // behaviour, timeout and all.
+  const identity = await readTailnetIdentity()
+  if (identity?.httpsAvailable !== false) {
+    // `--bg` or the command holds the terminal forever. It is background state
+    // on the machine either way, which is why `tailnetServeOrigin` reads it
+    // back instead of this function remembering what it did.
+    await runTailscale(['serve', '--bg', '--https', String(port), target], SERVE_TIMEOUT_MS)
+    const secure = await tailnetServeOrigin(port)
+    if (secure !== null) return { origin: secure, failure: '' }
+  }
 
   const plain = await runTailscale(
     ['serve', '--bg', '--http', String(port), target],

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -32,7 +32,6 @@ import { HostsCard } from './features/hosts/hosts-card'
 import { HostsPage } from './features/hosts/hosts-page'
 import { useRefetchOnReconnect } from './features/hosts/use-reconnect'
 import { SettingsPanel } from './features/settings/settings-panel'
-import { TailnetPanel } from './features/settings/tailnet-panel'
 import { RepositoryDetail } from './features/repositories/repository-detail'
 import { RepositoryList } from './features/repositories/repository-list'
 import { ReviewDetail } from './features/reviews/review-detail'
@@ -155,9 +154,12 @@ function HomeScreen() {
 
       <div className="flex flex-col gap-6">
         <RepositoryList />
+        {/* Hosts carries both directions of "other machines" now - the list of
+            the ones this install reaches, and the switch that lets them reach
+            back. The switch is on that screen rather than here; the card below
+            says whether it is on. */}
         <HostsCard />
         <AgentAccessCard />
-        <TailnetPanel />
         <SettingsPanel />
       </div>
     </>

--- a/src/renderer/src/components/copy-button.tsx
+++ b/src/renderer/src/components/copy-button.tsx
@@ -1,0 +1,90 @@
+/**
+ * A copy button that says it worked, and says so when it did not.
+ *
+ * Shared rather than local because two different features want the same
+ * behaviour for the same reason: they show a string whose whole purpose is to
+ * end up somewhere else - an agent's config file, a phone's address bar - and
+ * the app is the only thing standing between the user and retyping it.
+ *
+ * The refusal path is not theoretical and is why `source` is here. A clipboard
+ * write needs a focused document and a permission the browser may simply not
+ * give; when it is refused, `writeText` rejects and a button that only ever
+ * sets `copied` on success leaves the user pressing it again at a page that
+ * does nothing. So a failure selects the text instead - the same thing the
+ * person was about to do by hand, done for them, with the keystroke named.
+ *
+ * ## Placement belongs to the caller
+ *
+ * The button knows how to copy and nothing about where it sits. The agent
+ * page's snippets park it in a `<pre>`'s corner and the tailnet panel stands it
+ * next to a URL, which is a `className` away in both cases - and baking one of
+ * them in here would make the other one fight it.
+ */
+import { useState, type RefObject } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Tooltip } from '@/components/ui/tooltip'
+
+export function CopyButton({
+  label,
+  text,
+  source,
+  className,
+  children
+}: {
+  label: string
+  text: string
+  /** The element holding `text`, selected when the clipboard says no. */
+  source: RefObject<HTMLElement | null>
+  className?: string
+  children?: React.ReactNode
+}) {
+  const [state, setState] = useState<'idle' | 'copied' | 'select'>('idle')
+
+  async function copy(): Promise<void> {
+    try {
+      await navigator.clipboard.writeText(text)
+      setState('copied')
+      setTimeout(() => setState('idle'), 1800)
+    } catch {
+      const element = source.current
+      if (element) {
+        const range = document.createRange()
+        range.selectNodeContents(element)
+        window.getSelection()?.removeAllRanges()
+        window.getSelection()?.addRange(range)
+      }
+      // Left standing rather than timed out: it is an instruction now, and it
+      // stays true until the next press.
+      setState('select')
+    }
+  }
+
+  const icon = state === 'copied' ? <Check className="text-success" /> : <Copy />
+  const said = state === 'copied' ? 'Copied' : state === 'select' ? 'Selected — press copy' : null
+
+  // Two shapes, one behaviour: a labelled button when it is the action a page
+  // exists for, and the bare icon when it sits beside the thing it copies.
+  if (children !== undefined) {
+    return (
+      <Button onClick={() => void copy()} className={className}>
+        {icon}
+        {said ?? children}
+      </Button>
+    )
+  }
+
+  return (
+    <Tooltip label={said ?? label}>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => void copy()}
+        aria-label={label}
+        className={className}
+      >
+        {icon}
+      </Button>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/features/agent/agent-access-page.tsx
+++ b/src/renderer/src/features/agent/agent-access-page.tsx
@@ -51,12 +51,12 @@
  * its version, its link port) is left out rather than repeated under another
  * machine's heading.
  */
-import { useRef, useState, type RefObject } from 'react'
+import { useRef, useState } from 'react'
 import useSWR from 'swr'
-import { AlertTriangle, ArrowLeft, Check, ChevronDown, Copy, Plug } from 'lucide-react'
+import { AlertTriangle, ArrowLeft, ChevronDown, Plug } from 'lucide-react'
 import { Breakable } from '@/components/breakable'
+import { CopyButton } from '@/components/copy-button'
 import { Button } from '@/components/ui/button'
-import { Tooltip } from '@/components/ui/tooltip'
 import { Card } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tabs, TabsList, TabsPanel, TabsTab } from '@/components/ui/tabs'
@@ -71,84 +71,6 @@ import {
 } from '@shared/agent-setup'
 import { cn } from '@/lib/utils'
 import type { AppInfo, McpLaunchInfo } from '@shared/api'
-
-/**
- * A copy button that says it worked, and says so when it did not.
- *
- * Four of them on this page now - the prompt and one per format - which is
- * exactly when a local `copied` flag stops being adequate: one component per
- * button, each with its own.
- *
- * The refusal path is not theoretical and is why `source` is here. A clipboard
- * write needs a focused document and a permission the browser may simply not
- * give; when it is refused, `writeText` rejects and a button that only ever
- * sets `copied` on success leaves the user pressing it again at a page that
- * does nothing. So a failure selects the text instead - the same thing the
- * person was about to do by hand, done for them, with the keystroke named.
- */
-function CopyButton({
-  label,
-  text,
-  source,
-  className,
-  children
-}: {
-  label: string
-  text: string
-  /** The element holding `text`, selected when the clipboard says no. */
-  source: RefObject<HTMLElement | null>
-  className?: string
-  children?: React.ReactNode
-}) {
-  const [state, setState] = useState<'idle' | 'copied' | 'select'>('idle')
-
-  async function copy(): Promise<void> {
-    try {
-      await navigator.clipboard.writeText(text)
-      setState('copied')
-      setTimeout(() => setState('idle'), 1800)
-    } catch {
-      const element = source.current
-      if (element) {
-        const range = document.createRange()
-        range.selectNodeContents(element)
-        window.getSelection()?.removeAllRanges()
-        window.getSelection()?.addRange(range)
-      }
-      // Left standing rather than timed out: it is an instruction now, and it
-      // stays true until the next press.
-      setState('select')
-    }
-  }
-
-  const icon = state === 'copied' ? <Check className="text-success" /> : <Copy />
-  const said = state === 'copied' ? 'Copied' : state === 'select' ? 'Selected — press copy' : null
-
-  // Two shapes, one behaviour: the prompt's is a labelled button because it is
-  // the action the page exists for, and a snippet's is the icon in the corner.
-  if (children !== undefined) {
-    return (
-      <Button onClick={() => void copy()} className={className}>
-        {icon}
-        {said ?? children}
-      </Button>
-    )
-  }
-
-  return (
-    <Tooltip label={said ?? label}>
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={() => void copy()}
-        aria-label={label}
-        className={cn('absolute right-1.5 top-1.5', className)}
-      >
-        {icon}
-      </Button>
-    </Tooltip>
-  )
-}
 
 /**
  * One format, its own `<pre>` and its own copy button.
@@ -178,6 +100,7 @@ function SnippetPanel({ snippet }: { snippet: AgentConfigSnippet }) {
           label={`Copy the ${snippet.label} configuration`}
           text={snippet.text}
           source={textRef}
+          className="absolute right-1.5 top-1.5"
         />
       </div>
     </TabsPanel>

--- a/src/renderer/src/features/hosts/hosts-card.tsx
+++ b/src/renderer/src/features/hosts/hosts-card.tsx
@@ -5,26 +5,51 @@
  * one list of places, and a second thing that unfolds in place would break
  * that.
  *
- * It shows a count, and only a count. Reading how many hosts there are is a
- * local SQLite read; reading whether any of them is *up* is a connection to
- * every machine in the list, which is not a price the home screen should pay
- * for a subtitle. The Hosts screen is where reachability is asked for, by
- * somebody who went there to ask.
+ * It shows a count, and it shows whether this machine is reachable - two facts
+ * that cost nothing, next to one that would cost a great deal. Reading how many
+ * hosts there are is a local SQLite read, and `hosts.tailnet` is a `tailscale`
+ * call the home screen was already making when the switch itself lived here; it
+ * is the same SWR key, so moving the control to the Hosts screen left the cost
+ * where it was rather than adding one. Reading whether any *host* is up is the
+ * expensive one - a connection attempt per machine in the list - and that stays
+ * on the Hosts screen, asked for by somebody who went there to ask.
+ *
+ * The tailnet line is state without its control, deliberately. The switch is
+ * one click away on the screen that now owns both directions of this, and a
+ * second copy of it here would be two controls that can disagree for as long as
+ * one of them is mid-flight.
  */
 import { ChevronRight, Server } from 'lucide-react'
 import useSWR from 'swr'
 import { Card } from '@/components/ui/card'
 import { api, CACHE_KEYS } from '@/lib/api'
 import { navigate } from '@/lib/router'
+import { useTailnet } from './use-tailnet'
 
 export function HostsCard() {
   const { data: hosts } = useSWR(CACHE_KEYS.hosts, () => api.hosts.list())
+  const { data: tailnet } = useTailnet()
 
   function open(): void {
     navigate({ name: 'hosts' })
   }
 
   const count = hosts?.length ?? 0
+
+  // The host name alone rather than the URL: this is a subtitle, and the thing
+  // worth copying lives next to the switch that turns it on. `dnsName` is what
+  // the machine calls itself on the tailnet, which is the recognisable half.
+  const reachable = tailnet?.exposed === true ? tailnet.dnsName : null
+
+  // The long invitation is for a card that has nothing else to say. Once there
+  // is a count or an address, it is a sentence in the way of two facts - and
+  // the Hosts screen makes the same offer with a button under it.
+  const outbound =
+    count > 0
+      ? `${count} machine${count === 1 ? '' : 's'} over ssh`
+      : reachable === null
+        ? 'Review code on another machine over ssh — a PC’s WSL, a VPS, a build box'
+        : 'No hosts yet'
 
   return (
     <Card
@@ -44,10 +69,16 @@ export function HostsCard() {
       <Server className="size-4 shrink-0 text-muted-foreground" />
       <div className="min-w-0 flex-1">
         <p className="text-sm font-medium">Hosts</p>
+        {/* Wraps rather than truncates: the address is the half most likely to
+            run off the end, and half a hostname is worse than two lines. */}
         <p className="text-xs text-muted-foreground">
-          {count === 0
-            ? 'Review code on another machine over ssh — a PC’s WSL, a VPS, a build box'
-            : `${count} machine${count === 1 ? '' : 's'} reachable over ssh`}
+          {outbound}
+          {reachable !== null && (
+            <>
+              {' · reachable at '}
+              <span className="whitespace-nowrap font-mono">{reachable}</span>
+            </>
+          )}
         </p>
       </div>
       <ChevronRight className="size-4 shrink-0 text-muted-foreground" />

--- a/src/renderer/src/features/hosts/hosts-page.tsx
+++ b/src/renderer/src/features/hosts/hosts-page.tsx
@@ -20,6 +20,23 @@
  * them. The install runs wherever the core runs; that it might be a different
  * machine from the browser is exactly the point of the milestone.
  *
+ * ## Both directions of "another machine"
+ *
+ * The list is outbound: machines this install reaches over ssh. The tailnet
+ * switch above it is inbound: whether this install can be reached. They were on
+ * different screens, which split one relationship in half.
+ *
+ * This screen is where they belong because the subject was already the same.
+ * The Hosts route is `{ name: 'hosts'; host?: undefined }` in
+ * `shared/routes.ts` - never host-scoped, because `hosts.*` is the property of
+ * the install a person is driving - so "this machine, and the machines around
+ * it" is the whole topic here and nowhere else.
+ *
+ * The two headings are a pair or they are nothing. A machine with no Tailscale
+ * has no switch (rule 3: never a dependency), and labelling a lone list "Other
+ * machines" would be answering a question the screen no longer asks - so both
+ * headings are absent in that case and the screen reads exactly as it did.
+ *
  * ## One thing at a time
  *
  * `busy` holds a single host id rather than a set. Two installs at once would
@@ -43,13 +60,18 @@ import { HostCard } from './host-card'
 import { HostFormDialog } from './host-form-dialog'
 import { InstallResultDialog, type InstallOutcome } from './install-result-dialog'
 import { RemoveHostDialog } from './remove-host-dialog'
+import { TailnetPanel } from './tailnet-panel'
 import { useHostMutations, useHosts } from './use-hosts'
+import { useTailnet } from './use-tailnet'
 import type { HostWithState } from '@shared/schemas'
 
 export function HostsPage() {
   const { hosts, error, isLoading, isRefreshing, refresh } = useHosts()
   const { probeHost, installOnHost } = useHostMutations()
   const { data: info } = useSWR(CACHE_KEYS.appInfo, () => api.system.appInfo())
+  // Only to decide whether there are sections. The panel reads the same key.
+  const { data: tailnet } = useTailnet()
+  const sectioned = tailnet?.available === true
 
   const [formOpen, setFormOpen] = useState(false)
   const [editing, setEditing] = useState<HostWithState | undefined>(undefined)
@@ -166,6 +188,11 @@ export function HostsPage() {
         </div>
       </div>
 
+      {sectioned && <SectionHeading>This machine</SectionHeading>}
+      <TailnetPanel />
+
+      {sectioned && <SectionHeading>Other machines</SectionHeading>}
+
       {/* Above the list rather than below it: a machine you have not added yet
           is the thing you came here to do something about, and a proposal
           under twelve rows is a proposal nobody sees. It draws nothing at all
@@ -207,6 +234,25 @@ export function HostsPage() {
       />
       <InstallResultDialog outcome={outcome} onClose={() => setOutcome(null)} />
     </section>
+  )
+}
+
+/**
+ * The label over each half of the screen.
+ *
+ * A `<h2>` rather than a styled `<p>`, because it is the thing a screen reader
+ * uses to skip between the switch and the list, which is exactly the navigation
+ * the headings were added to provide for everybody else.
+ *
+ * `-mb-1` against the section's `gap-4`: a heading should sit nearer the thing
+ * it names than the thing above it, and the grid gap alone puts it exactly
+ * halfway between.
+ */
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="-mb-1 mt-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      {children}
+    </h2>
   )
 }
 

--- a/src/renderer/src/features/hosts/tailnet-panel.tsx
+++ b/src/renderer/src/features/hosts/tailnet-panel.tsx
@@ -9,6 +9,20 @@
  * in a tab as in the window - more so, since the person running `gitwarren
  * serve` on a headless box is the one who most needs it.
  *
+ * ## Why it lives under `hosts/` and renders on the Hosts screen
+ *
+ * It used to sit on the home screen next to the login-item switch, which put
+ * the two halves of one relationship on opposite ends of a page. A host is a
+ * machine this install reaches; this switch is whether this install can *be*
+ * reached. Same subject - this machine - opposite directions.
+ *
+ * `shared/routes.ts` had already committed to that subject: the Hosts route is
+ * `{ name: 'hosts'; host?: undefined }`, never host-scoped, because `hosts.*`
+ * is the property of the install a person is driving and even a hand-written
+ * `#/h/<id>/hosts` resolves here. So the Hosts screen is the one place where
+ * "this machine, and the machines around it" is already the whole topic, and a
+ * reachability switch anywhere else was the odd one out.
+ *
  * ## It says what the machine says, not what was asked for
  *
  * `tailscale serve` is machine state. It survives a GitWarren restart, and the
@@ -60,17 +74,17 @@
  * pressed.
  */
 import { useRef, useState } from 'react'
-import useSWR from 'swr'
 import { Globe, Loader2 } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import { Card } from '@/components/ui/card'
 import { Breakable } from '@/components/breakable'
 import { CopyButton } from '@/components/copy-button'
-import { api, CACHE_KEYS } from '@/lib/api'
+import { api } from '@/lib/api'
 import { errorMessage } from '@/lib/errors'
+import { useTailnet } from './use-tailnet'
 
 export function TailnetPanel() {
-  const { data: tailnet, mutate } = useSWR(CACHE_KEYS.tailnet, () => api.hosts.tailnet())
+  const { data: tailnet, mutate } = useTailnet()
   // Null when nothing is in flight; otherwise what was asked for, which is the
   // only thing the panel is entitled to claim before the machine answers.
   const [pending, setPending] = useState<boolean | null>(null)

--- a/src/renderer/src/features/hosts/use-tailnet.ts
+++ b/src/renderer/src/features/hosts/use-tailnet.ts
@@ -1,0 +1,22 @@
+/**
+ * This machine's tailnet reachability, read once for the three things that
+ * want it.
+ *
+ * The switch on the Hosts screen needs it to draw itself, the section headings
+ * around that switch need it to know whether there is a section at all, and the
+ * Hosts card on the home screen needs it for its subtitle. One SWR key rather
+ * than three reads: `hosts.tailnet` shells out to `tailscale`, and three
+ * components asking separately would be three process spawns to render one
+ * screen.
+ *
+ * A hook rather than each component calling `useSWR` with the same key is
+ * mostly about the key. SWR would dedupe them anyway; what it would not do is
+ * stop the fourth caller from spelling the fetcher slightly differently.
+ */
+import useSWR, { type SWRResponse } from 'swr'
+import { api, CACHE_KEYS } from '@/lib/api'
+import type { TailnetExposure } from '@shared/schemas'
+
+export function useTailnet(): SWRResponse<TailnetExposure> {
+  return useSWR(CACHE_KEYS.tailnet, () => api.hosts.tailnet())
+}

--- a/src/renderer/src/features/settings/tailnet-panel.tsx
+++ b/src/renderer/src/features/settings/tailnet-panel.tsx
@@ -25,6 +25,32 @@
  * the switch is the one the machine reported - `http` or `https`, whichever
  * happened.
  *
+ * ## The wait is shown, because the switch cannot show it
+ *
+ * The consequence of not being optimistic is that between the click and the
+ * machine's answer the switch sits in its old position, and a switch that has
+ * not moved is indistinguishable from a click that did not land. `tailscale
+ * serve` is fast when the tailnet has certificates and slow when it has to
+ * provision one, so the gap is real either way and the panel says what is
+ * happening in it rather than leaving the user to guess. Same `Loader2` the
+ * host dialogs use, for the same reason.
+ *
+ * ## The URL is a thing to use, not a thing to read
+ *
+ * It was prose - "Open it at <url>" - and prose is the one shape that serves
+ * neither of the two things anybody does with it. The address is for *another*
+ * device: a phone, the laptop in the other room. So the first affordance is
+ * copy, because the trip it has to make is into a message or a password
+ * manager, and a URL you cannot select is a URL you retype by hand off a
+ * screen, `tail688c0c` and all.
+ *
+ * The second is the link itself, for the one question this machine can answer
+ * on its own - whether the thing works at all. `target="_blank"` is what makes
+ * that open the real browser rather than navigating the app window away from
+ * the app: the main process catches it in `setWindowOpenHandler` and hands it
+ * to `shell.openExternal`. In a browser tab it is simply a link, which is the
+ * same reason `components/markdown.tsx` spells its anchors that way.
+ *
  * ## Absent rather than disabled when there is no Tailscale
  *
  * Rule 3: Tailscale is discovery and identity, never a dependency. A machine
@@ -33,19 +59,25 @@
  * argument `ShellCapabilities` makes about a control that explains itself when
  * pressed.
  */
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import useSWR from 'swr'
-import { Globe } from 'lucide-react'
+import { Globe, Loader2 } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
 import { Card } from '@/components/ui/card'
 import { Breakable } from '@/components/breakable'
+import { CopyButton } from '@/components/copy-button'
 import { api, CACHE_KEYS } from '@/lib/api'
 import { errorMessage } from '@/lib/errors'
 
 export function TailnetPanel() {
   const { data: tailnet, mutate } = useSWR(CACHE_KEYS.tailnet, () => api.hosts.tailnet())
-  const [busy, setBusy] = useState(false)
+  // Null when nothing is in flight; otherwise what was asked for, which is the
+  // only thing the panel is entitled to claim before the machine answers.
+  const [pending, setPending] = useState<boolean | null>(null)
+  const busy = pending !== null
   const [failure, setFailure] = useState<string | null>(null)
+  // The anchor below, so a refused clipboard can select it instead.
+  const webRootRef = useRef<HTMLAnchorElement>(null)
 
   // Nothing until the first read lands, and nothing at all on a machine with no
   // Tailscale. A switch that appeared and then vanished would be worse than one
@@ -53,18 +85,19 @@ export function TailnetPanel() {
   if (!tailnet?.available) return null
 
   async function toggle(next: boolean): Promise<void> {
-    setBusy(true)
+    setPending(next)
     setFailure(null)
     try {
       // No optimistic value, deliberately - see the header. `tailscale serve`
       // can take a second or two, and showing "on" during it would be showing
-      // the request rather than the machine.
+      // the request rather than the machine. The pending line below is how the
+      // user knows the click landed without being told an outcome yet.
       await mutate(api.hosts.setTailnetExposure({ exposed: next }), { revalidate: false })
     } catch (error) {
       setFailure(errorMessage(error))
       void mutate()
     } finally {
-      setBusy(false)
+      setPending(null)
     }
   }
 
@@ -87,17 +120,38 @@ export function TailnetPanel() {
         />
       </div>
 
-      {tailnet.exposed && tailnet.webRoot ? (
-        // Shown rather than described, because it is the thing a person types
-        // into a phone. `Breakable` so it wraps at its separators and stays
-        // selectable at 390 px - the rule M3.5 set and M4.5 found the hard
-        // edge of.
-        <p className="text-xs text-muted-foreground">
-          Open it at{' '}
-          <span className="font-mono">
-            <Breakable text={tailnet.webRoot} />
-          </span>
+      {busy ? (
+        // Which direction, because "putting it on" and "taking it off" fail
+        // differently and the user is waiting on one specific thing.
+        <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Loader2 className="size-3 shrink-0 animate-spin" />
+          {pending ? 'Putting this machine on your tailnet…' : 'Taking it off your tailnet…'}
         </p>
+      ) : null}
+
+      {!busy && tailnet.exposed && tailnet.webRoot ? (
+        <div className="flex items-center gap-1">
+          {/* `Breakable` so it wraps at its separators and stays selectable at
+              390 px - the rule M3.5 set and M4.5 found the hard edge of. The
+              anchor is the same element the copy button selects when the
+              clipboard is refused, which is why it holds the ref. */}
+          <a
+            ref={webRootRef}
+            href={tailnet.webRoot}
+            target="_blank"
+            rel="noreferrer noopener"
+            data-selectable
+            className="min-w-0 flex-1 font-mono text-xs text-primary underline underline-offset-2 hover:no-underline"
+          >
+            <Breakable text={tailnet.webRoot} />
+          </a>
+          <CopyButton
+            label="Copy this machine's tailnet address"
+            text={tailnet.webRoot}
+            source={webRootRef}
+            className="shrink-0"
+          />
+        </div>
       ) : null}
 
       {failure ? <p className="text-xs text-destructive">{failure}</p> : null}


### PR DESCRIPTION
Turning **Reachable on your tailnet** on did nothing visible for twenty seconds, then came good. Three things, found while chasing that one symptom.

## 1. The twenty seconds were self-inflicted

`serveTailnet` attempted `tailscale serve --bg --https` first and fell back to HTTP. On a tailnet with certificates switched off that command **hangs rather than refusing** — the M6.0 case the module header already describes — so `SERVE_TIMEOUT_MS` was not a safety net. It *was* the mechanism by which "HTTPS is unavailable" got discovered, on every toggle, forever.

Measured against a real `tailscale.exe` on a tailnet with HTTPS off (`CertDomains: null`):

```
serve --bg --https (20s cap): 20021ms  killed=true SIGTERM
serve status --json:             14ms
serve --bg --http:               20ms
serve status --json:             10ms
status --json:                   12ms
```

Everything but the doomed attempt is tens of milliseconds. Nobody was waiting on a network; they were waiting on a `SIGTERM`.

`tailscale status --json` already carries the answer as `CertDomains` — a list when the tailnet can issue certificates, null when it cannot — and it answers in 12 ms. `readTailnetIdentity` now reports it as `httpsAvailable`, and `serveTailnet` skips an attempt that can only ever time out. Same function, same machine, after:

```
httpsAvailable = false
serveTailnet:   43ms -> {"origin":"http://pc-win.tail688c0c.ts.net:41999"}
unserveTailnet: 41ms -> stillServed=false
```

**20,150 ms → 43 ms.**

The test is `identity?.httpsAvailable !== false` rather than `=== true` on purpose: a null identity means `status` itself did not answer, which is not evidence about certificates, and that case keeps the old behaviour, timeout and all. A tailnet that turns HTTPS on later still gets it on the next toggle, because nothing decided in advance. The 20 s bound stays for what a timeout is actually for — a certificate provision that is real but slow.

## 2. The rest of the wait was invisible

The panel is deliberately not optimistic: it shows what the machine reported, not what was asked for. The consequence is that the switch stays where it was until the answer lands, and a switch that has not moved is indistinguishable from a click that did not register. `busy` only set `disabled`, so the entire feedback was 50% opacity.

It now names which direction is in flight, using the `Loader2` the host dialogs already use. This still earns its place after fix 1 — a tailnet that *does* have certificates has to provision one, and that is a genuine round trip to Let's Encrypt.

## 3. And the URL was neither copyable nor clickable

"Open it at `<url>`" was prose, and prose serves neither of the two things anybody does with that address. `body { user-select: none }` in `index.css` meant it could not even be selected — so a URL whose entire purpose is to reach *another* device could only be retyped by hand off a screen, `tail688c0c` and all.

It is now the anchor it always should have been. `target="_blank"` is what routes the click to the real browser: the main process catches it in `setWindowOpenHandler` and hands it to `shell.openExternal`, the same spelling `components/markdown.tsx` uses. In a browser tab it is simply a link. Beside it is a copy button, because copy is the affordance that matches the trip the string actually has to make — into a message, or a phone's address bar.

That button is the one from `agent-access-page.tsx`, lifted to `components/copy-button.tsx` rather than written a fourth time. It already handles a refused clipboard by selecting the text instead, which is exactly as relevant here. Placement moved out of the component and to its two call sites, since the agent page parks it in a `<pre>`'s corner and this one stands it next to a link.

Checked as rendered at 420 px, at 390 px mid-toggle, and at 300 px where the URL wraps to two lines and the button stays put.

## 4. Hosts and the tailnet switch are one screen now

Second commit, added on request. The list of machines this install reaches was on one screen and the switch letting them reach back was on another — one relationship, split in half.

`shared/routes.ts` had already picked the screen. The Hosts route is `{ name: 'hosts'; host?: undefined }` — never host-scoped, because `hosts.*` is the property of the install a person is driving, and even a hand-written `#/h/<id>/hosts` resolves there. So "this machine, and the machines around it" was already that screen's whole topic, and a reachability switch anywhere else was the odd one out.

The switch moves there under a **This machine** heading, with the discovered-peers proposal and the list under **Other machines**. `tailnet-panel.tsx` moves to `features/hosts/` to match where it renders.

The two headings are a pair or they are nothing. A machine with no Tailscale has no switch — rule 3, never a dependency — and labelling a lone list "Other machines" would answer a question that screen no longer asks, so both are absent there and it reads exactly as it did before.

**The home screen keeps its shape.** Its order is places then controls — Repositories, Hosts, Agent Access, then the switches — and `hosts-card.tsx` says so in its header. Sliding the tailnet card up between Hosts and Agent Access would have grouped the two things by breaking that. So the card carries the state instead:

> 🖥 **Hosts** — 2 machines over ssh · reachable at `pc-win.tail688c0c.ts.net`

State without its control, deliberately: the switch is one click away on the screen that now owns both directions, and a second copy here would be two controls that can disagree for as long as one is mid-flight.

That subtitle costs nothing new. `hosts.tailnet` is a `tailscale` call the home screen was already making when the panel lived there, and it is the same SWR key — `use-tailnet.ts` exists so the three callers share it rather than spawning three processes to draw one screen. The expensive read stays put: whether any *host* is up is a connection attempt per machine, and that is still asked for only by somebody who opened the Hosts screen to ask.

## Checks

All four CI checks run locally on Windows, on both commits: `npm run lint` (clean — the one warning is pre-existing in `repository-detail.tsx`, untouched here), `npm run typecheck`, `npm run build`, `npm test` (571 pass, 0 fail, 5 pre-existing win32 skips).

**Not included:** tests for `src/core/tailnet.ts`, which has none today. The useful test here needs a fake `tailscale` binary on PATH, and that scaffolding is a larger piece of work than this fix — worth its own issue rather than being smuggled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jwhx9fYpvFPoMaVT2WiHKN



