### PR TITLE
Ask the machine before describing it, and let a finger comment on a line

### DIFF
--- a/src/renderer/src/components/copy-button.tsx
+++ b/src/renderer/src/components/copy-button.tsx
@@ -60,19 +60,31 @@ export function CopyButton({
     }
   }
 
-  const icon = state === 'copied' ? <Check className="text-success" /> : <Copy />
   const said = state === 'copied' ? 'Copied' : state === 'select' ? 'Selected — press copy' : null
 
   // Two shapes, one behaviour: a labelled button when it is the action a page
   // exists for, and the bare icon when it sits beside the thing it copies.
+  //
+  // The tick is green in one of them and not the other, and that is not an
+  // inconsistency - it is the same decision made twice against two different
+  // backgrounds. On the ghost button the tick sits on the page, where
+  // `--success` is the colour that says "that worked". Inside the filled
+  // button it would be `--success` on `--primary`, and in dark mode those are
+  // oklch lightness 0.72 and 0.68 - a green tick on a blue field, a hair
+  // apart, which is a success state nobody can see. There it inherits
+  // `--primary-foreground`, which is the one colour the button guarantees is
+  // readable on itself, and the word "Copied" next to it carries the news
+  // anyway.
   if (children !== undefined) {
     return (
       <Button onClick={() => void copy()} className={className}>
-        {icon}
+        {state === 'copied' ? <Check /> : <Copy />}
         {said ?? children}
       </Button>
     )
   }
