### PR TITLE
Pin the file header to the top while you read a long diff

### DIFF
--- a/src/renderer/src/features/reviews/diff-find-bar.tsx
+++ b/src/renderer/src/features/reviews/diff-find-bar.tsx
@@ -17,7 +17,8 @@ import {
   useMemo,
   useRef,
   useState,
-  type KeyboardEvent as ReactKeyboardEvent
+  type KeyboardEvent as ReactKeyboardEvent,
+  type Ref
 } from 'react'
 import { ChevronDown, ChevronUp, Search, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -180,7 +181,14 @@ export function useDiffFind(files: readonly FileDiff[]): DiffFind {
   }
 }
 
-export function DiffFindBar({ find }: { find: DiffFind }) {
+export function DiffFindBar({
+  find,
+  ref
+}: {
+  find: DiffFind
+  /** So the tab can measure how much room the bar takes at the top of the scroller. */
+  ref?: Ref<HTMLDivElement>
+}) {
   const { matches, index, query, term, truncated, fileCount, bindInput } = find
   const searching = term !== ''
   const none = searching && matches.length === 0
@@ -206,7 +214,10 @@ export function DiffFindBar({ find }: { find: DiffFind }) {
   return (
     // Sticky, so the count and the arrows stay reachable while the diff scrolls
     // past underneath them - which is the whole time a search is being used.
-    <div className="sticky top-0 z-20 flex items-center gap-2 rounded-lg border border-border bg-card/95 px-2 py-1.5 shadow-sm backdrop-blur">
+    <div
+      ref={ref}
+      className="sticky top-0 z-20 flex items-center gap-2 rounded-lg border border-border bg-card/95 px-2 py-1.5 shadow-sm backdrop-blur"
+    >
       <Search className="ml-1 size-4 shrink-0 text-muted-foreground" />
 
       <Input

--- a/src/renderer/src/features/reviews/diff-view.tsx
+++ b/src/renderer/src/features/reviews/diff-view.tsx
@@ -438,14 +438,47 @@ export function FileDiffCard({
     setExpanded(true)
   }
 
+  /**
+   * The sections of the body, in the order they are drawn.
+   *
+   * Named rather than asked inline, because the rules between them are now the
+   * header's to draw. The header is sticky, so a line belonging to the *top* of
+   * the first section scrolls up underneath it and leaves the file name sitting
+   * straight on the code; the header carries its own bottom rule instead, and
+   * each section below asks only whether something precedes it.
+   */
+  const showsOrphans = expanded && orphans.length > 0 && comments !== undefined
+  const showsDiff = expanded && hasBody
+  const showsImageDiff = expanded && showsImage && source !== undefined
+  const showsBinaryNote = expanded && !hasBody && file.isBinary && !showsImage
+  const showsBody = showsOrphans || showsDiff || showsImageDiff || showsBinaryNote
+
   return (
-    <Card className="overflow-hidden">
+    // `clip` rather than `hidden`: both cut the diff to the card's rounded
+    // corners, but `hidden` makes the card a scroll container of its own, and a
+    // scroll container that cannot scroll is a scrollport the sticky header
+    // below would be pinned inside - never moving, never sticking.
+    <Card className="overflow-clip">
       {/* Not one big button any more: the header carries actions of its own,
           and a button inside a button is not a thing the DOM allows. */}
       {/* Wraps, and the path keeps a floor of a few inches: on a narrow window
           the badges drop to a line of their own rather than squeezing the path
           into a column one character wide. */}
-      <div className="flex w-full flex-wrap items-center gap-1 pr-2">
+      <div
+        className={cn(
+          // Sticky, so a file taller than the window never leaves the reader
+          // wondering which file they are in: the path, the stat, the reviewed
+          // checkbox and the actions stay in reach the whole way down it. It
+          // sticks *inside its own card*, so it gives way to the next file's
+          // header rather than outliving the diff it names.
+          //
+          // `--diff-sticky-top` is whatever the tab has parked above it - the
+          // find bar, when that is open. On its own the header rests against
+          // the top of the scroller.
+          'sticky top-[var(--diff-sticky-top,0px)] z-10 flex w-full flex-wrap items-center gap-1 bg-card pr-2',
+          showsBody && 'border-b border-border'
+        )}
+      >
         <div className="flex min-w-0 grow basis-64 items-center gap-1">
           {/* The toggle takes only the room the path needs rather than the whole
               row, so the copy button can sit against the end of the path and
@@ -558,8 +591,8 @@ export function FileDiffCard({
         </div>
       </div>
 
-      {expanded && orphans.length > 0 && comments && (
-        <div className="flex flex-col gap-3 border-t border-border bg-muted/20 p-3">
+      {showsOrphans && comments && (
+        <div className="flex flex-col gap-3 bg-muted/20 p-3">
           <p className="text-xs text-muted-foreground">
             {orphans.length === 1 ? 'This comment is' : 'These comments are'} on code that is not in
             the diff any more.
@@ -595,8 +628,8 @@ export function FileDiffCard({
         </div>
       )}
 
-      {expanded && hasBody && (
-        <div className="border-t border-border">
+      {showsDiff && (
+        <div className={cn(showsOrphans && 'border-t border-border')}>
           {/* `@container` makes this element an inline-size container, which is
               what lets a comment inside it be sized to the *visible* width
               rather than to the width of the scrolled code. */}
@@ -661,12 +694,19 @@ export function FileDiffCard({
         </div>
       )}
 
-      {expanded && showsImage && source && (
-        <ImageDiff file={file} reviewId={source.reviewId} changes={source.changes} />
+      {showsImageDiff && source && (
+        <div className={cn((showsOrphans || showsDiff) && 'border-t border-border')}>
+          <ImageDiff file={file} reviewId={source.reviewId} changes={source.changes} />
+        </div>
       )}
 
-      {expanded && !hasBody && file.isBinary && !showsImage && (
-        <p className="border-t border-border px-3 py-3 text-xs text-muted-foreground">
+      {showsBinaryNote && (
+        <p
+          className={cn(
+            'px-3 py-3 text-xs text-muted-foreground',
+            showsOrphans && 'border-t border-border'
+          )}
+        >
           Binary file — no text diff to show.
         </p>
       )}

--- a/src/renderer/src/features/reviews/image-diff.tsx
+++ b/src/renderer/src/features/reviews/image-diff.tsx
@@ -65,7 +65,9 @@ export function ImageDiff({
   return (
     <div
       className={cn(
-        'grid gap-3 border-t border-border p-3',
+        // The rule above the panes belongs to whatever puts them there:
+        // in a file card that is the sticky header, which draws its own.
+        'grid gap-3 p-3',
         // One pane spans the width; two share it, and only once there is room
         // for both to stay legible - a narrow window stacks them instead.
         both && 'md:grid-cols-2'

--- a/src/renderer/src/features/reviews/review-files-tab.tsx
+++ b/src/renderer/src/features/reviews/review-files-tab.tsx
@@ -10,7 +10,14 @@
  * the edit you are making right now is a question you ask per visit, and each
  * answer is cached under its own SWR key so switching back is instant.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties
+} from 'react'
 import {
   AlertCircle,
   ArrowDown,
@@ -127,6 +134,37 @@ function scrollParent(element: HTMLElement): HTMLElement {
     if (overflow === 'auto' || overflow === 'scroll') return node
   }
   return document.documentElement
+}
+
+/**
+ * The gap the tab leaves between the blocks stacked down it - `gap-3`.
+ *
+ * Written out here because the sticky offset is arithmetic done in JS: a header
+ * parking directly against the underside of the find bar reads as one welded
+ * bar, and the gap it rests below is the same one it would have had in the flow.
+ */
+const STICKY_GAP = '0.75rem'
+
+/**
+ * The height of an element as it changes, for whoever has to leave room for it.
+ *
+ * A ref alone would not do: the bar appears and disappears, and its height is
+ * whatever its own content and the reader's font size make it, so the number
+ * has to be measured rather than assumed and has to arrive as state.
+ */
+function useMeasuredHeight(): [(node: HTMLDivElement | null) => void, number] {
+  const [node, setNode] = useState<HTMLDivElement | null>(null)
+  const [height, setHeight] = useState(0)
+
+  useEffect(() => {
+    if (node === null) return
+    const observer = new ResizeObserver(() => setHeight(node.offsetHeight))
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [node])
+
+  // An unmounted element takes up no room, whatever the last reading of it was.
+  return [setNode, node === null ? 0 : height]
 }
 
 /**
@@ -387,6 +425,21 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
   const paths = useMemo(() => files.map((file) => file.path), [files])
   const activePath = useActiveFile(paths)
   const find = useDiffFind(files)
+  const [bindFindBar, findBarHeight] = useMeasuredHeight()
+
+  /**
+   * Where a sticky thing in this tab parks, and how far below the top of the
+   * scroller a scrolled-to card comes to rest.
+   *
+   * Both shift down by the find bar when it is open, because it is sticky too
+   * and sits above everything else: a file header pinned to the top of the
+   * scroller would spend the whole search hidden behind it.
+   */
+  const stickyTop = find.open ? `calc(${findBarHeight}px + ${STICKY_GAP})` : '0px'
+  const stickyStyle = {
+    '--diff-sticky-top': stickyTop,
+    '--diff-scroll-top': `calc(${stickyTop} + 0.5rem)`
+  } as CSSProperties
 
   /**
    * The fingerprint of every file *as it is being shown*, which is what a
@@ -820,7 +873,7 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
         </div>
       </div>
 
-      {find.open && <DiffFindBar find={find} />}
+      {find.open && <DiffFindBar ref={bindFindBar} find={find} />}
 
       {changes !== 'committed' && data.workingTree?.isDirty && (
         <WorkingTreeBanner workingTree={data.workingTree} />
@@ -919,7 +972,7 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
       ) : (
         // `items-start` so the tree can stick to the top of the viewport while
         // the diff beside it scrolls; a stretched column would never stick.
-        <div className="flex items-start gap-4">
+        <div className="flex items-start gap-4" style={stickyStyle}>
           {listOpen && (
             // Two shapes, one element. Wide: a sticky sidebar that keeps its
             // own place while the diff scrolls past it, wider still where there
@@ -933,7 +986,7 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
                 'rounded-lg border border-border bg-card/50 px-1',
                 narrow
                   ? 'w-full'
-                  : 'sticky top-2 max-h-[calc(100dvh-6rem)] w-56 shrink-0 overflow-y-auto xl:w-64 2xl:w-72'
+                  : 'sticky top-[var(--diff-scroll-top,0.5rem)] max-h-[calc(100dvh-6rem)] w-56 shrink-0 overflow-y-auto xl:w-64 2xl:w-72'
               )}
             >
               <ChangedFilesTree
@@ -961,7 +1014,7 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
                 key={`${file.oldPath ?? ''}:${file.path}`}
                 id={fileDomId(file.path)}
                 data-file-path={file.path}
-                className="scroll-mt-2"
+                className="scroll-mt-[var(--diff-scroll-top,0.5rem)]"
               >
                 <FileDiffCard
                   // Remounted when the view changes: that is a different diff


### PR DESCRIPTION
A file in **Files changed** can be several screens tall, and once its header has scrolled away there is nothing on screen saying which file you are reading — or offering the reviewed checkbox, the open-in-editor actions and the copy-path button that live on it. The header now sticks, the way GitHub's does, and gives way to the next file's header rather than outliving the diff it names.

### What had to move

- **`overflow-hidden` → `overflow-clip` on the file card.** `hidden` makes the card a scroll container of its own, and a sticky child of a scrollport that cannot scroll never sticks. `clip` cuts the diff to the rounded corners the same way without creating one.
- **The rule between header and body is now the header's.** It used to belong to the top of the first body section, so it scrolled up underneath the pinned header and left the file name sitting straight on the code. Each section below now asks only whether something precedes it — which is also why `ImageDiff` gave up its own `border-t`.
- **A sticky offset for the find bar.** The find bar is sticky too and higher in the stack, so a header pinned to the top of the scroller would spend the whole search hidden behind it. The tab measures the bar with a `ResizeObserver` and publishes `--diff-sticky-top`; the header parks below it. The same number plus the old half-rem of breathing room becomes `--diff-scroll-top`, now used for a card's scroll margin and the file tree's resting place — both of which used to land under the find bar as well.

### Checks

`npm run typecheck`, `npm run lint` and `npm test` all pass.

There is no Electron binary installed on the machine this was written on, so the layout was verified in headless Chrome against the real compiled stylesheet and the real class strings, measuring each header's offset from the top of the scroller:

| state | file-1 header | file-2 header | file tree | find bar bottom |
|---|---|---|---|---|
| at rest, top of the list | 17 | 2460 | 16 | — |
| scrolled 900px into file 1 | **0** (pinned) | 1560 | 8 | — |
| same, with the find bar open | **50** (= 38 + 0.75rem) | 1610 | 58 | 38 |
| scrolled to the file 1/2 boundary | −13 (riding out) | 30 (arriving) | 8 | — |

The last row is the handover: file 1's header is pushed up and out with the bottom of its own card while file 2's arrives to take its place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKwUeR8XL3VNeKQ3Rofx4q
