### PR TITLE
Release 0.1.7-beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1114,13 +1114,41 @@ installers, and uploads them plus the manifests to a GitHub release for the
 current tag. The release is created as a **draft** — publish it in the GitHub UI
 when you are ready, and that is the moment clients begin to see the update.
 
-Publishing also fans out to two other places, both on the `release: published`
-event: `deploy-site.yml` rebuilds gitwarren.com so its download buttons point at
-the new assets, and `homebrew-tap.yml` asks
+Publishing a *stable* release also fans out to two other places, both on the
+`release: published` event: `deploy-site.yml` rebuilds gitwarren.com so its
+download buttons point at the new assets, and `homebrew-tap.yml` asks
 [klarluft/homebrew-tap](https://github.com/klarluft/homebrew-tap) to move its
 cask to the new version and checksums. The tap needs a `HOMEBREW_TAP_TOKEN`
 secret for that nudge to be immediate; without one it still catches the
 release on its own schedule within a few hours.
+
+### Prereleases
+
+A tag carrying a prerelease component — `v0.1.7-beta.3` — is a build for
+testers, and the pipeline keeps it away from everyone else. The draft is
+created `--prerelease`, and both fan-outs above decline to run for one: the
+website goes on advertising the newest stable release, and the Homebrew cask
+stays where it is.
+
+That flag is load-bearing. GitHub's `/releases/latest` skips a prerelease, and
+that endpoint is what electron-updater asks on behalf of every install running
+a stable version — `allowPrerelease` is derived from the *installed* version,
+so a 0.1.6 install never looks at a beta. Nothing else in the release says so:
+the update manifests inside a beta are still named `latest.yml`, because
+electron-builder derives no channel for the GitHub provider. Clear the flag,
+or tick *Set as the latest release* while publishing, and every stable install
+takes the beta on its next six-hourly check.
+
+So publish one explicitly rather than through the UI's defaults:
+
+```bash
+gh release edit v0.1.7-beta.3 --draft=false --prerelease --latest=false
+```
+
+Testers keep updating among themselves from there — a beta install looks for
+`beta-mac.yml`, gets a 404, and falls back to the `latest.yml` in the same
+release — and each one moves to the next stable release on its own, with no
+reinstall, as long as that version is higher than the beta they are on.
 
 To build without publishing (for local testing):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitwarren",
-  "version": "0.1.7-beta.2",
+  "version": "0.1.7-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitwarren",
-      "version": "0.1.7-beta.2",
+      "version": "0.1.7-beta.3",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitwarren",
   "productName": "GitWarren",
-  "version": "0.1.7-beta.2",
+  "version": "0.1.7-beta.3",
   "description": "Code review for your own machines and your own agents",
   "author": {
     "name": "Klarluft B.V.",


### PR DESCRIPTION
Version bump for a test build of current main — 16 commits past `v0.1.7-beta.2`: M5's WSL carrier finished, both directions of "another machine" on the Hosts screen, the tailnet toggle answering at once, cross-platform CI, the sticky file header, and #59's prerelease guards.

Same three-line shape as the beta.2 bump (`package.json` + `package-lock.json`), plus a README correction.

### Why this one gets published

Beta.2 was deliberately left as a draft: publishing it would have repointed every download button on gitwarren.com at a beta and moved the Homebrew cask with it. #59 and klarluft/gitwarren-site#13 closed all four of those paths, so publishing a prerelease now means only that testers can be handed a link to it. The README still described the old behaviour ("Publishing also fans out to two other places") and now documents what a prerelease actually does, why the flag is load-bearing, and the one command that publishes one without handing it to everybody.

### Checked

- `npm run lint` — 0 errors (1 pre-existing warning in `repository-detail.tsx`, untouched here).
- `npm test` — 576 tests, 572 pass, 0 fail, 4 skipped (the stdio-carrier tests that are deliberately not run on darwin).

### After merge

```bash
git tag v0.1.7-beta.3 && git push origin v0.1.7-beta.3
# ...release.yml builds and fills the draft, which is created --prerelease...
gh release edit v0.1.7-beta.3 --draft=false --prerelease --latest=false
```

macOS artifacts will be signed and notarized (the Apple secrets are set). Windows has no certificate configured, so the installer stays unsigned and SmartScreen will want a *More info → Run anyway*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XrGE5W1itGq3pJ7EpAnenG