+
+  const icon = state === 'copied' ? <Check className="text-success" /> : <Copy />
 
   return (
     <Tooltip label={said ?? label}>

--- a/src/renderer/src/features/hosts/discovered-hosts.tsx
+++ b/src/renderer/src/features/hosts/discovered-hosts.tsx
@@ -39,9 +39,14 @@ import { Breakable } from '@/components/breakable'
 import { api, CACHE_KEYS } from '@/lib/api'
 import { errorMessage } from '@/lib/errors'
 import { useHostMutations } from './use-hosts'
-import type { DiscoveredPeer } from '@shared/schemas'
+import type { DiscoveredPeer, HostWithState } from '@shared/schemas'
 
-export function DiscoveredHosts() {
+export function DiscoveredHosts({
+  onAdded
+}: {
+  /** The host that was just created, so the screen can reach it once. */
+  onAdded?: (host: HostWithState) => void
+}) {
   const {
     data: peers,
     isLoading,
@@ -72,8 +77,16 @@ export function DiscoveredHosts() {
       // under. Nothing is guessed about the scheme or the port, which is M6.0's
       // finding applied: whether a tailnet can do HTTPS is a property of the
       // tailnet, so it is a fact to carry rather than a default to apply.
-      await addHost({ target: peer.origin, kind: 'websocket', label: peer.dnsName.split('.')[0] })
+      const created = await addHost({
+        target: peer.origin,
+        kind: 'websocket',
+        label: peer.dnsName.split('.')[0]
+      })
       await mutate()
+      // This peer answered a probe seconds ago, so the row that has just landed
+      // is about a machine known to be up and running GitWarren - and it would
+      // still draw "Not checked yet" until somebody asked. The screen asks.
+      onAdded?.(created)
     } catch (error) {
       setFailure(errorMessage(error))
     } finally {

--- a/src/renderer/src/features/hosts/host-card.tsx
+++ b/src/renderer/src/features/hosts/host-card.tsx
@@ -65,7 +65,11 @@ export function HostCard({
               {host.label}
             </h3>
             <ReachabilityBadge host={host} />
-            <DaemonVersionBadge host={host} appVersion={appVersion} />
+            <DaemonVersionBadge
+              host={host}
+              appVersion={appVersion}
+              checking={busy === 'probe'}
+            />
           </div>
           {/* Wraps rather than truncates, for the reason the repository card
               gives about paths: the tail of `xfor@100.78.0.23` is the half that

--- a/src/renderer/src/features/hosts/host-form-dialog.tsx
+++ b/src/renderer/src/features/hosts/host-form-dialog.tsx
@@ -39,6 +39,13 @@
  * started - and a form that refused would be wrong about a situation it cannot
  * see. The row lands in the list and says "Not tried yet", with "Try now" beside
  * it.
+ *
+ * What the row does *not* do any more is sit there waiting to be asked. The
+ * form reports the host it created through `onAdded`, and the screen reaches it
+ * once - see the note on `probeAdded` in `hosts-page.tsx`. That is the
+ * difference between refusing to add an unreachable host, which would be wrong,
+ * and finding out whether it is reachable, which is the question the person had
+ * when they pressed the button.
  */
 import { useState, type FormEvent } from 'react'
 import useSWR from 'swr'
@@ -60,30 +67,45 @@ import { useHostMutations, useWslDistros } from './use-hosts'
 import { addHostInputSchema, updateHostInputSchema } from '@shared/schemas'
 import { parseWithSchema } from '@shared/validation'
 import { api, CACHE_KEYS } from '@/lib/api'
-import type { Host, HostKind, WslDistro } from '@shared/schemas'
+import type { Host, HostKind, HostWithState, WslDistro } from '@shared/schemas'
 
 interface HostFormDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   /** Present when editing; absent when adding. */
   host?: Host | undefined
+  /** The host that was just created. Never called for an edit. */
+  onAdded?: (host: HostWithState) => void
 }
 
-export function HostFormDialog({ open, onOpenChange, host }: HostFormDialogProps) {
+export function HostFormDialog({ open, onOpenChange, host, onAdded }: HostFormDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         {/* Mounted only while open, which is what resets the fields between
             openings - fresh mount, fresh `useState`, nothing left over. */}
         {open && (
-          <HostForm key={host?.id ?? 'new'} host={host} onDone={() => onOpenChange(false)} />
+          <HostForm
+            key={host?.id ?? 'new'}
+            host={host}
+            onAdded={onAdded}
+            onDone={() => onOpenChange(false)}
+          />
         )}
       </DialogContent>
     </Dialog>
   )
 }
 
-function HostForm({ host, onDone }: { host: Host | undefined; onDone: () => void }) {
+function HostForm({
+  host,
+  onDone,
+  onAdded
+}: {
+  host: Host | undefined
+  onDone: () => void
+  onAdded: ((host: HostWithState) => void) | undefined
+}) {
   const isEditing = host !== undefined
   const { addHost, updateHost } = useHostMutations()
   // Only asked while adding. Editing cannot change a carrier, so the list would
@@ -146,7 +168,13 @@ function HostForm({ host, onDone }: { host: Host | undefined; onDone: () => void
           ...(trimmedLabel ? { label: trimmedLabel } : {}),
           ...(trimmedEditor ? { editorTarget: trimmedEditor } : {})
         })
-        await addHost(input)
+        const created = await addHost(input)
+        // After `onDone`, not before: the probe is a second round trip and the
+        // dialog has no business staying open across it. The row is already in
+        // the list by now, so the screen can put a spinner on it.
+        onDone()
+        onAdded?.(created)
+        return
       }
       onDone()
     } catch (caught) {

--- a/src/renderer/src/features/hosts/host-status.tsx
+++ b/src/renderer/src/features/hosts/host-status.tsx
@@ -14,8 +14,25 @@
  * that as "unreachable" would mean every host anyone adds is red before it has
  * been given a chance, which teaches people to ignore the colour. It gets its
  * own, quieter word and no colour at all.
+ *
+ * ## The same distinction, for what is installed
+ *
+ * `daemon_version` is null in two situations that are not the same situation:
+ * the machine was asked and had no GitWarren on it, and the machine has never
+ * been asked anything at all. Until now both drew "GitWarren not installed",
+ * which made every freshly added host accuse a machine of missing software
+ * before a single packet had been sent to it - and the accusation was often
+ * wrong, as pressing refresh immediately proved.
+ *
+ * Which one it is cannot be read off `daemonVersion` alone; it is read off the
+ * reachability beside it. A host that has never been tried knows nothing about
+ * its own contents either, so `reachabilityOf(...) === 'unknown'` is exactly
+ * the condition under which the install badge has to keep quiet. Anything that
+ * has actually been reached - or has actually failed, which for ssh is where
+ * "GitWarren is not installed on xfor@pc-wsl" comes from - has been asked, and
+ * the badge speaks.
  */
-import { CircleCheck, CircleDashed, CircleX, Download } from 'lucide-react'
+import { CircleCheck, CircleDashed, CircleX, Download, Loader2 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import type { HostWithState } from '@shared/schemas'
 
@@ -86,12 +103,27 @@ export function ReachabilityBadge({
  */
 export function DaemonVersionBadge({
   host,
-  appVersion
+  appVersion,
+  checking = false
 }: {
   host: HostWithState
   appVersion: string | undefined
+  /** True while a probe for this host is in flight. */
+  checking?: boolean
 }) {
   if (host.daemonVersion === null) {
+    // Asked nothing, so claim nothing. See the header.
+    if (reachabilityOf(host) === 'unknown') {
+      return checking ? (
+        <Badge variant="outline">
+          <Loader2 className="animate-spin" />
+          Checking…
+        </Badge>
+      ) : (
+        <Badge variant="outline">Not checked yet</Badge>
+      )
+    }
+
     return (
       <Badge variant="outline">
         <Download />
@@ -115,7 +147,17 @@ export function DaemonVersionBadge({
   )
 }
 
-/** Whether the install button should be the loud one. */
+/**
+ * Whether the install button should be the loud one.
+ *
+ * Never for a host nobody has asked yet. A filled, primary-coloured "Install
+ * GitWarren" is this screen telling somebody what to do next, and it has no
+ * business doing that on a guess - the machine may well already have it, which
+ * is the whole point of the badge above keeping quiet. The button is still
+ * there and still works; it just stops shouting until there is something to
+ * shout about.
+ */
 export function needsInstall(host: HostWithState, appVersion: string | undefined): boolean {
-  return host.daemonVersion === null || (appVersion !== undefined && host.daemonVersion !== appVersion)
+  if (host.daemonVersion === null) return reachabilityOf(host) !== 'unknown'
+  return appVersion !== undefined && host.daemonVersion !== appVersion
 }

--- a/src/renderer/src/features/hosts/hosts-page.tsx
+++ b/src/renderer/src/features/hosts/hosts-page.tsx
@@ -43,6 +43,22 @@
  * be two 45 MB streams and two `ssh` connections from a screen with one
  * spinner, and the honest way to say "this is one operation you are waiting on"
  * is to let it be one.
+ *
+ * ## A host that has just been added is asked about itself
+ *
+ * The one place this screen reaches a machine without being asked to, and the
+ * exception is narrow enough to state exactly: somebody has this second
+ * described a machine and pressed Add. `hosts.list` is a SQLite read and the
+ * fresh row has never been connected to, so before `probeAdded` the card drew
+ * "Not tried yet" next to what was then "GitWarren not installed" - a sentence
+ * about software on a machine nothing had spoken to. Pressing refresh replaced
+ * it with the truth, which is how the bug was found, and having to press
+ * refresh to find out what you just added is the bug.
+ *
+ * This does not reopen `use-hosts.ts`'s refusal to poll. That refusal is about
+ * a screen left open holding a connection to every machine in the list, on a
+ * timer, forever. This is one connection, to one machine, once, in direct
+ * response to a button - the same standard `probe` and `install` already meet.
  */
 import { useCallback, useMemo, useState } from 'react'
 import useSWR from 'swr'
@@ -98,6 +114,27 @@ export function HostsPage() {
       // anything landing here is the app failing rather than the machine - and
       // it belongs in front of the person, not in a console.
       setOutcome({ kind: 'error', label: host.label, message: errorMessage(caught) })
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  /**
+   * Reach a host that has just been added.
+   *
+   * Deliberately not `probe`: a failure here must not raise the install-result
+   * dialog. `hosts.probe` answers rather than throws for a machine that is
+   * simply not there, so anything thrown is this app failing - and even that,
+   * in response to something nobody explicitly asked for, belongs on the card
+   * as `state.lastError` rather than in a modal over a screen the person is
+   * still using. The row says what happened either way.
+   */
+  async function probeAdded(host: HostWithState): Promise<void> {
+    setBusy({ id: host.id, what: 'probe' })
+    try {
+      await probeHost(host.id)
+    } catch {
+      // See above. The list is revalidated by `probeHost` regardless.
     } finally {
       setBusy(null)
     }
@@ -197,7 +234,7 @@ export function HostsPage() {
           is the thing you came here to do something about, and a proposal
           under twelve rows is a proposal nobody sees. It draws nothing at all
           when there is nothing to propose. */}
-      <DiscoveredHosts />
+      <DiscoveredHosts onAdded={(host) => void probeAdded(host)} />
 
       {isLoading && <LoadingState />}
 
@@ -225,7 +262,12 @@ export function HostsPage() {
         </ul>
       )}
 
-      <HostFormDialog open={formOpen} onOpenChange={setFormOpen} host={editing} />
+      <HostFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        host={editing}
+        onAdded={(host) => void probeAdded(host)}
+      />
       <RemoveHostDialog
         host={removing}
         onOpenChange={(open) => {

--- a/src/renderer/src/features/reviews/diff-view.tsx
+++ b/src/renderer/src/features/reviews/diff-view.tsx
@@ -324,9 +324,33 @@ export function FileDiffCard({
   /**
    * A drag ends wherever the pointer is released, which is often outside the
    * button - or outside the card - so the listener goes on the window.
+   *
+   * The *move* is on the window for a different and less obvious reason. Rows
+   * also report `onPointerEnter`, and with a mouse that is enough: the pointer
+   * really does travel across each row and each row really is told. A finger
+   * does not work that way. Touch sets *implicit pointer capture* on whatever
+   * the gesture started on - the `+` button - so for the rest of the drag every
+   * pointer event is delivered to that button and no row is ever entered. The
+   * range simply never grew, which is why dragging out several lines worked on
+   * a desktop and did nothing at all on a phone.
+   *
+   * So the pointer is followed rather than waited for: one listener, hit-test
+   * where it actually is, read the row's own `data-diff-*` off the result. That
+   * is correct for a mouse too - `onPointerEnter` stays because it costs
+   * nothing and keeps the desktop path working if a hit-test ever lands on
+   * something unexpected - and it is the same set of coordinates either way.
    */
   useEffect(() => {
     if (!dragging) return
+
+    const move = (event: PointerEvent): void => {
+      const under = document.elementFromPoint(event.clientX, event.clientY)
+      const row = under?.closest('[data-diff-line]')
+      if (!row) return
+      const side = row.getAttribute('data-diff-side')
+      const line = Number(row.getAttribute('data-diff-line'))
+      if ((side === 'base' || side === 'head') && Number.isInteger(line)) dragOver(side, line)
+    }
 
     const finish = (): void => {
       const startLine = Math.min(dragging.startLine, dragging.line)
@@ -341,13 +365,15 @@ export function FileDiffCard({
       )
     }
 
+    window.addEventListener('pointermove', move)
     window.addEventListener('pointerup', finish)
     window.addEventListener('pointercancel', finish)
     return () => {
+      window.removeEventListener('pointermove', move)
       window.removeEventListener('pointerup', finish)
       window.removeEventListener('pointercancel', finish)
     }
-  }, [dragging])
+  }, [dragging, dragOver])
 
   // A shared constant rather than a fresh `[]`, so a file with no comments
   // does not hand the memo below a new array identity on every render.
@@ -1077,6 +1103,12 @@ function LineRow({
     <>
       <div
         id={number === null ? undefined : lineDomId(filePath, side, number)}
+        // Read by the drag listener in `DiffFileCard`, which hit-tests the
+        // pointer rather than waiting to be entered - see the note there. On
+        // the row rather than on the gutter cell because a finger dragging down
+        // the left edge wanders across all three columns.
+        data-diff-side={number === null ? undefined : side}
+        data-diff-line={number === null ? undefined : number}
         className={cn(
           'group grid grid-cols-[3rem_3rem_1fr]',
           // Backgrounds are mutually exclusive rather than layered: two
@@ -1127,9 +1159,47 @@ function LineRow({
               title={`Comment on ${side === 'head' ? 'line' : 'removed line'} ${number} — drag or shift-click for several`}
               aria-label={`Comment on line ${number} of ${filePath}`}
               className={cn(
-                'absolute left-0.5 top-1/2 hidden -translate-y-1/2 items-center justify-center rounded bg-primary p-0.5 text-primary-foreground shadow-sm',
-                'group-hover:flex focus-visible:flex',
-                (composing || selected) && 'flex'
+                'absolute left-0.5 top-1/2 flex -translate-y-1/2 items-center justify-center rounded bg-primary p-0.5 text-primary-foreground shadow-sm',
+                // `touch-none` is what lets a finger drag the range out at all:
+                // whether a touch scrolls the page or becomes a pointer drag is
+                // decided by `touch-action` and by nothing else -
+                // `preventDefault` on pointerdown does not reach that decision.
+                'touch-none',
+                'focus-visible:flex',
+                // Visible by default, and hidden again only where hovering is a
+                // thing that can happen.
+                //
+                // It used to be the other way round - `hidden`, revealed by
+                // `group-hover` - which on a phone is a button that does not
+                // exist, because there is no hover to wait for and no other way
+                // in. Commenting on a line was unreachable rather than merely
+                // awkward. `(hover: hover)` is the only honest test for that: it
+                // asks about the pointer the person actually has, rather than
+                // about a screen width or a user agent string, so a tablet with
+                // a mouse gets the desktop behaviour and a touchscreen laptop
+                // gets both.
+                //
+                // Written as one either/or rather than as a pile of classes
+                // that override each other. A hidden and a shown variant of the
+                // same media query are the same specificity inside it, so which
+                // one won would come down to the order Tailwind happened to
+                // emit them in; only one of them is ever in the string.
+                //
+                // (The other reason not to write the losing class in a comment
+                // here: Tailwind scans this file for candidates and does not
+                // know a comment from code, so naming one would compile a dead
+                // rule into the stylesheet.)
+                composing || selected
+                  ? null
+                  : [
+                      '[@media(hover:hover)]:hidden [@media(hover:hover)]:group-hover:flex',
+                      // Standing at every line where it cannot hide, it has to
+                      // stop being the loudest thing in the gutter. It sits left
+                      // of the right-aligned line number rather than over it, so
+                      // this is weight rather than occlusion - and it is back to
+                      // full strength on the range it is actually holding.
+                      '[@media(hover:none)]:opacity-70'
+                    ]
               )}
             >
               <Plus className="size-3" />

--- a/src/renderer/src/lib/__tests__/format.test.ts
+++ b/src/renderer/src/lib/__tests__/format.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The display helpers, with the clock and the locale held still.
+ *
+ * Everything in `format.ts` reaches for `Intl`, which reads a locale from the
+ * environment, so the assertions here are about the shape of the output rather
+ * than its exact wording: a runner on a machine set to German is not a failing
+ * test, and asserting on "3 days ago" would make it one. Where a case is about
+ * a locale-independent decision - which unit was picked, whether a number was
+ * grouped at all, what an unknown size draws - it is asserted exactly.
+ */
+import { strict as assert } from 'node:assert'
+import { test } from 'node:test'
+import { absoluteTime, fileSize, plural, relativeTime, timeOfDay } from '../format'
+
+const DAY = 24 * 60 * 60 * 1000
+
+test('nothing is drawn for a timestamp that was never set', () => {
+  assert.equal(relativeTime(null), '')
+  assert.equal(absoluteTime(null), '')
+})
+
+test('an unparseable timestamp is handed back rather than swallowed', () => {
+  assert.equal(relativeTime('not a date'), 'not a date')
+  assert.equal(absoluteTime('not a date'), 'not a date')
+})
+
+test('the largest unit that fits is the one the phrase uses', () => {
+  const parts = new Intl.RelativeTimeFormat().formatToParts(-3, 'day')
+  const dayWord = parts.map((part) => part.value).join('')
+
+  const threeDaysAgo = new Date(Date.now() - 3 * DAY).toISOString()
+  assert.equal(relativeTime(threeDaysAgo), dayWord)
+})
+
+test('anything under a minute is just now, in either direction', () => {
+  assert.equal(relativeTime(new Date(Date.now() - 5_000).toISOString()), 'just now')
+  assert.equal(relativeTime(new Date(Date.now() + 5_000).toISOString()), 'just now')
+})
+
+test('a clock time says nothing about the date it came from', () => {
+  const noon = Date.UTC(2026, 0, 1, 12, 0, 0)
+  assert.ok(!timeOfDay(noon).includes('2026'))
+})
+
+test('bytes stay bytes below a kilobyte', () => {
+  assert.equal(fileSize(0), '0 B')
+  assert.equal(fileSize(1023), '1023 B')
+})
+
+test('the unit climbs and the precision drops as the number grows', () => {
+  assert.equal(fileSize(1024), '1.0 KB')
+  assert.equal(fileSize(412 * 1024), '412 KB')
+  assert.equal(fileSize(5.5 * 1024 * 1024), '5.5 MB')
+})
+
+test('the top unit is gigabytes rather than an unbounded ladder', () => {
+  assert.equal(fileSize(4096 * 1024 * 1024 * 1024), '4096 GB')
+})
+
+test('a size nobody knows draws a dash instead of NaN', () => {
+  assert.equal(fileSize(Number.NaN), '—')
+  assert.equal(fileSize(Number.POSITIVE_INFINITY), '—')
+  assert.equal(fileSize(-1), '—')
+})
+
+test('one of something is singular and everything else is not', () => {
+  assert.equal(plural(1, 'file'), '1 file')
+  assert.equal(plural(0, 'file'), '0 files')
+  assert.equal(plural(3, 'file'), '3 files')
+})
+
+test('an irregular plural is spelled by the caller', () => {
+  assert.equal(plural(2, 'entry', 'entries'), '2 entries')
+})
+
+test('a four-figure count is grouped rather than run together', () => {
+  const grouped = plural(24000, 'file')
+  assert.ok(grouped.endsWith(' files'))
+  assert.notEqual(grouped, '24000 files')
+})

--- a/src/renderer/src/lib/format.ts
+++ b/src/renderer/src/lib/format.ts
@@ -55,8 +55,17 @@ export function timeOfDay(timestamp: number): string {
 /**
  * "412 KB". Powers of two with the units people expect next to a file, which
  * is what every git host prints beside an image.
+ *
+ * The guard on the first line is about where the number comes from. A size is
+ * whatever the store reported, and a file that vanished between the listing and
+ * the stat hands back `undefined` through a type that promised a number - which
+ * arrives here as `NaN` and leaves as the string "NaN B", printed in the corner
+ * of an image the user is looking at. An em dash is the honest thing to draw
+ * when nobody knows the size, and putting it here rather than a `?? ''` at each
+ * of the three call sites means the next caller inherits the answer.
  */
 export function fileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '—'
   if (bytes < 1024) return `${bytes} B`
   const units = ['KB', 'MB', 'GB']
   let value = bytes / 1024
@@ -68,7 +77,17 @@ export function fileSize(bytes: number): string {
   return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`
 }
 
-/** "3 files" / "1 file" - pluralisation is not worth a dependency. */
+const COUNT = new Intl.NumberFormat()
+
+/**
+ * "3 files" / "1 file" - pluralisation is not worth a dependency.
+ *
+ * The count goes through `Intl` for the same reason the timestamps above do: a
+ * review that refreshes a vendored lockfile really does say 24000 files, and an
+ * unseparated run of digits is a number the reader has to stop and count. The
+ * locale is the one the window is already formatting its dates in, so the
+ * separator matches the rest of the screen rather than being chosen here.
+ */
 export function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
-  return `${count} ${count === 1 ? singular : pluralForm}`
+  return `${COUNT.format(count)} ${count === 1 ? singular : pluralForm}`
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -37,6 +37,8 @@
     "src/renderer/src/lib/__tests__/host-reachability.test.ts",
     "src/renderer/src/lib/event-scope.ts",
     "src/renderer/src/lib/__tests__/event-scope.test.ts",
+    "src/renderer/src/lib/format.ts",
+    "src/renderer/src/lib/__tests__/format.test.ts",
     "src/renderer/src/features/reviews/diff-search.ts",
     "src/renderer/src/features/reviews/__tests__/diff-search.test.ts",
     "src/web/loopback-fragment.ts",


### PR DESCRIPTION
Four reported problems, plus three questions answered in the thread rather than in code.

### A newly added host accused a machine before speaking to it

`daemon_version` is null in two situations that are not the same situation: the machine was asked and had no GitWarren on it, and the machine has never been asked anything at all. The badge drew **"GitWarren not installed"** for both, so every host anyone added libelled a machine that usually *did* have GitWarren — which pressing refresh immediately disproved. Having to press refresh to find out what you just added is the bug.

Which of the two it is cannot be read off `daemonVersion` alone; it is read off the reachability beside it, and `host-status.tsx` already had exactly this argument written out under *"Never tried is not the same as down"*. It now covers the install badge too:

- never asked → **"Not checked yet"**, or **"Checking…"** with a spinner while a probe is in flight
- asked and reached → the version
- asked and refused → **"GitWarren not installed"**, which is where ssh's own `GitWarren is not installed on xfor@pc-wsl` comes from and is true

`needsInstall` no longer makes Install the loud primary button on a guess, and the Hosts screen now reaches a host it has just added — from the Add dialog and from the tailnet discovery list alike.

This does not reopen `use-hosts.ts`'s refusal to poll. That refusal is about a screen left open holding a connection to every machine in the list, on a timer, forever. This is one connection, to one machine, once, in direct response to a button — the same standard `probe` and `install` already meet. Its failure deliberately does not raise the install-result dialog: nobody explicitly asked for it, so it belongs on the card as `state.lastError`.

### A green tick on a blue button

The copied state put `--success` on `--primary`. In dark mode those are oklch lightness **0.72 and 0.68** — a green tick on a blue field, a hair apart, invisible. Green stays on the ghost icon button, where it sits on the page and is the colour that says "that worked"; inside the filled button the tick inherits `--primary-foreground`, the one colour the button guarantees is readable on itself, and the word "Copied" beside it carries the news anyway.

### A phone could not comment on a line at all

The `+` in the gutter was `hidden` until `group-hover`, and a touchscreen has no hover to wait for — so the only way into a line comment was a gesture the device cannot produce. It is visible by default now and hidden again only under `(hover: hover)`, which asks about the pointer the person actually has rather than about a screen width or a user agent: a tablet with a mouse keeps the desktop behaviour, a touchscreen laptop gets both. Where it cannot hide it drops to `opacity-70` so it stops being the loudest thing in the gutter; it sits left of the right-aligned line number rather than over it, so nothing is occluded.

### And multi-line comments could not be dragged out with a finger

Touch sets *implicit pointer capture* on whatever the gesture started on — the `+` — so for the rest of the drag every pointer event went to that button and no row was ever entered by `onPointerEnter`. Dragging out a range worked on a desktop and did nothing at all on a phone.

The drag now follows the pointer rather than waiting for it: one window `pointermove` listener, hit-test where the pointer actually is, read the row's own `data-diff-side` / `data-diff-line` off the result. That is correct for a mouse too, and `onPointerEnter` stays as the belt to its braces. `touch-none` on the button is what lets the gesture be a drag rather than a page scroll — `touch-action` decides that and `preventDefault` on pointerdown cannot reach it. So press-and-drag down the gutter is now the same gesture on a phone as on a desktop.

### Verification

`npm run typecheck`, `npx eslint .` (one pre-existing warning in `repository-detail.tsx`, untouched here) and `npm test` — 584 passing, 0 failing.

The two arbitrary media variants were checked in the *compiled* stylesheet, not assumed: both rules are emitted, and base `.flex` lands before `[@media(hover:hover)]:hidden` which lands before the `group-hover` rule, so the cascade resolves the way the markup reads. The shown/hidden pair is written as one either-or rather than as overriding classes, because two variants of the same media query are the same specificity inside it and which one won would otherwise come down to Tailwind's emission order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANTyxgSx6DJo3fUhSm4YL4