### PR TITLE
Keep a prerelease away from the stable audience

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -13,8 +13,16 @@ name: Deploy site
 # buttons still point at the previous release, or fall back to the releases
 # page. Publishing the draft is the moment the assets become real.
 #
-# `published` rather than `released` on purpose: `released` does not fire for
-# prereleases, and v0.1.0 is one.
+# `published` rather than `released`, even though `released` already skips
+# prereleases: keeping the broader trigger means the decision to skip one is
+# written here, in an `if:` that can be read, rather than inferred from which
+# webhook GitHub chose to send.
+#
+# And skipped it must be. A prerelease is published so that testers can be
+# handed a link to it; gitwarren.com is where everyone else arrives, and its
+# buttons should go on pointing at the newest stable build. The site's own
+# lookup declines prereleases as well - this is the outer of the two guards,
+# and the one that saves an entire pointless deploy.
 
 on:
   release:
@@ -26,6 +34,9 @@ on:
 jobs:
   deploy:
     name: Rebuild and deploy gitwarren.com
+    # `github.event.release` is absent on a manual run, which leaves the first
+    # clause true and the redeploy button working.
+    if: github.event_name != 'release' || github.event.release.prerelease == false
     runs-on: ubuntu-latest
     steps:
       # Both repositories are public, so the default token is enough here.

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -9,6 +9,14 @@ name: Homebrew tap
 # release starts life as a draft, and only publishing makes its assets
 # visible to the API the bump reads from.
 #
+# Prereleases are deliberately not announced. The tap's bump.sh resolves the
+# latest published release with `--exclude-pre-releases` when it is given no
+# tag, but this dispatch hands it one - and an explicit tag is taken as given,
+# prerelease or not. So a beta announced from here would land in the cask and
+# reach every `brew upgrade` on the next run. Saying nothing leaves the tap's
+# own six-hourly schedule to find the newest stable release, which is the
+# right answer for a beta: no bump at all.
+#
 # Needs HOMEBREW_TAP_TOKEN — a fine-grained PAT for the klarluft/homebrew-tap
 # repository with *Contents: read and write* (a repository_dispatch counts as
 # a write to contents). Without it the job is skipped rather than failed: the
@@ -21,6 +29,7 @@ on:
 jobs:
   notify:
     name: Ask the tap to bump
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     env:
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,20 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists, leaving it alone."
           else
-            gh release create "$TAG" --draft --title "$TAG" --generate-notes
+            # A tag carrying a prerelease component - v0.1.7-beta.1 - is created
+            # flagged as a prerelease, and that flag is the only thing keeping it
+            # away from ordinary users. GitHub's /releases/latest skips
+            # prereleases, and that endpoint is what electron-updater asks on
+            # behalf of every install running a stable version. Nothing else in
+            # the release distinguishes it: the update manifests inside a beta
+            # release are still called latest.yml, because electron-builder does
+            # not derive a channel for the GitHub provider. Clear the flag and
+            # every stable install takes the beta on its next six-hourly check.
+            prerelease=""
+            case "$TAG" in
+              *-*) prerelease="--prerelease" ;;
+            esac
+            gh release create "$TAG" --draft --title "$TAG" --generate-notes $prerelease
           fi
 
   build:


### PR DESCRIPTION
Publishing `v0.1.7-beta.2` as things stand would put the beta in front of everyone. Three paths needed a guard.

### The draft is created without `--prerelease`

GitHub's `/releases/latest` skips prereleases, and that endpoint is what electron-updater asks on behalf of every install running a stable version (`allowPrerelease` is derived from the *installed* version, so a 0.1.6 install has it `false`). That flag is the only thing standing between a beta and every stable install: the update manifests inside a beta release are still named `latest.yml` / `latest-mac.yml` / `latest-linux.yml`, because electron-builder derives no channel for the GitHub provider. It now comes from the tag rather than from remembering to tick a box.

### `deploy-site.yml` would have rebuilt gitwarren.com onto the beta

It fires on `release: published`, which includes prereleases, and the site takes the newest non-draft release — prereleases included. The download buttons would have moved to `v0.1.7-beta.2`. The job now declines a prerelease; manual redeploys are unaffected.

The matching fix in the site's own lookup is in klarluft/gitwarren-site — that one is the load-bearing half, since it also covers a redeploy triggered by anything else.

### `homebrew-tap.yml` would have bumped the cask to the beta

It dispatches the tag to the tap, whose `bump.sh` excludes prereleases only when left to pick a release itself; an explicit tag is taken as given. The beta would have reached every `brew upgrade --cask gitwarren`. The dispatch is now skipped, which leaves the tap's own six-hourly schedule to keep finding the newest stable release.

### Checked

All three workflows parse, and both guard expressions evaluate as intended (`github.event.release` is absent on a manual run, leaving deploy-site's redeploy button working). The tag test in the draft step: `v0.1.7-beta.2` → `--prerelease`, `v0.1.7` → no flag.

Unaffected: npm already publishes any tag containing `-` under the `next` dist-tag, and beta installs still update among themselves (they look for `beta-mac.yml`, 404, and fall back to `latest.yml` in the same release) and move to a later stable on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrGE5W1itGq3pJ7EpAnenG