### PR TITLE
Let a review be read, and commented on, past its own diff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,12 @@ can agree on the shape before you spend time on it.
 Two things are deliberate design constraints rather than gaps, and changes that
 break them will not be merged:
 
-- **It runs on one machine.** No server, no account system, no telemetry, no
-  network calls in the core review path. If a feature needs a backend, it is out
-  of scope for this project.
+- **It runs on machines the user owns.** No server, no account system, no
+  telemetry, and nothing relayed through anybody else. GitWarren reaches your
+  other machines directly — over `ssh`, over `wsl.exe`, or over your own tailnet
+  — and a repository's reviews stay on the machine that repository is on. If a
+  feature needs a backend, a hosted relay or an account, it is out of scope for
+  this project.
 - **Git is read, not reimplemented.** GitWarren shells out to the user's own
   `git`. It does not bundle a git implementation and does not write to the user's
   repositories.

--- a/README.md
+++ b/README.md
@@ -20,13 +20,19 @@ brew install klarluft/tap/gitwarren-cli   # macOS and Linux, brings its own Node
 
 See [The `gitwarren` command line](#the-gitwarren-command-line).
 
-A cross-platform desktop app for doing code reviews of your own git
-repositories, on your own machines. Your machines, your agents, no one else's
-server — and no account.
+Code review for your own git repositories, on your own machines. Your machines,
+your agents, no one else's server — and no account.
 
-Reviews live on the machine the code is on. GitWarren reaches your other
-machines over SSH, over `wsl.exe`, or over your own tailnet, and nothing is
-replicated, relayed or stored anywhere but the computers you already own.
+It runs as a desktop app on macOS, Windows and Linux, or as a command that
+serves the same review UI into a browser tab. Same renderer either way; the
+shell is the only thing that differs. A machine with no screen at all — a VPS, a
+WSL distro, a box an agent works on — runs the headless half and is reviewed
+from somewhere else.
+
+Reviews live on the machine the code is on, and stay there. GitWarren reaches
+your other machines over SSH, over `wsl.exe`, or over your own tailnet, and
+nothing is replicated, relayed or stored anywhere but the computers you already
+own. See [Your other machines](#your-other-machines).
 
 Built for the moment a coding agent — Claude Code, Codex, or anything else that
 edits files on your disk — has just finished, and its work is sitting in your
@@ -64,6 +70,7 @@ Local AI agents get the same capabilities through an MCP server over stdio.
 - [Database migrations](#database-migrations)
 - [Agent access (MCP)](#agent-access-mcp)
 - [The `gitwarren` command line](#the-gitwarren-command-line)
+- [Your other machines](#your-other-machines)
 - [Linking the user back into the app](#linking-the-user-back-into-the-app)
 - [Images in comments](#images-in-comments)
 - [Release process](#release-process)
@@ -702,7 +709,10 @@ which the page turns into `gitwarren://<instance-id>/review/4/conversation`.
 That is what lets a link resolve on whichever GitWarren the user clicked from —
 the app can tell its own review 4 from another machine's. A link naming an
 install this one is not lands on the home screen rather than opening the local
-review with that number; reaching another host arrives in M4.
+review with that number. If the install it names is a host this one knows, the
+link opens *that* machine's review instead — the host segment travels with it,
+so this install's review 4 is never reachable by a link that meant another
+machine's.
 
 The link is a chain of three hops, and each one is load-bearing:
 
@@ -1031,7 +1041,7 @@ It exists for two audiences that the app cannot serve. Someone who will not
 install an Electron app gets the identical renderer in a tab — every line is
 shared, the shell is not. And a machine with no screen at all — a VPS, a WSL
 distro, a box an agent works on — gets the daemon and the MCP server, which is
-what M4 and M5 in [docs/across-hosts.md](docs/across-hosts.md) build on.
+what [Your other machines](#your-other-machines) is built on.
 
 ### Three ways to install it
 
@@ -1039,7 +1049,7 @@ what M4 and M5 in [docs/across-hosts.md](docs/across-hosts.md) build on.
 | --- | --- |
 | `npx gitwarren` | Uses the Node you already have; `better-sqlite3` arrives as an ordinary dependency. The Windows answer, and about 700 KB. |
 | `brew install klarluft/tap/gitwarren-cli` | Pours the self-contained tarball. Brings its own Node, so nothing on the machine can upgrade out from under the native addon. |
-| The release tarball | `gitwarren-daemon-<v>-<target>.tar.gz`, unpacked anywhere. What M4 installs on a remote host. |
+| The release tarball | `gitwarren-daemon-<v>-<target>.tar.gz`, unpacked anywhere. What GitWarren sends to a remote host over SSH. |
 
 The formula is `gitwarren-cli` and the cask stays `gitwarren`. The tokens differ
 so `brew install klarluft/tap/gitwarren` keeps meaning the app; the *binary* is
@@ -1066,7 +1076,7 @@ Two things, and only the second is about logging in:
 
 1. **The launchers.** `~/.gitwarren/bin/gitwarren` and `~/.gitwarren/bin/gitwarren-mcp`,
    at the paths the rest of GitWarren already names — the Agent Access page
-   prints the second as a command to paste, and M4 spawns the first over ssh as
+   prints the second as a command to paste, and the app spawns the first over ssh as
    `~/.gitwarren/bin/gitwarren serve --stdio`. Rerunning after an update points
    them at the install that ran last.
 2. **The login item.** A LaunchAgent on macOS, a `systemd --user` unit on Linux,
@@ -1085,6 +1095,94 @@ build rather than inheriting them. Both have a fallback relative to the working
 directory, and a login item does not have one — launchd starts a job in `/`.
 That is resolved once, at install time, while the answer is still knowable; see
 `src/cli/install.ts`.
+
+---
+
+## Your other machines
+
+A repository lives on one machine, and so does its review. GitWarren does not
+copy either. What it does instead is reach the machine the code is already on,
+run the same review there, and render it in the window in front of you.
+
+Five rules hold this together, and every screen below follows from them:
+
+1. **A host owns its repositories.** SQLite, git and the MCP server for a repo
+   live on the machine that repo is on. Reviews never move.
+2. **Nothing syncs.** The window is a view onto hosts. It caches nothing across
+   a disconnect, and a machine that is offline is shown as offline rather than
+   as its last known state.
+3. **One protocol, several carriers.** The same requests, responses and events
+   run unchanged over a child-process pipe, `wsl.exe`, `ssh`, or a WebSocket.
+4. **Links resolve where they are clicked.** A loopback link names the host in
+   its fragment and opens on whichever GitWarren you clicked from. A tailnet URL
+   is offered in addition, but only while that host is actually listening.
+5. **Agents never cross the network.** MCP stays on stdio, local to its host,
+   reading real paths. The daemon exists for the human elsewhere, not for the
+   agent next to the code.
+
+**Other machines** is where all of it is driven, in both directions: the
+machines this one reaches, and whether this one can be reached back.
+
+### Over SSH
+
+Add a machine you can already reach over `ssh` — a VPS, a build box, a PC's WSL
+distro — and GitWarren installs itself there over the same connection. The host
+needs nothing but git: the daemon tarball ships a Node binary of its own, so
+there is no runtime to install and nothing to keep up to date by hand. It is
+fetched from the GitHub release by the machine you are sitting at and streamed
+down the pipe.
+
+Nothing is left running. `ssh host gitwarren serve --stdio` is spawned on
+demand, and a connection pool hangs up after ten idle minutes rather than
+holding a socket open to every machine you own.
+
+### WSL, from the Windows app
+
+A WSL distro is a host like any other, reached over `wsl.exe` instead of `ssh`.
+The Windows app lists the distributions on the machine and installs into the one
+you pick, running as that distribution's own default user.
+
+Windows-native repositories stay first class — most Windows developers do not
+run WSL, and agents have run natively there since late 2025. A Windows path and
+a WSL path are *different machines*, so a WSL path offered as a local repository
+is refused rather than read through `\\wsl$`, which is the wrong architecture
+even on the days it works.
+
+### On your tailnet
+
+Turn on **Reachable on your tailnet** and GitWarren runs `tailscale serve` in
+front of the loopback port. Every request then has to carry a Tailscale login
+equal to this machine's owner; anything else is refused before it reaches the
+dispatcher. There is no pairing token, and nothing is exposed to the internet —
+`funnel` is deliberately not used.
+
+Your other machines find this one by themselves: peers from
+`tailscale status --json` are probed, and the ones that answer are proposed as
+hosts with the instance id they reported. Manual entry stays for everything
+else. A machine added twice under two names is recognised as one machine,
+because the identity that settles it is the instance id rather than the address
+you typed.
+
+A listening host is also the only kind that can **push**. Comments and reviews
+arrive as events the moment they are written — including writes from an agent,
+which pokes the owner of its data directory over the port it already publishes.
+A host reached over SSH or `wsl.exe` has no process of its own to push from, so
+there the 15-second poll is still the floor. It is the floor everywhere: a lost
+event costs seconds, never correctness.
+
+### The phone
+
+Nothing was built for it. The web view is reachable at the host's `webUrl` from
+any device on the tailnet, and `tailscale serve` supplies the identity, so there
+is no token to get onto a phone. Below `lg` the files list and the diff become
+separate screens and the composer sits above the keyboard.
+
+MCP results carry that `webUrl` alongside the always-present loopback `guiUrl`
+whenever the host is listening — so a link an agent prints can be opened on the
+machine you are holding, not only the one it ran on.
+
+The full design, its spikes and the outcome of every milestone are in
+[docs/across-hosts.md](docs/across-hosts.md).
 
 ---
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -97,7 +97,7 @@ linux:
     - target: AppImage
       arch: [x64, arm64]
   category: Development
-  synopsis: Local code review for your git repositories
+  synopsis: Code review for your own machines and your own agents
   artifactName: ${productName}-${version}-${arch}.${ext}
 
 publish:

--- a/packaging/npm/package.template.json
+++ b/packaging/npm/package.template.json
@@ -1,8 +1,8 @@
 {
   "name": "gitwarren",
   "version": "__VERSION__",
-  "description": "Local-only code review for your git repositories, served on loopback",
-  "keywords": ["code-review", "git", "diff", "mcp", "local-first"],
+  "description": "Code review for your own machines and your own agents, served on loopback. No Electron, no account.",
+  "keywords": ["code-review", "git", "diff", "mcp", "local-first", "ssh", "wsl", "tailscale", "self-hosted"],
   "homepage": "https://github.com/klarluft/gitwarren-app",
   "repository": { "type": "git", "url": "git+https://github.com/klarluft/gitwarren-app.git" },
   "bugs": "https://github.com/klarluft/gitwarren-app/issues",

--- a/src/core/__tests__/comments.test.ts
+++ b/src/core/__tests__/comments.test.ts
@@ -81,6 +81,10 @@ before(() => {
   // a line the reviewer cannot see - in a three-line file the whole file is
   // context and every line is anchorable.
   write(checkout, 'long.ts', longFile('original'))
+  // A file the feature branch never touches, so it is in the repository and
+  // nowhere in the diff. This is what the browse tab is for, and what a comment
+  // on unchanged code has to anchor against.
+  write(checkout, 'untouched.ts', 'const untouched = true\nexport default untouched\n')
   git(checkout, 'add', '.')
   git(checkout, 'commit', '-m', 'initial')
 
@@ -423,20 +427,84 @@ test('the snapshot is never rewritten by later activity on the thread', async ()
   git(checkout, 'reset', '--hard', 'HEAD~1')
 })
 
-test('commenting on a line outside the diff is kept, and says so', async () => {
+test('a line outside the diff anchors against the file itself', async () => {
   // Line 1 of `long.ts` is far above the only hunk, so the reviewer never sees
-  // it in this diff. An agent reading the file with git can still have
-  // something to say about it, and dropping the comment would be worse than
-  // showing it out of line - so it is stored with no anchor text and reported
-  // as unpinnable.
+  // it in this diff - but the file does have a line 1, and it is the line the
+  // comment is about. Anchoring only against the patch used to report this as
+  // outdated the moment it was written.
   const thread = await commentsService.createThread(
     { reviewId, body: 'Unrelated but worth noting.', filePath: 'long.ts', line: 1 },
     claude
   )
 
+  assert.equal(thread.anchorText, 'line 1')
+  assert.deepEqual(
+    thread.anchorSnapshot?.lines.map((line) => line.content),
+    ['line 1']
+  )
+
+  const [anchored] = await commentsService.listAnchored({ reviewId })
+  assert.deepEqual(anchored?.anchor, { state: 'anchored', line: 1, startLine: null })
+})
+
+test('a file the branch never touched can be commented on', async () => {
+  const thread = await commentsService.createThread(
+    { reviewId, body: 'This was already wrong.', filePath: 'untouched.ts', line: 2 },
+    claude
+  )
+
+  assert.equal(thread.anchorText, 'export default untouched')
+
+  const [anchored] = await commentsService.listAnchored({ reviewId })
+  assert.deepEqual(anchored?.anchor, { state: 'anchored', line: 2, startLine: null })
+})
+
+test('a comment on an unchanged file follows its line when the file moves', async () => {
+  const thread = await commentsService.createThread(
+    { reviewId, body: 'This was already wrong.', filePath: 'untouched.ts', line: 2 },
+    claude
+  )
+  assert.equal(thread.anchorText, 'export default untouched')
+
+  // Two lines pushed in above it. The stored line number is now wrong and the
+  // text is the only thing that can find it again - the same rule the diff
+  // side has always followed.
+  write(checkout, 'untouched.ts', '// a note\n// and another\nconst untouched = true\nexport default untouched\n')
+  git(checkout, 'add', '.')
+  git(checkout, 'commit', '-m', 'preamble')
+
+  const [anchored] = await commentsService.listAnchored({ reviewId })
+  assert.deepEqual(anchored?.anchor, { state: 'moved', line: 4, startLine: null })
+
+  git(checkout, 'reset', '--hard', 'HEAD~1')
+})
+
+test('a line the file does not have is still kept, and says so', async () => {
+  // Nothing in the diff and nothing in the file either: `long.ts` is 40 lines.
+  // The comment is worth keeping - an agent may have been reading a stale copy
+  // - but nothing can honestly pin it to a line a reader can see.
+  const thread = await commentsService.createThread(
+    { reviewId, body: 'Off the end.', filePath: 'long.ts', line: 900 },
+    claude
+  )
+
   assert.equal(thread.anchorText, null)
-  // Nothing was on screen to snapshot either; the comment stands on its own.
   assert.equal(thread.anchorSnapshot, null)
+
+  const [anchored] = await commentsService.listAnchored({ reviewId })
+  assert.deepEqual(anchored?.anchor, { state: 'outdated', line: null, startLine: null })
+})
+
+test('a base-side line outside the diff is not matched against the current file', async () => {
+  // "Base" means the version the change started from. A file's text can only
+  // speak for the head side, so claiming a hit here would be pinning a comment
+  // about removed code to code that is still there.
+  const thread = await commentsService.createThread(
+    { reviewId, body: 'What happened to this?', filePath: 'long.ts', side: 'base', line: 1 },
+    claude
+  )
+
+  assert.equal(thread.anchorText, null)
 
   const [anchored] = await commentsService.listAnchored({ reviewId })
   assert.deepEqual(anchored?.anchor, { state: 'outdated', line: null, startLine: null })

--- a/src/core/__tests__/reviews.test.ts
+++ b/src/core/__tests__/reviews.test.ts
@@ -319,6 +319,53 @@ test('excluding uncommitted work reads the committed blob instead', async () => 
   assert.deepEqual(content.lines, ['one', 'TWO', 'three'])
 })
 
+test('the tree lists the whole repository, not only what changed', async () => {
+  const id = await createReview()
+  const tree = await reviewsService.tree({ id, changes: 'all' })
+
+  assert.equal(tree.error, null)
+  // From the worktree, because that is where the head branch is - which is why
+  // the staged and untracked files are here and the diff's uncommitted work is
+  // browsable.
+  assert.equal(tree.source, 'worktree')
+  assert.deepEqual(tree.paths, [
+    '.gitignore',
+    'a.txt',
+    'b.txt',
+    'staged.txt',
+    'untracked.txt'
+  ])
+  // `noise.log` is ignored, and stays out of the listing exactly as it stays
+  // out of a commit. A file browser that showed build output would be a file
+  // browser nobody could find anything in.
+  assert.ok(!tree.paths.includes('noise.log'))
+  assert.equal(tree.truncated, false)
+})
+
+test('excluding uncommitted work lists the head commit instead', async () => {
+  const id = await createReview()
+  const tree = await reviewsService.tree({ id, changes: 'committed' })
+
+  assert.equal(tree.source, 'commit')
+  assert.deepEqual(tree.paths, ['.gitignore', 'a.txt', 'b.txt'])
+})
+
+test('a file the branch never touched is in the tree and can be read', async () => {
+  // The whole point of browsing: `.gitignore` is in neither side of this
+  // review's diff, and is still a file somebody may want to read and remark on.
+  const id = await createReview()
+
+  const tree = await reviewsService.tree({ id, changes: 'all' })
+  assert.ok(tree.paths.includes('.gitignore'))
+
+  const diff = await reviewsService.diff({ id, changes: 'all' })
+  assert.ok(!diff.files.some((file) => file.path === '.gitignore'))
+
+  const content = await reviewsService.file({ id, path: '.gitignore', changes: 'all' })
+  assert.equal(content.error, null)
+  assert.deepEqual(content.lines, ['*.log'])
+})
+
 test('a file outside the repository is refused rather than read', async () => {
   const id = await createReview()
   const content = await reviewsService.file({ id, path: '../../../etc/hosts' })

--- a/src/core/__tests__/reviews.test.ts
+++ b/src/core/__tests__/reviews.test.ts
@@ -363,7 +363,14 @@ test('a file the branch never touched is in the tree and can be read', async () 
 
   const content = await reviewsService.file({ id, path: '.gitignore', changes: 'all' })
   assert.equal(content.error, null)
-  assert.deepEqual(content.lines, ['*.log'])
+  // Compared without the line terminator: this file is checked out by git
+  // rather than written by the test, so on a Windows runner with the default
+  // `core.autocrlf` it arrives as `*.log\r`. What the test is about is that the
+  // content is there to read, not which bytes end the line.
+  assert.deepEqual(
+    content.lines.map((line) => line.replace(/\r$/, '')),
+    ['*.log']
+  )
 })
 
 test('a file outside the repository is refused rather than read', async () => {

--- a/src/core/git-compare.ts
+++ b/src/core/git-compare.ts
@@ -48,6 +48,7 @@ import type {
   ReviewCommits,
   ReviewCompare,
   ReviewDiff,
+  ReviewTree,
   UpstreamTracking,
   WorkingTreeChanges,
   WorkingTreeFile
@@ -728,6 +729,92 @@ async function readUntrackedFiles(worktreePath: string): Promise<FileDiff[]> {
 // ---------------------------------------------------------------------------
 // Whole-file reads, for expanding a diff's hidden context
 // ---------------------------------------------------------------------------
+
+/**
+ * How many paths a tree listing will carry.
+ *
+ * Chosen against real repositories rather than as a round number: a large
+ * monorepo checkout runs to a few tens of thousands of tracked files, and the
+ * screen folds every one of them into a tree it then has to render. Past this
+ * the listing says it was cut short, and the filter box - which is how anybody
+ * finds a file in a tree that size anyway - is still there.
+ *
+ * Paths are cheap on the wire in a way the diff is not: twenty thousand of them
+ * is under a megabyte, read once when the tab is opened and cached under its own
+ * SWR key for the rest of the visit.
+ */
+const MAX_TREE_PATHS = 20_000
+
+/**
+ * Every file in the repository at the review's head.
+ *
+ * Which *head* is the whole question, and the answer is the same one the diff
+ * gives: with a worktree holding the head branch and anything but a
+ * committed-only view asked for, the head *is* that worktree, so the listing
+ * comes from disk and includes the files the branch has not committed yet. A
+ * reviewer looking at uncommitted work who could not open an uncommitted file
+ * would be looking at half a repository.
+ *
+ * `ls-files` rather than `readdir`: it already applies `.gitignore`, so
+ * `node_modules` and build output stay out of the listing exactly as they stay
+ * out of a commit, and it does it in one process rather than one per directory.
+ * `--cached --others` is tracked files plus untracked-but-not-ignored ones,
+ * which together are "what is in this checkout that anyone would review".
+ *
+ * A deleted-but-not-yet-committed file is listed, because `--cached` reports
+ * what the index holds. That is the honest answer: the file is still part of
+ * this review, and asking for it falls back to the committed blob the same way
+ * an expander does.
+ */
+export async function readReviewTree(
+  repositoryPath: string,
+  baseRef: string,
+  headRef: string,
+  options: ReadDiffOptions
+): Promise<ReviewTree> {
+  const compare = await resolveCompare(repositoryPath, baseRef, headRef)
+  const changes = effectiveChanges(options.changes, compare)
+  const empty = { paths: [], truncated: false }
+
+  const worktree = changes === 'committed' ? null : compare.headWorktree
+  const source = worktree === null ? 'commit' : 'worktree'
+
+  if (worktree === null && !compare.head.sha) {
+    return { ...empty, source, error: compare.error ?? 'The head ref does not resolve to a commit.' }
+  }
+
+  const result =
+    worktree === null
+      ? await runGitRaw(
+          // `-r` recurses into subtrees so the result is files rather than
+          // directory objects; without it a listing stops at the top level.
+          ['-c', 'core.quotePath=false', 'ls-tree', '-r', '--name-only', '-z', compare.head.sha as string, '--'],
+          repositoryPath
+        )
+      : await runGitRaw(
+          ['-c', 'core.quotePath=false', 'ls-files', '-z', '--cached', '--others', '--exclude-standard', '--'],
+          worktree.path
+        )
+
+  if (result.code !== 0) {
+    return { ...empty, source, error: result.stderr.trim() || 'Could not list the files.' }
+  }
+
+  // NUL-separated, so a path with a newline or a quote in it survives whole -
+  // which is also why `core.quotePath` is off above rather than the output
+  // being unescaped here.
+  const all = result.stdout.split('\0').filter((path) => path.length > 0)
+  // `--cached --others` can name the same path twice when a file is both
+  // tracked and reported as other; `ls-files` does not promise a sort either.
+  const paths = [...new Set(all)].sort((left, right) => left.localeCompare(right))
+
+  return {
+    paths: paths.slice(0, MAX_TREE_PATHS),
+    source,
+    truncated: paths.length > MAX_TREE_PATHS,
+    error: null
+  }
+}
 
 /** Past this a file is not worth shipping across IPC to render as context. */
 const MAX_FILE_LINES = 20_000

--- a/src/core/rpc/dispatcher.ts
+++ b/src/core/rpc/dispatcher.ts
@@ -197,6 +197,7 @@ const handlers: {
   'reviews.remove': (params) => reviewsService.remove(params),
   'reviews.commits': (params) => reviewsService.commits(params),
   'reviews.diff': (params) => reviewsService.diff(params),
+  'reviews.tree': (params) => reviewsService.tree(params),
   'reviews.file': (params) => reviewsService.file(params),
   'reviews.image': (params) => reviewsService.image(params),
   'reviews.filePath': (params) => reviewsService.absolutePath(params),

--- a/src/core/services/comments.ts
+++ b/src/core/services/comments.ts
@@ -25,7 +25,7 @@ import {
   type RepositoryRow,
   type ReviewRow
 } from '../db/schema.js'
-import { readReviewDiff } from '../git-compare.js'
+import { readReviewDiff, readReviewFile } from '../git-compare.js'
 import { attachmentReferencesIn, ingestBodyAttachments } from '../attachment-ingest.js'
 import { attachmentsBySha, parseAttachmentUrl } from './attachments.js'
 import { AppError } from '../../shared/errors.js'
@@ -34,11 +34,12 @@ import {
   findAnchorFile,
   isInlineAnchor,
   resolveAnchor,
+  resolveAnchorInFile,
   type AnchorState,
   type DiffSide
 } from '../../shared/comment-anchors.js'
 import type { DiffChanges } from '../../shared/git.js'
-import { contextForRange, snippetAt } from '../../shared/comment-snippets.js'
+import { contextForRange, snippetAt, snippetInFile } from '../../shared/comment-snippets.js'
 import { parseWithSchema as parse } from '../../shared/validation.js'
 import {
   anchorSnapshotSchema,
@@ -249,19 +250,35 @@ function readThreads(reviewId: number): CommentThread[] {
 }
 
 /**
- * What the diff said at the moment a thread was opened.
+ * What the code said at the moment a thread was opened.
  *
  * Two things are kept, and they do different jobs. `anchorText` is the one line,
- * and it is what `resolveAnchor` re-finds the comment by later. `snapshot` is
- * that line with the few above it - GitHub's `diff_hunk` - and it exists purely
- * so the comment is still readable after the code it was about has been
+ * and it is what the anchor resolvers re-find the comment by later. `snapshot`
+ * is that line with the few above it - GitHub's `diff_hunk` - and it exists
+ * purely so the comment is still readable after the code it was about has been
  * rewritten. Neither is ever updated afterwards; a snapshot that follows the
  * branch is not a snapshot.
  *
- * Both are null when the line is not in the diff - an agent commenting on an
- * unchanged part of a file, or on a stale line number. That is not an error:
- * the comment is still worth keeping, it simply cannot be pinned to a line the
- * reader can see, and `resolveAnchor` reports it as outdated from the start.
+ * ## Two places the line can be found, and why the second one matters
+ *
+ * The diff first, because a comment on changed code should be captured from
+ * exactly the patch the commenter was reading - the base side of an
+ * `uncommitted` diff numbers a different commit than the base side of a
+ * committed one, and only the diff knows which.
+ *
+ * Then the file, for every line the patch does not print. That is not a rare
+ * fallback: it is the ordinary case for the browse tab, where the whole point
+ * is to remark on code the branch did not touch, and it was already the case
+ * for a comment left on a line unfolded out of a diff's expanders. Before this,
+ * both stored no anchor at all - which meant the comment was reported
+ * `outdated` from the second it was written, not because anything had drifted
+ * but because nobody had looked in the document it was actually about.
+ *
+ * Both are still null when neither can vouch for the line: a base-side line
+ * outside the patch (by definition one this change removed, which the current
+ * file cannot speak for), a binary or unreadable file, a line number past the
+ * end. That is not an error - the comment is kept either way - it simply cannot
+ * be pinned to a line a reader can see.
  */
 async function captureAnchor(
   repositoryPath: string,
@@ -279,17 +296,68 @@ async function captureAnchor(
     .flatMap((hunk) => hunk.lines)
     .find((candidate) => (side === 'base' ? candidate.oldNumber : candidate.newNumber) === line)
 
-  return {
-    anchorText: found?.content ?? null,
-    anchorSha: diff.head.sha,
-    // A comment on a block is snapshotted across the whole block, so an
-    // outdated one is still shown against everything it was about rather than
-    // against its last line alone.
-    snapshot:
-      found === undefined
-        ? null
-        : snippetAt(file, side, line, contextForRange(startLine, line))
+  if (found !== undefined) {
+    return {
+      anchorText: found.content,
+      anchorSha: diff.head.sha,
+      // A comment on a block is snapshotted across the whole block, so an
+      // outdated one is still shown against everything it was about rather than
+      // against its last line alone.
+      snapshot: snippetAt(file, side, line, contextForRange(startLine, line))
+    }
   }
+
+  const unanchored = { anchorText: null, anchorSha: diff.head.sha, snapshot: null }
+  if (side === 'base') return unanchored
+
+  const content = await readReviewFile(repositoryPath, review.baseRef, review.headRef, filePath, {
+    changes
+  })
+  const text = content.error !== null || content.isBinary ? undefined : content.lines[line - 1]
+  if (text === undefined) return unanchored
+
+  return {
+    anchorText: text,
+    anchorSha: diff.head.sha,
+    snapshot: snippetInFile(content.lines, line, contextForRange(startLine, line))
+  }
+}
+
+/**
+ * The files needed to re-find comments the diff could not place.
+ *
+ * Capped, and the cap is the reason this is a function rather than four lines
+ * inline. `listAnchored` is an agent-facing call; a review that has collected
+ * comments on a hundred different untouched files would otherwise spawn a
+ * hundred git processes to answer one question about a discussion. Past the
+ * ceiling the remaining threads keep the answer the diff gave them, which is
+ * the same `outdated` they reported before any of this existed - degraded, not
+ * wrong.
+ *
+ * Paths are read together rather than in sequence: they are independent reads
+ * of independent files, so the cost is the slowest rather than the sum.
+ */
+const MAX_ANCHOR_FILE_READS = 25
+
+async function readFilesForAnchoring(
+  repositoryPath: string,
+  review: ReviewRow,
+  paths: string[]
+): Promise<Map<string, string[]>> {
+  const read = await Promise.all(
+    paths.slice(0, MAX_ANCHOR_FILE_READS).map(async (path) => {
+      const content = await readReviewFile(repositoryPath, review.baseRef, review.headRef, path, {
+        // The widest view of the branch, matching the diff read above it: a
+        // comment should anchor against the code as the branch actually stands.
+        changes: 'all'
+      })
+      return [path, content.error !== null || content.isBinary ? null : content.lines] as const
+    })
+  )
+
+  return new Map(
+    read.filter((entry): entry is readonly [string, string[]] => entry[1] !== null)
+  )
 }
 
 /**
@@ -354,11 +422,18 @@ export const commentsService = {
   },
 
   /**
-   * The same threads, each resolved against the current diff.
+   * The same threads, each resolved against the code as it stands now.
    *
    * This is the shape agents get. They have no diff in hand and no way to run
    * the anchoring themselves, and an agent acting on a comment needs to know
    * whether it still points at live code.
+   *
+   * The diff answers for every thread about changed code, in one read. What is
+   * left over are threads about files the patch does not contain - comments
+   * left in the browse tab, and the ones an agent writes on unchanged code - and
+   * those are re-found in the files themselves, one read per distinct path. The
+   * order matters: a file that *is* in the diff must be resolved against the
+   * diff, because a base-side line has no counterpart in the head-side file.
    */
   async listAnchored(input: unknown): Promise<AnchoredCommentThread[]> {
     const { reviewId } = parse(listCommentsInputSchema, input)
@@ -375,19 +450,65 @@ export const commentsService = {
       changes: 'all'
     })
 
-    return threads.map((thread) => {
-      if (!isInlineAnchor(thread)) return { ...thread, anchor: null }
+    const placed = threads.map((thread) => {
+      if (!isInlineAnchor(thread)) return { thread, anchor: null, path: null }
       const file = findAnchorFile(diff.files, thread.filePath)
       return {
-        ...thread,
+        thread,
         anchor: resolveAnchor(file, {
           filePath: thread.filePath,
           side: thread.side,
           line: thread.line,
           startLine: thread.startLine,
           anchorText: thread.anchorText
-        })
+        }),
+        /**
+         * Which file to read if the diff could not place it - under the name
+         * the file has *now*, so a thread left before a rename is re-found in
+         * the file it became rather than at a path nothing answers to.
+         */
+        path: file?.path ?? thread.filePath
       }
+    })
+
+    /**
+     * The threads the diff had nothing to say about, on the head side, with
+     * something to search for.
+     *
+     * "Outside the diff" is not the same as "outside the patch": a file can be
+     * in the diff and the commented line still nowhere in its hunks - a remark
+     * on the function a change sits inside, or on any line a reviewer unfolded
+     * out of an expander. Both land here, which is why the test is the *result*
+     * the diff gave rather than whether the file appeared in it.
+     */
+    const unplaced = placed.filter(
+      (entry) =>
+        entry.anchor?.state === 'outdated' &&
+        entry.path !== null &&
+        entry.thread.side === 'head' &&
+        entry.thread.anchorText !== null
+    )
+
+    const files = await readFilesForAnchoring(repository.path, review, [
+      ...new Set(unplaced.map((entry) => entry.path as string))
+    ])
+
+    return placed.map(({ thread, anchor, path }) => {
+      if (anchor === null || anchor.state !== 'outdated' || path === null) {
+        return { ...thread, anchor }
+      }
+
+      const refound = resolveAnchorInFile(files.get(path), {
+        filePath: path,
+        side: thread.side,
+        line: thread.line,
+        startLine: thread.startLine,
+        anchorText: thread.anchorText
+      })
+
+      // Only ever an improvement: the diff already said outdated, so a miss
+      // here leaves the answer exactly where it was.
+      return { ...thread, anchor: refound.state === 'outdated' ? anchor : refound }
     })
   },
 

--- a/src/core/services/reviews.ts
+++ b/src/core/services/reviews.ts
@@ -7,7 +7,7 @@
  *
  * The split worth noticing here is between the CRUD half and the read-only git
  * half. `list`/`get`/`create`/`update`/`remove` write durable rows and are
- * exposed to agents over MCP. `commits`/`diff` only read git, and are
+ * exposed to agents over MCP. `commits`/`diff`/`tree` only read git, and are
  * deliberately *not* exposed: an agent with access to the repository can run
  * `git log` and `git diff` itself, and a second, lossier copy of that data
  * behind a tool call would be strictly worse than the real thing. What agents
@@ -22,6 +22,7 @@ import {
   readReviewDiff,
   readReviewFile,
   readReviewImage,
+  readReviewTree,
   resolveCompare,
   resolveReviewFilePath
 } from '../git-compare.js'
@@ -37,11 +38,12 @@ import {
   reviewDiffInputSchema,
   reviewFileInputSchema,
   reviewImageInputSchema,
+  reviewTreeInputSchema,
   updateReviewInputSchema,
   type Review,
   type ReviewWithRepository
 } from '../../shared/schemas.js'
-import type { FileContent, FileImage, ReviewCommits, ReviewDiff } from '../../shared/git.js'
+import type { FileContent, FileImage, ReviewCommits, ReviewDiff, ReviewTree } from '../../shared/git.js'
 
 function toReview(row: ReviewRow): Review {
   return {
@@ -228,6 +230,23 @@ export const reviewsService = {
     const row = requireReview(id)
     const repository = requireRepository(row.repositoryId)
     return readReviewDiff(repository.path, row.baseRef, row.headRef, { changes })
+  },
+
+  /**
+   * Every file in the repository at the review's head, changed or not.
+   *
+   * A read-only git call like `commits` and `diff`, and exposed to the UI for
+   * the same reason they are: a person looking at a review on another machine
+   * has no filesystem to browse. It stays off the MCP surface for the reason
+   * given at the top of this file - an agent with the repository in front of it
+   * has `git ls-files`, and a lossier copy behind a tool call would be worse
+   * than the real thing.
+   */
+  async tree(input: unknown): Promise<ReviewTree> {
+    const { id, changes } = parse(reviewTreeInputSchema, input)
+    const row = requireReview(id)
+    const repository = requireRepository(row.repositoryId)
+    return readReviewTree(repository.path, row.baseRef, row.headRef, { changes })
   },
 
   /**

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -415,10 +415,12 @@ server.registerTool(
     description:
       'Every discussion on a review: review-level threads and line comments alike, each with its ' +
       'full message history and who wrote each message. Line threads also carry an `anchor` ' +
-      'saying where they land in the diff as it stands right now - "anchored" (the line is ' +
+      'saying where they land in the code as it stands right now - "anchored" (the line is ' +
       'unchanged), "moved" (the code shifted and `anchor.line` is its current line) or "outdated" ' +
-      '(the line is no longer in the diff, so the comment may be about code that has since been ' +
-      'rewritten). Check the anchor before acting on a line comment. An outdated one still ' +
+      '(the line is gone, so the comment may be about code that has since been rewritten). ' +
+      'Threads about files the diff does not contain are resolved against those files at the ' +
+      'head rather than against the patch, so a comment on unchanged code reports an honest ' +
+      'anchor too. Check the anchor before acting on a line comment. An outdated one still ' +
       'carries `anchorSnapshot`, the code as it read when the comment was written, which is how ' +
       'to tell what was being objected to before it was rewritten.\n\n' +
       'A body may contain images, written as markdown pointing at a ' +
@@ -450,8 +452,12 @@ server.registerTool(
       'default) for the code as it will be, "base" to remark on a line the change removed. ' +
       'Add `startLine` to comment on a block rather than a single line; `line` is then the ' +
       'last line of it, and the one the whole range follows if the code moves. ' +
-      'The line is not required to be part of the diff: the comment is kept either way, and the ' +
-      'returned thread says whether it could be anchored to a visible line. ' +
+      'The line is not required to be part of the diff. A line the patch does not print is ' +
+      'looked up in the file itself at the head, so a remark on code this branch did not touch ' +
+      'anchors and follows that code exactly as one on a changed line does - people read these ' +
+      'in the review\'s Browse files tab. Only a line that is in neither the diff nor the file ' +
+      '(past the end of it, or on the "base" side outside the patch) is kept without an anchor; ' +
+      'the returned thread says which happened. ' +
       'Comments are attributed automatically from the MCP handshake - see `agent_identity`.\n\n' +
       ATTACHMENT_GUIDANCE +
       GUI_URL_NOTE + WEB_URL_NOTE,

--- a/src/renderer/src/features/reviews/changed-files-tree.tsx
+++ b/src/renderer/src/features/reviews/changed-files-tree.tsx
@@ -1,11 +1,9 @@
 /**
  * The list of changed files beside the diff.
  *
- * A flat list of paths is unreadable past about a dozen files - every row
- * starts with the same forty characters - so the paths are folded into a tree.
- * Directories with a single child are collapsed into their parent
- * (`src/renderer/src` on one row), which is what makes a deep source tree fit
- * in a narrow column and is the one thing GitHub's file tree gets most right.
+ * The folding into a tree is `path-tree.ts`, shared with the browse tab's
+ * listing of the whole repository. What is here is what a *changed* file's row
+ * says: how much changed, whether anyone commented, whether it has been read.
  *
  * The tree is a *navigation* aid, not a second copy of the diff: it scrolls the
  * page to a file, and it says how much changed and whether anyone commented.
@@ -16,75 +14,8 @@ import { Check, ChevronDown, ChevronRight, History } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { FileStatusIcon } from './diff-view'
 import { FilePath } from './file-path'
+import { buildPathTree, type PathNode } from './path-tree'
 import type { FileDiff } from '@shared/git'
-
-interface FileNode {
-  kind: 'file'
-  /** Full repository-relative path - also the DOM anchor and the tree key. */
-  path: string
-  name: string
-  file: FileDiff
-}
-
-interface DirectoryNode {
-  kind: 'directory'
-  path: string
-  /** May be several segments, when a chain of lone directories was folded. */
-  name: string
-  children: TreeNode[]
-}
-
-type TreeNode = FileNode | DirectoryNode
-
-function buildTree(files: FileDiff[]): TreeNode[] {
-  const root: DirectoryNode = { kind: 'directory', path: '', name: '', children: [] }
-
-  for (const file of files) {
-    const segments = file.path.split('/')
-    const name = segments.pop() as string
-    let parent = root
-
-    for (const segment of segments) {
-      const path = parent.path ? `${parent.path}/${segment}` : segment
-      const existing = parent.children.find(
-        (child): child is DirectoryNode => child.kind === 'directory' && child.path === path
-      )
-      if (existing) {
-        parent = existing
-      } else {
-        const created: DirectoryNode = { kind: 'directory', path, name: segment, children: [] }
-        parent.children.push(created)
-        parent = created
-      }
-    }
-
-    parent.children.push({ kind: 'file', path: file.path, name, file })
-  }
-
-  // The root itself is not collapsed: folding it away would silently drop the
-  // one directory every file in the review shares, which is exactly the label
-  // that tells you what part of the tree you are looking at.
-  return root.children.map((child) => (child.kind === 'directory' ? collapse(child) : child))
-}
-
-/** Fold `a` -> `b` -> [files] into a single `a/b` row. */
-function collapse(node: DirectoryNode): DirectoryNode {
-  const children = node.children.map((child) =>
-    child.kind === 'directory' ? collapse(child) : child
-  )
-
-  const only = children.length === 1 ? children[0] : undefined
-  if (only?.kind === 'directory') {
-    return {
-      kind: 'directory',
-      path: only.path,
-      name: node.name ? `${node.name}/${only.name}` : only.name,
-      children: only.children
-    }
-  }
-
-  return { ...node, children }
-}
 
 export interface ChangedFilesTreeProps {
   files: FileDiff[]
@@ -107,7 +38,9 @@ export function ChangedFilesTree({
   reviewedPaths,
   changedSincePaths
 }: ChangedFilesTreeProps) {
-  const tree = useMemo(() => buildTree(files), [files])
+  const tree = useMemo(() => buildPathTree(files.map((file) => file.path)), [files])
+  // What each row needs about its own file, looked up by path - see `path-tree.ts`.
+  const byPath = useMemo(() => new Map(files.map((file) => [file.path, file])), [files])
 
   return (
     <nav aria-label="Changed files" className="flex flex-col gap-px py-1 text-xs">
@@ -116,6 +49,7 @@ export function ChangedFilesTree({
           key={node.path}
           node={node}
           depth={0}
+          byPath={byPath}
           activePath={activePath}
           onSelect={onSelect}
           unresolvedByFile={unresolvedByFile}
@@ -130,14 +64,16 @@ export function ChangedFilesTree({
 function TreeRows({
   node,
   depth,
+  byPath,
   activePath,
   onSelect,
   unresolvedByFile,
   reviewedPaths,
   changedSincePaths
 }: {
-  node: TreeNode
+  node: PathNode
   depth: number
+  byPath: Map<string, FileDiff>
 } & Omit<ChangedFilesTreeProps, 'files'>) {
   const [open, setOpen] = useState(true)
   // Indent by nesting depth, but stop growing it before the column runs out of
@@ -169,6 +105,7 @@ function TreeRows({
               key={child.path}
               node={child}
               depth={depth + 1}
+              byPath={byPath}
               activePath={activePath}
               onSelect={onSelect}
               unresolvedByFile={unresolvedByFile}
@@ -180,6 +117,8 @@ function TreeRows({
     )
   }
 
+  // Always present: the tree was built from these very paths.
+  const file = byPath.get(node.path) as FileDiff
   const unresolved = unresolvedByFile.get(node.path) ?? 0
   const isActive = node.path === activePath
   const isReviewed = reviewedPaths.has(node.path)
@@ -210,7 +149,7 @@ function TreeRows({
       ) : hasChangedSince ? (
         <History className="mt-0.5 size-3 shrink-0 text-warning" />
       ) : (
-        <FileStatusIcon status={node.file.status} className="mt-0.5 size-3 shrink-0" />
+        <FileStatusIcon status={file.status} className="mt-0.5 size-3 shrink-0" />
       )}
       {/* The whole name, wrapped if it has to be. A file list that cannot tell
           you which file a row is is not doing the one job it has. */}
@@ -223,10 +162,10 @@ function TreeRows({
           {unresolved}
         </span>
       )}
-      {!node.file.isBinary && (
+      {!file.isBinary && (
         <span className="mt-px shrink-0 font-mono text-[0.625rem] tabular-nums">
-          <span className="text-success">+{node.file.additions}</span>{' '}
-          <span className="text-destructive">−{node.file.deletions}</span>
+          <span className="text-success">+{file.additions}</span>{' '}
+          <span className="text-destructive">−{file.deletions}</span>
         </span>
       )}
     </button>

--- a/src/renderer/src/features/reviews/diff-snippet.tsx
+++ b/src/renderer/src/features/reviews/diff-snippet.tsx
@@ -41,6 +41,12 @@ interface DiffSnippetProps {
   /** Head sha the snapshot was taken against, shown with the note. */
   capturedSha?: string | null
   onOpen?: () => void
+  /**
+   * Where `onOpen` goes, for the tooltip. A snippet can lead to Files changed
+   * or, for a comment on a file that diff does not contain, to Browse files -
+   * and a button that names the wrong one of those is worse than a plain path.
+   */
+  openLabel?: string
   className?: string
 }
 
@@ -55,6 +61,7 @@ export function DiffSnippet({
   historical = false,
   capturedSha = null,
   onOpen,
+  openLabel = 'Files changed',
   className
 }: DiffSnippetProps) {
   // "was line" matches how the Files changed tab labels a thread it can no
@@ -78,7 +85,7 @@ export function DiffSnippet({
         type="button"
         onClick={onOpen}
         disabled={!onOpen}
-        title={onOpen ? `Open ${filePath} in Files changed` : filePath}
+        title={onOpen ? `Open ${filePath} in ${openLabel}` : filePath}
         className={cn(
           'flex w-full items-center gap-2 px-3 py-2 text-left',
           onOpen && 'transition-colors hover:bg-muted/60'

--- a/src/renderer/src/features/reviews/diff-view.tsx
+++ b/src/renderer/src/features/reviews/diff-view.tsx
@@ -66,6 +66,7 @@ import {
 } from '@shared/diff-gaps'
 import { errorMessage } from '@/lib/errors'
 import { matchOffsets, rowPosition, type DiffSearch } from './diff-search'
+import { useLineSelection, type LineRange } from './line-selection'
 import { imageMediaType } from '@shared/git'
 import type { DiffChanges, DiffHunk, DiffLine, FileChangeStatus, FileDiff } from '@shared/git'
 import type { CommentThread } from '@shared/schemas'
@@ -115,16 +116,6 @@ export function FileStatusIcon({
   return <Icon className={cn('size-4 shrink-0', STATUS_COLOURS[status], className)} />
 }
 
-/**
- * A run of lines on one side of the diff: what a comment covers, and what the
- * reviewer is dragging out before the composer opens. `startLine === line` is
- * an ordinary single-line comment, which is most of them.
- */
-export interface LineRange {
-  side: DiffSide
-  startLine: number
-  line: number
-}
 
 /** A thread together with where it lands in the diff being displayed. */
 export interface AnchoredThread extends CommentThread {
@@ -218,8 +209,13 @@ export function FileDiffCard({
   file: FileDiff
   comments?: DiffComments
   source?: DiffFileSource
-  /** A line in *this* file someone has navigated to; opens the card if folded. */
-  focus?: { side: DiffSide; line: number }
+  /**
+   * Set when this is the file someone has navigated to; opens the card if it is
+   * folded. Only its presence is read here - the line is drawn from `marked`,
+   * and scrolled to by id - so a link that names a file and no line still opens
+   * the card it names.
+   */
+  focus?: { side?: DiffSide; line?: number }
   /** The same line while it is still worth pointing at. */
   marked?: { side: DiffSide; line: number }
   /** Omitted where there is nothing to mark against - a card shown on its own. */
@@ -230,12 +226,10 @@ export function FileDiffCard({
   const lineCount = file.hunks.reduce((total, hunk) => total + hunk.lines.length, 0)
   /** Null until the reviewer opens or closes the card themselves. */
   const [toggled, setToggled] = useState<boolean | null>(null)
-  /** The lines the reviewer is writing a new comment on. */
-  const [composingOn, setComposingOn] = useState<LineRange | null>(null)
-  /** The range being dragged out right now, before the pointer comes up. */
-  const [dragging, setDragging] = useState<LineRange | null>(null)
   /** Head-side line numbers unfolded out of the gaps between the hunks. */
   const [revealed, setRevealed] = useState<ReadonlySet<number>>(() => new Set())
+  const { composingOn, setComposingOn, startSelection, dragOver, selection, isDragging } =
+    useLineSelection()
 
   const isReviewed = reviewed?.isReviewed ?? false
 
@@ -292,89 +286,6 @@ export function FileDiffCard({
     [text]
   )
 
-  /**
-   * Start commenting at a line, or grow the open range to reach it.
-   *
-   * Two gestures, both of which people already know from GitHub: press and
-   * drag the `+` down the gutter, or shift-click a second line. Shift-click
-   * keeps the first line of the existing range as the anchor, so the range
-   * only ever grows away from where the reviewer started.
-   */
-  const startSelection = useCallback(
-    (side: DiffSide, line: number, extend: boolean) => {
-      if (extend && composingOn && composingOn.side === side) {
-        const anchor = composingOn.startLine
-        setComposingOn({ side, startLine: Math.min(anchor, line), line: Math.max(anchor, line) })
-        return
-      }
-      setDragging({ side, startLine: line, line })
-    },
-    [composingOn]
-  )
-
-  const dragOver = useCallback((side: DiffSide, line: number) => {
-    setDragging((current) => {
-      if (!current || current.side !== side || current.line === line) return current
-      // `startLine` stays the line the drag began on; the pointer can be either
-      // side of it, and the range is normalised when the pointer comes up.
-      return { ...current, line }
-    })
-  }, [])
-
-  /**
-   * A drag ends wherever the pointer is released, which is often outside the
-   * button - or outside the card - so the listener goes on the window.
-   *
-   * The *move* is on the window for a different and less obvious reason. Rows
-   * also report `onPointerEnter`, and with a mouse that is enough: the pointer
-   * really does travel across each row and each row really is told. A finger
-   * does not work that way. Touch sets *implicit pointer capture* on whatever
-   * the gesture started on - the `+` button - so for the rest of the drag every
-   * pointer event is delivered to that button and no row is ever entered. The
-   * range simply never grew, which is why dragging out several lines worked on
-   * a desktop and did nothing at all on a phone.
-   *
-   * So the pointer is followed rather than waited for: one listener, hit-test
-   * where it actually is, read the row's own `data-diff-*` off the result. That
-   * is correct for a mouse too - `onPointerEnter` stays because it costs
-   * nothing and keeps the desktop path working if a hit-test ever lands on
-   * something unexpected - and it is the same set of coordinates either way.
-   */
-  useEffect(() => {
-    if (!dragging) return
-
-    const move = (event: PointerEvent): void => {
-      const under = document.elementFromPoint(event.clientX, event.clientY)
-      const row = under?.closest('[data-diff-line]')
-      if (!row) return
-      const side = row.getAttribute('data-diff-side')
-      const line = Number(row.getAttribute('data-diff-line'))
-      if ((side === 'base' || side === 'head') && Number.isInteger(line)) dragOver(side, line)
-    }
-
-    const finish = (): void => {
-      const startLine = Math.min(dragging.startLine, dragging.line)
-      const line = Math.max(dragging.startLine, dragging.line)
-      setDragging(null)
-      setComposingOn((current) =>
-        // Clicking the `+` of a composer that is already open on exactly those
-        // lines closes it again, which is how the button worked before ranges.
-        current && current.side === dragging.side && current.startLine === startLine && current.line === line
-          ? null
-          : { side: dragging.side, startLine, line }
-      )
-    }
-
-    window.addEventListener('pointermove', move)
-    window.addEventListener('pointerup', finish)
-    window.addEventListener('pointercancel', finish)
-    return () => {
-      window.removeEventListener('pointermove', move)
-      window.removeEventListener('pointerup', finish)
-      window.removeEventListener('pointercancel', finish)
-    }
-  }, [dragging, dragOver])
-
   // A shared constant rather than a fresh `[]`, so a file with no comments
   // does not hand the memo below a new array identity on every render.
   const threads = comments?.threads ?? NO_THREADS
@@ -425,15 +336,7 @@ export function FileDiffCard({
     onCompose: setComposingOn,
     onSelectStart: startSelection,
     onSelectOver: dragOver,
-    // While the pointer is down the drag wins; after it comes up the composer's
-    // own range is what stays lit.
-    selection: dragging
-      ? {
-          side: dragging.side,
-          startLine: Math.min(dragging.startLine, dragging.line),
-          line: Math.max(dragging.startLine, dragging.line)
-        }
-      : composingOn,
+    selection,
     covered,
     marked: marked ?? null,
     filePath: file.path,
@@ -659,7 +562,7 @@ export function FileDiffCard({
           {/* `@container` makes this element an inline-size container, which is
               what lets a comment inside it be sized to the *visible* width
               rather than to the width of the scrolled code. */}
-          <div className={cn('@container overflow-x-auto', dragging && 'select-none')}>
+          <div className={cn('@container overflow-x-auto', isDragging && 'select-none')}>
             <div className="min-w-max font-mono text-xs leading-5">
               {file.hunks.map((hunk, index) => {
                 const gap = gapByHunk.get(index)
@@ -747,7 +650,7 @@ export function FileDiffCard({
  * far side of the header, because "copy" on its own says nothing about what
  * gets copied - next to the thing it copies, it needs no explaining.
  */
-function CopyPathAction({ path }: { path: string }) {
+export function CopyPathAction({ path }: { path: string }) {
   const [copied, setCopied] = useState(false)
 
   async function copyPath(): Promise<void> {
@@ -803,7 +706,7 @@ function FileActions({
   )
 }
 
-function IconAction({
+export function IconAction({
   label,
   onClick,
   icon
@@ -1023,7 +926,7 @@ function ExpandButton({
   )
 }
 
-interface RowContext {
+export interface RowContext {
   placed: Map<string, AnchoredThread[]>
   comments: DiffComments | undefined
   /** The range the composer is open on, if any. */
@@ -1042,6 +945,15 @@ interface RowContext {
   filePath: string
   /** The find in progress, so a row can pick its own hits out. */
   search: DiffSearch | null
+  /**
+   * Draw one number column instead of two.
+   *
+   * A diff has two sides and therefore two gutters, one of which is blank on
+   * any given row. A *file* has one, and rendering the diff's grid for it
+   * leaves three rems of permanently empty column down the left of everything -
+   * see `file-source-view.tsx`, which is the only caller that sets this.
+   */
+  oneGutter?: boolean
 }
 
 function HunkRows({
@@ -1064,7 +976,7 @@ function HunkRows({
   )
 }
 
-function LineRow({
+export function LineRow({
   line,
   placed,
   comments,
@@ -1076,7 +988,8 @@ function LineRow({
   covered,
   marked,
   filePath,
-  search
+  search,
+  oneGutter = false
 }: { line: DiffLine } & RowContext) {
   // Which side a comment on this row belongs to, and the number it carries
   // there. Shared with the search, so a hit is addressed to the row it is on.
@@ -1110,7 +1023,8 @@ function LineRow({
         data-diff-side={number === null ? undefined : side}
         data-diff-line={number === null ? undefined : number}
         className={cn(
-          'group grid grid-cols-[3rem_3rem_1fr]',
+          'group grid',
+          oneGutter ? 'grid-cols-[3rem_1fr]' : 'grid-cols-[3rem_3rem_1fr]',
           // Backgrounds are mutually exclusive rather than layered: two
           // background utilities on one element are resolved by stylesheet
           // order, not by the order they are written here.
@@ -1128,7 +1042,7 @@ function LineRow({
           inThread && 'shadow-[inset_3px_0_0_0_var(--color-primary)]'
         )}
       >
-        <Gutter value={line.oldNumber} />
+        {!oneGutter && <Gutter value={line.oldNumber} />}
         <div
           className="relative border-r border-border"
           // Extending a drag has to be caught on the row, not on the button:
@@ -1336,7 +1250,7 @@ function LineText({
   return <>{parts}</>
 }
 
-function Gutter({ value }: { value: number | null }) {
+export function Gutter({ value }: { value: number | null }) {
   return (
     <span className="select-none border-r border-border px-2 text-right tabular-nums text-muted-foreground/70">
       {value ?? ''}

--- a/src/renderer/src/features/reviews/file-source-view.tsx
+++ b/src/renderer/src/features/reviews/file-source-view.tsx
@@ -1,0 +1,305 @@
+/**
+ * One file of a review, whole, with the same comment gutter the diff has.
+ *
+ * This is the browse tab's counterpart to `FileDiffCard`, and the reason it is
+ * a separate component rather than a mode of that one is that the two are
+ * answering different questions. A diff card is about a *change*: it has two
+ * sides, a status, a line count that changed, a reviewed tick that means "I
+ * have read this change". A file has none of that. It is one version of one
+ * document, and dressing it up as a patch with no hunks would mean a card that
+ * spends most of its code explaining which of its own affordances do not apply.
+ *
+ * What the two do share is the part that matters: a row of code with a `+` in
+ * its gutter, and what happens when you drag that `+` down five lines.
+ * `LineRow` and `useLineSelection` are both used verbatim here, so a comment
+ * left on an unchanged file is made with the same gesture, drawn in the same
+ * place, and stored through the same call as one left on a diff.
+ *
+ * ## Lines, not hunks
+ *
+ * The file arrives as `FileContent` - the same read the diff's expanders make -
+ * and each line becomes a `DiffLine` of type `context` numbered on the head
+ * side only. `oldNumber` is deliberately null: `rowPosition` then reports every
+ * row as head-side, which is what a file that is not being compared to anything
+ * actually is, and the base-side gutter draws blank instead of repeating the
+ * same number twice.
+ */
+import { useEffect, useMemo } from 'react'
+import { FileWarning } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { errorMessage } from '@/lib/errors'
+import { cn } from '@/lib/utils'
+import { CommentThreadCard } from '../comments/comment-thread-card'
+import { CopyPathAction, IconAction, LineRow, type DiffComments, type RowContext } from './diff-view'
+import { FilePath } from './file-path'
+import { ImagePane } from './image-diff'
+import { useLineSelection } from './line-selection'
+import { useReviewFile } from './use-reviews'
+import { SquareArrowOutUpRight } from 'lucide-react'
+import { resolveAnchorInFile } from '@shared/comment-anchors'
+import { imageMediaType } from '@shared/git'
+import type { DiffChanges, DiffLine } from '@shared/git'
+import type { CommentThread } from '@shared/schemas'
+import type { AnchoredThread } from './diff-view'
+
+/**
+ * Past this the file is shown but the browser is not asked to lay out every
+ * line of it at once.
+ *
+ * `readReviewFile` already refuses anything past 20,000 lines, so this is about
+ * what a *DOM* will take rather than what a pipe will: each row is a grid of
+ * three elements plus a hover button, and a generated bundle or a lockfile will
+ * happily hit six figures of them. The file is still readable to the ceiling,
+ * and the card says where it stopped - which is a great deal more use than a
+ * tab that goes unresponsive for nine seconds.
+ */
+const MAX_RENDERED_LINES = 5_000
+
+export interface FileSourceCardProps {
+  reviewId: number
+  path: string
+  /** Which version of the file to read - as always, the diff's own setting. */
+  changes: DiffChanges
+  /** Threads stored against this path, not yet placed against the text. */
+  threads: CommentThread[]
+  comments: Omit<DiffComments, 'threads'>
+  /** True when this file is part of the review's diff, so the card can say so. */
+  isChanged: boolean
+  /** A line arrived at from a link, marked while the reader finds it. */
+  marked?: { side: 'base' | 'head'; line: number }
+  editorLabel?: string | null
+  onOpenInEditor?: (path: string, line: number) => void
+}
+
+export function FileSourceCard({
+  reviewId,
+  path,
+  changes,
+  threads,
+  comments,
+  isChanged,
+  marked,
+  editorLabel,
+  onOpenInEditor
+}: FileSourceCardProps) {
+  const text = useReviewFile(reviewId, path, changes)
+  const selection = useLineSelection()
+
+  // Unlike the diff's expanders, which read a file only once somebody asks for
+  // more context, the whole point of this screen is the file - so it is asked
+  // for as soon as the card exists.
+  const { load } = text
+  useEffect(() => load(), [load])
+
+  const content = text.content
+  const lines = content?.lines
+
+  /**
+   * Where each thread lands in the text on screen.
+   *
+   * Run here against the file the reader is looking at, for exactly the reason
+   * the files tab runs `resolveAnchor` against the diff on screen rather than
+   * trusting one the main process read a moment later: a comment must never be
+   * placed against a version of the file nobody is being shown.
+   */
+  const anchored = useMemo<AnchoredThread[]>(
+    () =>
+      threads.map((thread) => ({
+        ...thread,
+        anchor: resolveAnchorInFile(lines, {
+          filePath: path,
+          // `isInlineAnchor` is what put these threads in this list, so both
+          // are set; the fallbacks satisfy the types without inventing a
+          // position for a thread that has none.
+          side: thread.side ?? 'head',
+          line: thread.line ?? 0,
+          startLine: thread.startLine,
+          anchorText: thread.anchorText
+        })
+      })),
+    [threads, lines, path]
+  )
+
+  const placed = useMemo(() => {
+    const map = new Map<string, AnchoredThread[]>()
+    for (const thread of anchored) {
+      if (thread.anchor.line === null || thread.side === null) continue
+      const key = `${thread.side}:${thread.anchor.line}`
+      const existing = map.get(key)
+      if (existing) existing.push(thread)
+      else map.set(key, [thread])
+    }
+    return map
+  }, [anchored])
+
+  /** Every line a thread's range covers, so a block comment shows its reach. */
+  const covered = useMemo(() => {
+    const all = new Set<string>()
+    for (const thread of anchored) {
+      const { line, startLine } = thread.anchor
+      if (line === null || startLine === null || thread.side === null) continue
+      for (let current = startLine; current <= line; current += 1) {
+        all.add(`${thread.side}:${current}`)
+      }
+    }
+    return all
+  }, [anchored])
+
+  const rows: DiffLine[] = useMemo(
+    () =>
+      (lines ?? []).slice(0, MAX_RENDERED_LINES).map((line, index) => ({
+        type: 'context',
+        content: line,
+        // Null on purpose - see the note at the top of this file.
+        oldNumber: null,
+        newNumber: index + 1
+      })),
+    [lines]
+  )
+
+  const rowContext: RowContext = {
+    placed,
+    comments: { ...comments, threads: anchored },
+    composingOn: selection.composingOn,
+    onCompose: selection.setComposingOn,
+    onSelectStart: selection.startSelection,
+    onSelectOver: selection.dragOver,
+    selection: selection.selection,
+    covered,
+    marked: marked ?? null,
+    filePath: path,
+    search: null,
+    // A file has one set of line numbers; the diff's second gutter would be a
+    // column of nothing down the whole document.
+    oneGutter: true
+  }
+
+  const orphans = anchored.filter((thread) => thread.anchor.line === null)
+  const unresolved = anchored.filter((thread) => thread.resolvedAt === null).length
+  const problem = content?.error ?? (text.error === undefined ? null : errorMessage(text.error))
+  const isImage = (content?.isBinary ?? false) && imageMediaType(path) !== null
+  const clipped = (lines?.length ?? 0) > MAX_RENDERED_LINES
+
+  return (
+    <Card className="overflow-clip">
+      <div
+        className={cn(
+          // Sticky for the same reason the diff card's header is: a file taller
+          // than the window should never leave the reader wondering which file
+          // they are in.
+          'sticky top-[var(--diff-sticky-top,0px)] z-10 flex w-full flex-wrap items-center gap-1',
+          'border-b border-border bg-card px-3 py-2'
+        )}
+      >
+        <span data-selectable className="min-w-0 grow basis-64 font-mono text-xs">
+          <FilePath path={path} />
+        </span>
+
+        <div className="ml-auto flex flex-wrap items-center gap-2 pl-2">
+          {isChanged && (
+            // Worth saying plainly. A file open in this tab looks the same
+            // whether or not the branch touched it, and "this one is in the
+            // diff" is the difference between browsing and reviewing.
+            <Badge variant="outline">In this diff</Badge>
+          )}
+          {content?.source === 'commit' && (
+            <Badge variant="outline" title="Read from the head commit, not from a working tree.">
+              committed
+            </Badge>
+          )}
+          {anchored.length > 0 && (
+            <Badge variant={unresolved > 0 ? 'default' : 'outline'}>
+              {unresolved > 0 ? `${unresolved} unresolved` : `${anchored.length} resolved`}
+            </Badge>
+          )}
+          <CopyPathAction path={path} />
+          {onOpenInEditor && (
+            <IconAction
+              label={editorLabel ? `Open in ${editorLabel}` : 'Open in your editor'}
+              onClick={() => onOpenInEditor(path, 1)}
+              icon={<SquareArrowOutUpRight />}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Threads that cannot be pinned to a line of this file: the code they
+          were about has been rewritten since. Listed rather than dropped, for
+          the same reason the files tab lists its orphans - a discussion that
+          disappears because the code moved is the failure this app must not
+          have. */}
+      {orphans.length > 0 && (
+        <div className="flex flex-col gap-2 border-b border-border bg-muted/20 p-3">
+          <p className="text-xs text-muted-foreground">
+            {orphans.length === 1 ? 'A comment' : `${orphans.length} comments`} on code that is no
+            longer in this file.
+          </p>
+          {orphans.map((thread) => (
+            <CommentThreadCard
+              key={thread.id}
+              thread={thread}
+              mutations={comments.mutations}
+              anchorState={thread.anchor.state}
+              location={
+                thread.line === null ? null : (
+                  <span className="font-mono text-xs text-muted-foreground">
+                    was line {thread.line}
+                  </span>
+                )
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      {problem !== null ? (
+        <p className="flex items-center gap-2 p-3 text-xs text-muted-foreground">
+          <FileWarning className="size-4 shrink-0 text-warning" />
+          {problem}
+        </p>
+      ) : isImage ? (
+        <div className="p-3">
+          <ImagePane
+            reviewId={reviewId}
+            path={path}
+            side="head"
+            changes={changes}
+            renamedFrom={null}
+          />
+        </div>
+      ) : content?.isBinary ? (
+        <p className="p-3 text-xs text-muted-foreground">
+          This is a binary file. There is nothing to show and nothing to comment on.
+        </p>
+      ) : text.isLoading || content === undefined ? (
+        <div className="flex flex-col gap-1 p-3">
+          <Skeleton className="h-3 w-2/3" />
+          <Skeleton className="h-3 w-1/2" />
+          <Skeleton className="h-3 w-3/4" />
+        </div>
+      ) : rows.length === 0 ? (
+        <p className="p-3 text-xs text-muted-foreground">This file is empty.</p>
+      ) : (
+        <div
+          className={cn('@container overflow-x-auto', selection.isDragging && 'select-none')}
+        >
+          <div className="min-w-max font-mono text-xs leading-5">
+            {rows.map((line) => (
+              <LineRow key={line.newNumber} line={line} {...rowContext} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {(clipped || content?.truncated === true) && (
+        <p className="border-t border-border px-3 py-2 text-xs text-muted-foreground">
+          {content?.truncated === true
+            ? 'This file is longer than GitWarren will read; the rest is not shown.'
+            : `Only the first ${MAX_RENDERED_LINES.toLocaleString()} lines are shown.`}
+        </p>
+      )}
+    </Card>
+  )
+}

--- a/src/renderer/src/features/reviews/image-diff.tsx
+++ b/src/renderer/src/features/reviews/image-diff.tsx
@@ -95,7 +95,7 @@ export function ImageDiff({
   )
 }
 
-function ImagePane({
+export function ImagePane({
   reviewId,
   path,
   side,

--- a/src/renderer/src/features/reviews/line-selection.ts
+++ b/src/renderer/src/features/reviews/line-selection.ts
@@ -1,0 +1,154 @@
+/**
+ * Choosing the lines a new comment is about.
+ *
+ * Two gestures, both of which people already know from GitHub: press and drag
+ * the `+` down the gutter, or shift-click a second line. They are the same
+ * gestures over a diff and over a whole file, which is why this is a hook
+ * rather than state inside the diff card - `FileDiffCard` and `FileSourceCard`
+ * are two different ways of drawing lines, and exactly one way of selecting
+ * them.
+ *
+ * The touch handling below is the reason it is worth sharing rather than
+ * writing twice. It is not obvious, it was arrived at by testing on a phone,
+ * and a second copy would be a second copy that does not have it.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import type { DiffSide } from '@shared/comment-anchors'
+
+/**
+ * A run of lines on one side: what a comment covers, and what the reviewer is
+ * dragging out before the composer opens. `startLine === line` is an ordinary
+ * single-line comment, which is most of them.
+ */
+export interface LineRange {
+  side: DiffSide
+  startLine: number
+  line: number
+}
+
+export interface LineSelection {
+  /** The lines the reviewer is writing a new comment on, if any. */
+  composingOn: LineRange | null
+  /** Open the composer on a range, or close it with null. */
+  setComposingOn: (target: LineRange | null) => void
+  /** Begin a selection at this line, or extend the open one when held. */
+  startSelection: (side: DiffSide, line: number, extend: boolean) => void
+  /** Drag the selection over this line. Ignored when nothing is being dragged. */
+  dragOver: (side: DiffSide, line: number) => void
+  /**
+   * The range to light up right now - the drag while the pointer is down, the
+   * composer's own range after it comes up. Normalised, so `startLine` is
+   * always the earlier of the two however the drag ran.
+   */
+  selection: LineRange | null
+  /**
+   * True while the pointer is down. The code is made unselectable for exactly
+   * that long: dragging the gutter otherwise leaves the whole file highlighted
+   * as a text selection behind the range being chosen.
+   */
+  isDragging: boolean
+}
+
+export function useLineSelection(): LineSelection {
+  const [composingOn, setComposingOn] = useState<LineRange | null>(null)
+  /** The range being dragged out right now, before the pointer comes up. */
+  const [dragging, setDragging] = useState<LineRange | null>(null)
+
+  /**
+   * Start commenting at a line, or grow the open range to reach it.
+   *
+   * Shift-click keeps the first line of the existing range as the anchor, so
+   * the range only ever grows away from where the reviewer started.
+   */
+  const startSelection = useCallback(
+    (side: DiffSide, line: number, extend: boolean) => {
+      if (extend && composingOn && composingOn.side === side) {
+        const anchor = composingOn.startLine
+        setComposingOn({ side, startLine: Math.min(anchor, line), line: Math.max(anchor, line) })
+        return
+      }
+      setDragging({ side, startLine: line, line })
+    },
+    [composingOn]
+  )
+
+  const dragOver = useCallback((side: DiffSide, line: number) => {
+    setDragging((current) => {
+      if (!current || current.side !== side || current.line === line) return current
+      // `startLine` stays the line the drag began on; the pointer can be either
+      // side of it, and the range is normalised when the pointer comes up.
+      return { ...current, line }
+    })
+  }, [])
+
+  /**
+   * A drag ends wherever the pointer is released, which is often outside the
+   * button - or outside the card - so the listener goes on the window.
+   *
+   * The *move* is on the window for a different and less obvious reason. Rows
+   * also report `onPointerEnter`, and with a mouse that is enough: the pointer
+   * really does travel across each row and each row really is told. A finger
+   * does not work that way. Touch sets *implicit pointer capture* on whatever
+   * the gesture started on - the `+` button - so for the rest of the drag every
+   * pointer event is delivered to that button and no row is ever entered. The
+   * range simply never grew, which is why dragging out several lines worked on
+   * a desktop and did nothing at all on a phone.
+   *
+   * So the pointer is followed rather than waited for: one listener, hit-test
+   * where it actually is, read the row's own `data-diff-*` off the result. That
+   * is correct for a mouse too - `onPointerEnter` stays because it costs
+   * nothing and keeps the desktop path working if a hit-test ever lands on
+   * something unexpected - and it is the same set of coordinates either way.
+   */
+  useEffect(() => {
+    if (!dragging) return
+
+    const move = (event: PointerEvent): void => {
+      const under = document.elementFromPoint(event.clientX, event.clientY)
+      const row = under?.closest('[data-diff-line]')
+      if (!row) return
+      const side = row.getAttribute('data-diff-side')
+      const line = Number(row.getAttribute('data-diff-line'))
+      if ((side === 'base' || side === 'head') && Number.isInteger(line)) dragOver(side, line)
+    }
+
+    const finish = (): void => {
+      const startLine = Math.min(dragging.startLine, dragging.line)
+      const line = Math.max(dragging.startLine, dragging.line)
+      setDragging(null)
+      setComposingOn((current) =>
+        // Clicking the `+` of a composer that is already open on exactly those
+        // lines closes it again, which is how the button worked before ranges.
+        current && current.side === dragging.side && current.startLine === startLine && current.line === line
+          ? null
+          : { side: dragging.side, startLine, line }
+      )
+    }
+
+    window.addEventListener('pointermove', move)
+    window.addEventListener('pointerup', finish)
+    window.addEventListener('pointercancel', finish)
+    return () => {
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', finish)
+      window.removeEventListener('pointercancel', finish)
+    }
+  }, [dragging, dragOver])
+
+  return {
+    composingOn,
+    setComposingOn,
+    startSelection,
+    dragOver,
+    // While the pointer is down the drag wins; after it comes up the composer's
+    // own range is what stays lit.
+    selection: dragging
+      ? {
+          side: dragging.side,
+          startLine: Math.min(dragging.startLine, dragging.line),
+          line: Math.max(dragging.startLine, dragging.line)
+        }
+      : composingOn,
+    isDragging: dragging !== null
+  }
+}

--- a/src/renderer/src/features/reviews/path-tree.ts
+++ b/src/renderer/src/features/reviews/path-tree.ts
@@ -1,0 +1,97 @@
+/**
+ * Folding a flat list of paths into a tree.
+ *
+ * A flat list of paths is unreadable past about a dozen files - every row
+ * starts with the same forty characters - and a directory chain with one child
+ * in it (`src/renderer/src`) wastes three rows saying nothing. Both problems
+ * are the same problem, and both lists in this app have them: the changed files
+ * beside a diff, and every file in the repository in the browse tab.
+ *
+ * So the folding lives here and the two trees differ only in what they draw on
+ * a row. Nodes carry a path and nothing else on purpose: what a row needs to
+ * know about a file - how much changed, whether anyone commented, whether it
+ * has been read - is looked up by path by whoever is drawing it, which is the
+ * one thing that stops this module growing a field per feature.
+ */
+
+export interface PathFileNode {
+  kind: 'file'
+  /** Full repository-relative path - also the DOM anchor and the tree key. */
+  path: string
+  name: string
+}
+
+export interface PathDirectoryNode {
+  kind: 'directory'
+  path: string
+  /** May be several segments, when a chain of lone directories was folded. */
+  name: string
+  children: PathNode[]
+}
+
+export type PathNode = PathFileNode | PathDirectoryNode
+
+/**
+ * Build the tree, in the order the paths arrive.
+ *
+ * Deliberately not sorted here. The changed-files list is already sorted by the
+ * diff and the browse tree by the tree read, and re-sorting would either be a
+ * no-op or would silently disagree with the order the caller chose.
+ */
+export function buildPathTree(paths: string[]): PathNode[] {
+  const root: PathDirectoryNode = { kind: 'directory', path: '', name: '', children: [] }
+  // One map rather than a linear scan of `children` per segment: with twenty
+  // thousand paths the scan is the difference between a tree that builds in a
+  // few milliseconds and one that takes a visible pause.
+  const directories = new Map<string, PathDirectoryNode>([['', root]])
+
+  for (const path of paths) {
+    const segments = path.split('/')
+    const name = segments.pop() as string
+    let parent = root
+
+    for (const segment of segments) {
+      const directoryPath = parent.path ? `${parent.path}/${segment}` : segment
+      const existing = directories.get(directoryPath)
+      if (existing) {
+        parent = existing
+      } else {
+        const created: PathDirectoryNode = {
+          kind: 'directory',
+          path: directoryPath,
+          name: segment,
+          children: []
+        }
+        parent.children.push(created)
+        directories.set(directoryPath, created)
+        parent = created
+      }
+    }
+
+    parent.children.push({ kind: 'file', path, name })
+  }
+
+  // The root itself is not collapsed: folding it away would silently drop the
+  // one directory every file in the list shares, which is exactly the label
+  // that tells you what part of the tree you are looking at.
+  return root.children.map((child) => (child.kind === 'directory' ? collapse(child) : child))
+}
+
+/** Fold `a` -> `b` -> [files] into a single `a/b` row. */
+function collapse(node: PathDirectoryNode): PathDirectoryNode {
+  const children = node.children.map((child) =>
+    child.kind === 'directory' ? collapse(child) : child
+  )
+
+  const only = children.length === 1 ? children[0] : undefined
+  if (only?.kind === 'directory') {
+    return {
+      kind: 'directory',
+      path: only.path,
+      name: node.name ? `${node.name}/${only.name}` : only.name,
+      children: only.children
+    }
+  }
+
+  return { ...node, children }
+}

--- a/src/renderer/src/features/reviews/repository-files-tree.tsx
+++ b/src/renderer/src/features/reviews/repository-files-tree.tsx
@@ -1,0 +1,279 @@
+/**
+ * Every file in the repository, as something a person can actually find a file
+ * in.
+ *
+ * The changed-files tree next door lists tens of files and can afford to show
+ * all of them open. This one lists all of them - twenty thousand in a large
+ * checkout - so it has two modes, and which one you are in is decided by
+ * whether the filter box has anything in it.
+ *
+ * **Browsing.** A tree with its directories shut, opened one at a time, plus
+ * whatever is already open along the path to the file being read. This is for
+ * when you know roughly where you are going, or want to see how the project is
+ * laid out.
+ *
+ * **Filtering.** A flat, ranked list of matches - a fuzzy file finder, the way
+ * every editor does it. Deliberately *not* a filtered tree: once you are typing
+ * `revfiles` you are not navigating a hierarchy any more, you are naming a
+ * file, and the directory rows in between are noise you have to scroll past.
+ * Flat also keeps the keystroke cheap, because nothing is re-folded per key.
+ */
+import { useCallback, useMemo, useState } from 'react'
+import { ChevronDown, ChevronRight, FileCode, Search, X } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { fuzzyMatch } from '@/lib/fuzzy'
+import { FilePath } from './file-path'
+import { buildPathTree, type PathNode } from './path-tree'
+
+/**
+ * How many matches a filter shows.
+ *
+ * Nobody scrolls to the hundredth-best fuzzy match; they type another letter.
+ * The cap is what keeps a one-character query over a twenty-thousand-file
+ * repository from rendering twenty thousand rows on the way to being narrowed.
+ */
+const MAX_MATCHES = 200
+
+export interface RepositoryFilesTreeProps {
+  paths: string[]
+  /** The file currently open, or null before one has been picked. */
+  selectedPath: string | null
+  onSelect: (path: string) => void
+  /** Paths the review's diff contains, so the tree can mark them. */
+  changedPaths: ReadonlySet<string>
+  /** Unresolved comment count per path. */
+  unresolvedByFile: Map<string, number>
+}
+
+export function RepositoryFilesTree({
+  paths,
+  selectedPath,
+  onSelect,
+  changedPaths,
+  unresolvedByFile
+}: RepositoryFilesTreeProps) {
+  const [query, setQuery] = useState('')
+  const tree = useMemo(() => buildPathTree(paths), [paths])
+
+  /**
+   * Directories the reader has opened or shut by hand. Absent means "no
+   * opinion", which is not the same as shut - see `isOpen` below.
+   */
+  const [toggled, setToggled] = useState<ReadonlyMap<string, boolean>>(() => new Map())
+
+  /**
+   * Every directory above the file being read.
+   *
+   * Derived rather than written into the open set when the selection changes,
+   * which is the difference between this and the obvious version. Deriving
+   * means arriving on a deep link opens the tree to where you are without an
+   * effect that writes state during render - and it means a directory the
+   * reader shut *stays* shut even though the current file is inside it, because
+   * an explicit decision outranks a default.
+   */
+  const onPathToSelection = useMemo(() => {
+    const ancestors = new Set<string>()
+    if (selectedPath === null) return ancestors
+    const segments = selectedPath.split('/')
+    segments.pop()
+    let prefix = ''
+    for (const segment of segments) {
+      prefix = prefix ? `${prefix}/${segment}` : segment
+      ancestors.add(prefix)
+    }
+    return ancestors
+  }, [selectedPath])
+
+  const isOpen = useCallback(
+    (path: string) => toggled.get(path) ?? onPathToSelection.has(path),
+    [toggled, onPathToSelection]
+  )
+
+  const toggle = useCallback(
+    (path: string, next: boolean) =>
+      setToggled((current) => new Map(current).set(path, next)),
+    []
+  )
+
+  const matches = useMemo(() => {
+    const needle = query.trim()
+    if (needle === '') return null
+
+    const scored: { path: string; score: number }[] = []
+    for (const path of paths) {
+      const hit = fuzzyMatch(needle, path)
+      if (hit !== null) scored.push({ path, score: hit.score })
+    }
+    scored.sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
+    return { shown: scored.slice(0, MAX_MATCHES).map((entry) => entry.path), total: scored.length }
+  }, [paths, query])
+
+  const rowProps = { selectedPath, onSelect, changedPaths, unresolvedByFile }
+
+  return (
+    <div className="flex min-h-0 flex-col">
+      <div className="sticky top-0 z-10 flex items-center gap-1.5 border-b border-border bg-card px-2 py-1.5">
+        <Search className="size-3.5 shrink-0 text-muted-foreground" />
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Filter files"
+          aria-label="Filter files in this repository"
+          className="min-w-0 flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+        />
+        {query !== '' && (
+          <button
+            type="button"
+            onClick={() => setQuery('')}
+            aria-label="Clear the filter"
+            className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-3.5" />
+          </button>
+        )}
+      </div>
+
+      {matches === null ? (
+        <nav aria-label="Repository files" className="flex flex-col gap-px py-1 text-xs">
+          {tree.map((node) => (
+            <TreeRows
+              key={node.path}
+              node={node}
+              depth={0}
+              isOpen={isOpen}
+              onToggle={toggle}
+              {...rowProps}
+            />
+          ))}
+        </nav>
+      ) : matches.shown.length === 0 ? (
+        <p className="px-3 py-4 text-xs text-muted-foreground">No file matches that.</p>
+      ) : (
+        <nav aria-label="Matching files" className="flex flex-col gap-px py-1 text-xs">
+          {matches.shown.map((path) => (
+            // The whole path on a match row, not just the name: in a flat list
+            // the directory is the only thing telling two `index.ts` apart.
+            <FileRow key={path} path={path} label={path} {...rowProps} />
+          ))}
+          {matches.total > matches.shown.length && (
+            <p className="px-3 py-2 text-[0.6875rem] text-muted-foreground">
+              {matches.total - matches.shown.length} more match. Keep typing to narrow it.
+            </p>
+          )}
+        </nav>
+      )}
+    </div>
+  )
+}
+
+function TreeRows({
+  node,
+  depth,
+  isOpen,
+  onToggle,
+  ...rowProps
+}: {
+  node: PathNode
+  depth: number
+  isOpen: (path: string) => boolean
+  onToggle: (path: string, open: boolean) => void
+} & Omit<RepositoryFilesTreeProps, 'paths'>) {
+  // Indent by nesting depth, but stop growing it before the column runs out of
+  // room; a path fifteen directories deep should still show its file name.
+  const indent = { paddingLeft: `${Math.min(depth, 6) * 0.75 + 0.25}rem` }
+
+  if (node.kind === 'file') {
+    return <FileRow path={node.path} label={node.name} indent={indent} {...rowProps} />
+  }
+
+  const open = isOpen(node.path)
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => onToggle(node.path, !open)}
+        aria-expanded={open}
+        style={indent}
+        className="flex w-full items-start gap-1 rounded py-1 pr-1 text-left text-muted-foreground hover:bg-muted"
+      >
+        {open ? (
+          <ChevronDown className="mt-0.5 size-3 shrink-0" />
+        ) : (
+          <ChevronRight className="mt-0.5 size-3 shrink-0" />
+        )}
+        <FilePath path={node.name} emphasizeName={false} className="min-w-0" />
+      </button>
+      {open &&
+        node.children.map((child) => (
+          <TreeRows
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            isOpen={isOpen}
+            onToggle={onToggle}
+            {...rowProps}
+          />
+        ))}
+    </>
+  )
+}
+
+function FileRow({
+  path,
+  label,
+  indent,
+  selectedPath,
+  onSelect,
+  changedPaths,
+  unresolvedByFile
+}: {
+  path: string
+  /** The file's name in the tree, its whole path in a filter result. */
+  label: string
+  indent?: { paddingLeft: string }
+} & Omit<RepositoryFilesTreeProps, 'paths'>) {
+  const unresolved = unresolvedByFile.get(path) ?? 0
+  const isSelected = path === selectedPath
+  const isChanged = changedPaths.has(path)
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(path)}
+      style={indent ?? { paddingLeft: '0.25rem' }}
+      aria-current={isSelected ? 'true' : undefined}
+      className={cn(
+        'flex w-full items-start gap-1.5 rounded py-1 pr-1 text-left transition-colors',
+        isSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-muted'
+      )}
+      title={isChanged ? `${path} - changed in this review` : path}
+    >
+      <FileCode
+        className={cn(
+          'mt-0.5 size-3 shrink-0',
+          // The one distinction worth drawing in a list of every file there is:
+          // which of them this review is actually about.
+          isChanged ? 'text-primary' : 'text-muted-foreground/60'
+        )}
+      />
+      <span
+        className={cn(
+          'min-w-0 flex-1 break-all font-mono text-[0.6875rem]',
+          isChanged && !isSelected && 'text-foreground'
+        )}
+      >
+        {label}
+      </span>
+      {unresolved > 0 && (
+        <span
+          className="shrink-0 rounded-full bg-primary px-1 text-[0.5625rem] font-semibold leading-4 text-primary-foreground"
+          title={`${unresolved} unresolved`}
+        >
+          {unresolved}
+        </span>
+      )}
+    </button>
+  )
+}

--- a/src/renderer/src/features/reviews/review-browse-tab.tsx
+++ b/src/renderer/src/features/reviews/review-browse-tab.tsx
@@ -1,0 +1,263 @@
+/**
+ * The browse tab: the repository the review is against, one file at a time.
+ *
+ * Files changed answers "what did this branch do". This answers the question
+ * that keeps coming after it - "what does the thing it did that *to* look
+ * like" - and it exists because reviewing a change frequently means reading
+ * code the change did not touch: the caller of the function that was edited,
+ * the test that was not updated, the interface a new field should have gone on.
+ * Until now the only way to do that was to leave GitWarren, which also meant
+ * that anything you noticed over there had nowhere to be written down.
+ *
+ * So the point of the tab is not really browsing. It is that a comment can be
+ * left on any line of any file, and it lands in the same review, in the same
+ * discussion, anchored by the same rules (`shared/comment-anchors.ts`) as a
+ * comment on the diff.
+ *
+ * ## One file, and it is in the URL
+ *
+ * Files changed stacks every changed file down one page, which is right for a
+ * patch of twelve files and impossible for a repository of twelve thousand. So
+ * this shows one, and which one is part of the location -
+ * `#/reviews/4/browse/src%2Fapp.ts` - rather than component state. That is the
+ * same decision `DiffFocus` made for arriving at a line: a file being read is a
+ * place, it survives a reload, and it is a link somebody can paste to a
+ * colleague or an agent can write into a comment.
+ *
+ * `replace` rather than `navigate` when a file is picked, matching the tab
+ * strip. Clicking through fifteen files should not put fifteen entries between
+ * the reviewer and the way out.
+ *
+ * ## Which version of the files
+ *
+ * Always the review's own head, read the way the diff's default reads it - the
+ * worktree when one holds the head branch, the head commit otherwise. There is
+ * deliberately no committed/uncommitted control here to match the one in Files
+ * changed. That control answers "which changes am I reviewing", and this tab is
+ * not showing changes; a third meaning for it would be a third thing to get
+ * wrong, and reading the branch as it actually stands on disk is the only
+ * answer anybody wants from a file browser.
+ */
+import { useCallback, useMemo } from 'react'
+import { AlertCircle, FolderTree, ListTree, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { errorMessage, isDisconnection } from '@/lib/errors'
+import { plural } from '@/lib/format'
+import { useHost, useApi } from '@/lib/host-scope'
+import { useHostScope } from '@/lib/host-scope'
+import { useNarrow } from '@/lib/narrow'
+import { useStoredFlag, useStoredPreference } from '@/lib/preferences'
+import { replace, type DiffFocus } from '@/lib/router'
+import { cn } from '@/lib/utils'
+import { useCommentMutations, useReviewComments } from '../comments/use-comments'
+import { FileSourceCard } from './file-source-view'
+import { RepositoryFilesTree } from './repository-files-tree'
+import { DEFAULT_DIFF_CHANGES, useEditors, useReviewDiff, useReviewTree } from './use-reviews'
+import { isInlineAnchor } from '@shared/comment-anchors'
+import { remotelyOpenable } from '@shared/editors'
+import type { Review } from '@shared/schemas'
+
+export function ReviewBrowseTab({ review, focus }: { review: Review; focus?: DiffFocus }) {
+  const api = useApi()
+  const host = useHost()
+  const scope = useHostScope()
+  const narrow = useNarrow()
+  const [treeOpen, setTreeOpen] = useStoredFlag('browse-tree', true)
+  const [editorId] = useStoredPreference('editor', null)
+
+  const changes = DEFAULT_DIFF_CHANGES
+  const tree = useReviewTree(review.id, changes)
+  // Already in the cache: the review screen starts this read at mount, and the
+  // files tab subscribes to the same key. What is wanted here is only which
+  // paths it covers, so the tree can mark them.
+  const diff = useReviewDiff(review.id, changes)
+  const { threads } = useReviewComments(review.id)
+  const mutations = useCommentMutations()
+  const localEditors = useEditors()
+
+  const selectedPath = focus?.filePath ?? null
+
+  const selectFile = useCallback(
+    (path: string) => {
+      replace({ name: 'review', reviewId: review.id, tab: 'browse', focus: { filePath: path }, ...scope })
+    },
+    [review.id, scope]
+  )
+
+  const changedPaths = useMemo(
+    () => new Set((diff.data?.files ?? []).map((file) => file.path)),
+    [diff.data?.files]
+  )
+
+  /** Line threads by the path they were left on, wherever that path is. */
+  const threadsByFile = useMemo(() => {
+    const byFile = new Map<string, typeof threads>()
+    for (const thread of threads) {
+      if (!isInlineAnchor(thread)) continue
+      const existing = byFile.get(thread.filePath)
+      if (existing) existing.push(thread)
+      else byFile.set(thread.filePath, [thread])
+    }
+    return byFile
+  }, [threads])
+
+  const unresolvedByFile = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const [path, fileThreads] of threadsByFile) {
+      const open = fileThreads.filter((thread) => thread.resolvedAt === null).length
+      if (open > 0) counts.set(path, open)
+    }
+    return counts
+  }, [threadsByFile])
+
+  /**
+   * The editors on *this* machine that can open a file on *that* one - the same
+   * two questions the files tab asks, and the same answer for the same reason.
+   * See the long note in `review-files-tab.tsx`.
+   */
+  const editors = useMemo(
+    () => (host === undefined || localEditors === undefined ? localEditors : remotelyOpenable(localEditors)),
+    [host, localEditors]
+  )
+
+  const openOnItsHost = useCallback(
+    (path: string, line: number) => {
+      void api.reviews
+        .openInEditor({ id: review.id, path, changes, line, ...(editorId === null ? {} : { editorId }) })
+        .catch(() => undefined)
+    },
+    [api, review.id, changes, editorId]
+  )
+
+  const openInEditor =
+    host !== undefined && editors !== undefined && editors.editors.length === 0
+      ? undefined
+      : openOnItsHost
+
+  if (tree.isLoading && tree.data === undefined) {
+    return (
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+
+  if (tree.error !== undefined) {
+    return (
+      <Card className="flex items-start gap-3 border-destructive/40 p-4">
+        <AlertCircle className="mt-0.5 size-5 shrink-0 text-destructive" />
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-medium">
+            {isDisconnection(tree.error)
+              ? 'That machine is not answering.'
+              : 'The repository could not be listed.'}
+          </p>
+          <p className="text-xs text-muted-foreground">{errorMessage(tree.error)}</p>
+        </div>
+      </Card>
+    )
+  }
+
+  const paths = tree.data?.paths ?? []
+  const listOpen = narrow ? selectedPath === null || treeOpen : treeOpen
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setTreeOpen(!treeOpen)}
+          aria-expanded={listOpen}
+        >
+          {listOpen ? <PanelLeftClose /> : <PanelLeftOpen />}
+          {listOpen ? 'Hide files' : 'Show files'}
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          {plural(paths.length, 'file')} at <span className="font-mono">{review.headRef}</span>
+          {tree.data?.truncated === true && ' (listing cut short)'}
+        </p>
+      </div>
+
+      {tree.data?.error !== null && tree.data?.error !== undefined && (
+        <Card className="flex items-start gap-3 border-warning/40 p-3 text-xs">
+          <AlertCircle className="mt-0.5 size-4 shrink-0 text-warning" />
+          <p>{tree.data.error}</p>
+        </Card>
+      )}
+
+      {/* `items-start` so the tree can stick to the top of the viewport while
+          the file beside it scrolls; a stretched column would never stick. */}
+      <div className="flex items-start gap-4">
+        {listOpen && (
+          <aside
+            className={cn(
+              'rounded-lg border border-border bg-card/50',
+              narrow
+                ? 'w-full'
+                : 'sticky top-2 max-h-[calc(100dvh-6rem)] w-56 shrink-0 overflow-y-auto xl:w-64 2xl:w-72'
+            )}
+          >
+            <RepositoryFilesTree
+              paths={paths}
+              selectedPath={selectedPath}
+              onSelect={selectFile}
+              changedPaths={changedPaths}
+              unresolvedByFile={unresolvedByFile}
+            />
+          </aside>
+        )}
+
+        {/* On a narrow window the list is the screen *instead of* the file, so
+            the two never share the width. Same tree, two layouts - the rule the
+            files tab settled on. */}
+        {(!narrow || !listOpen) && (
+          <div className="min-w-0 flex-1">
+            {selectedPath === null ? (
+              <Card className="flex flex-col items-center gap-2 border-dashed px-6 py-12 text-center">
+                <div className="rounded-full bg-muted p-3 text-muted-foreground">
+                  <FolderTree className="size-6" />
+                </div>
+                <h3 className="font-medium">Pick a file</h3>
+                <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+                  Every file in the repository is here, not only the ones this branch changed. Open
+                  one to read it — and to comment on any line of it, in this review.
+                </p>
+              </Card>
+            ) : (
+              <FileSourceCard
+                // Remounted per file: a different file is a different document,
+                // and nothing the reader unfolded or half-typed about the last
+                // one belongs to this one.
+                key={selectedPath}
+                reviewId={review.id}
+                path={selectedPath}
+                changes={changes}
+                threads={threadsByFile.get(selectedPath) ?? []}
+                comments={{ reviewId: review.id, mutations, changes }}
+                isChanged={changedPaths.has(selectedPath)}
+                marked={
+                  focus?.side !== undefined && focus.line !== undefined
+                    ? { side: focus.side, line: focus.line }
+                    : undefined
+                }
+                editorLabel={editors?.editors.find((editor) => editor.id === editorId)?.label ?? null}
+                onOpenInEditor={openInEditor}
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      {narrow && listOpen && selectedPath !== null && (
+        <Button variant="outline" size="sm" onClick={() => setTreeOpen(false)}>
+          <ListTree />
+          Back to {selectedPath.slice(selectedPath.lastIndexOf('/') + 1)}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/features/reviews/review-conversation-tab.tsx
+++ b/src/renderer/src/features/reviews/review-conversation-tab.tsx
@@ -24,6 +24,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Markdown } from '@/components/markdown'
 import { errorMessage, isDisconnection } from '@/lib/errors'
 import { absoluteTime, relativeTime } from '@/lib/format'
+import { useHostScope } from '@/lib/host-scope'
 import { replace } from '@/lib/router'
 import { CommentComposer } from '../comments/comment-composer'
 import { CommentThreadCard } from '../comments/comment-thread-card'
@@ -44,6 +45,19 @@ interface TimelineEntry {
   thread: CommentThread
   /** What to print above it. Null for a review-level thread. */
   snippet: ThreadSnippet | null
+  /**
+   * Which tab this thread's code lives in.
+   *
+   * `files` for a thread about a file the diff contains, `browse` for one about
+   * a file it does not - a comment left on unchanged code, which is an ordinary
+   * thing to have since the browse tab. Sending those to Files changed would
+   * land the reader on the orphan list at the top of a diff their comment is
+   * not in, rather than on the line they wrote it about.
+   *
+   * Null while the diff is still being read, and for a review-level thread:
+   * neither has a file to go to.
+   */
+  tab: 'files' | 'browse' | null
 }
 
 /**
@@ -56,7 +70,7 @@ interface TimelineEntry {
  */
 function buildTimeline(threads: CommentThread[], files: FileDiff[] | undefined): TimelineEntry[] {
   const entries = threads.map<TimelineEntry>((thread) => {
-    if (!isInlineAnchor(thread)) return { thread, snippet: null }
+    if (!isInlineAnchor(thread)) return { thread, snippet: null, tab: null }
 
     const file = files === undefined ? undefined : findAnchorFile(files, thread.filePath)
     const anchor =
@@ -70,13 +84,18 @@ function buildTimeline(threads: CommentThread[], files: FileDiff[] | undefined):
             anchorText: thread.anchorText
           })
 
-    return { thread, snippet: threadSnippet(thread, anchor, file) }
+    return {
+      thread,
+      snippet: threadSnippet(thread, anchor, file),
+      tab: files === undefined ? null : file === undefined ? 'browse' : 'files'
+    }
   })
 
   return entries.sort((a, b) => a.thread.createdAt.localeCompare(b.thread.createdAt))
 }
 
 export function ReviewConversationTab({ review, onEdit }: ReviewConversationTabProps) {
+  const scope = useHostScope()
   const { threads, error, isLoading } = useReviewComments(review.id)
   const mutations = useCommentMutations()
 
@@ -117,7 +136,7 @@ export function ReviewConversationTab({ review, onEdit }: ReviewConversationTabP
         </p>
       )}
 
-      {timeline.map(({ thread, snippet }) => (
+      {timeline.map(({ thread, snippet, tab }) => (
         <div key={thread.id} className="flex flex-col gap-2">
           {snippet !== null &&
             // A thread with neither a snapshot nor a live anchor has nothing to
@@ -139,16 +158,21 @@ export function ReviewConversationTab({ review, onEdit }: ReviewConversationTabP
                   replace({
                     name: 'review',
                     reviewId: review.id,
-                    tab: 'files',
-                    ...(snippet.line === null
-                      ? {}
-                      : {
-                          focus: {
-                            filePath: snippet.filePath,
-                            side: snippet.side,
-                            line: snippet.line
-                          }
-                        })
+                    // Whichever tab can actually show this code - see
+                    // `TimelineEntry.tab`. Falls back to Files changed while the
+                    // diff is still being read, which is where it always went.
+                    tab: tab ?? 'files',
+                    focus:
+                      snippet.line === null
+                        ? // Browse needs the path even with no line: it is the
+                          // whole destination there, and Files changed has
+                          // always scrolled to the file's card on one.
+                          { filePath: snippet.filePath }
+                        : { filePath: snippet.filePath, side: snippet.side, line: snippet.line },
+                    // Every link out of this screen has to carry the host, or a
+                    // reviewer three clicks into another machine's review is
+                    // walked back to their own by a link that looks local.
+                    ...scope
                   })
                 }
               />

--- a/src/renderer/src/features/reviews/review-detail.tsx
+++ b/src/renderer/src/features/reviews/review-detail.tsx
@@ -23,6 +23,7 @@ import {
   ArrowRight,
   CircleDot,
   FileDiff,
+  FolderTree,
   GitCommitHorizontal,
   GitPullRequestArrow,
   MessageSquare,
@@ -42,6 +43,7 @@ import { useRegisterCommands, type Command } from '@/features/commands/command-r
 import { navigate, replace, REVIEW_TABS, type DiffFocus, type ReviewTab } from '@/lib/router'
 import { useReviewComments } from '../comments/use-comments'
 import { RefChip } from './ref-chip'
+import { ReviewBrowseTab } from './review-browse-tab'
 import { ReviewCommitsTab } from './review-commits-tab'
 import { ReviewConversationTab } from './review-conversation-tab'
 import { ReviewFilesTab } from './review-files-tab'
@@ -62,13 +64,15 @@ import type { Review } from '@shared/schemas'
 const TAB_LABELS: Record<ReviewTab, string> = {
   conversation: 'Conversation',
   commits: 'Commits',
-  files: 'Files changed'
+  files: 'Files changed',
+  browse: 'Browse files'
 }
 
 const TAB_ICONS: Record<ReviewTab, typeof MessageSquare> = {
   conversation: MessageSquare,
   commits: GitCommitHorizontal,
-  files: FileDiff
+  files: FileDiff,
+  browse: FolderTree
 }
 
 interface ReviewDetailProps {
@@ -331,6 +335,14 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
             {commits.data && <TabsCount>{commits.data.commits.length}</TabsCount>}
           </TabsTab>
           <TabsTab value="files">Files changed</TabsTab>
+          {/* Last, and named for what it does rather than for what it holds.
+              "Files" would be the same word as the tab next to it for two
+              different things; "Browse files" says which of the two is the one
+              that lets you go and look at something nobody changed. */}
+          <TabsTab value="browse">
+            <FolderTree />
+            Browse files
+          </TabsTab>
         </TabsList>
 
         <TabsPanel value="conversation">
@@ -341,6 +353,9 @@ export function ReviewDetail({ reviewId, tab, focus }: ReviewDetailProps) {
         </TabsPanel>
         <TabsPanel value="files">
           <ReviewFilesTab review={review} focus={focus} />
+        </TabsPanel>
+        <TabsPanel value="browse">
+          <ReviewBrowseTab review={review} focus={focus} />
         </TabsPanel>
       </Tabs>
 

--- a/src/renderer/src/features/reviews/review-files-tab.tsx
+++ b/src/renderer/src/features/reviews/review-files-tab.tsx
@@ -47,13 +47,13 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { errorMessage, isDisconnection } from '@/lib/errors'
 import { formatStep } from '@/lib/keys'
 import { plural } from '@/lib/format'
-import { useApi, useHost } from '@/lib/host-scope'
+import { useApi, useHost, useHostScope } from '@/lib/host-scope'
 import { useNarrow } from '@/lib/narrow'
 import { useStoredFlag, useStoredPreference } from '@/lib/preferences'
 import { revealElement } from '@/lib/reveal'
 import { cn } from '@/lib/utils'
 import { useRegisterCommands, type Command } from '@/features/commands/command-registry'
-import type { DiffFocus } from '@/lib/router'
+import { replace, type DiffFocus } from '@/lib/router'
 import { CommentThreadCard } from '../comments/comment-thread-card'
 import { useCommentMutations, useReviewComments } from '../comments/use-comments'
 import { ChangedFilesTree } from './changed-files-tree'
@@ -71,6 +71,7 @@ import {
 import { fileDiffDigest } from '@shared/diff-digest'
 import { remotelyOpenable } from '@shared/editors'
 import { findAnchorFile, isInlineAnchor, resolveAnchor } from '@shared/comment-anchors'
+import type { DiffSide } from '@shared/comment-anchors'
 import { threadSnippet } from '@shared/comment-snippets'
 import type { DiffChanges, FileDiff as FileDiffData } from '@shared/git'
 import { isSelfReview } from '@shared/schemas'
@@ -262,13 +263,27 @@ function useActiveFile(paths: string[]): string | null {
 }
 
 /**
+ * The line half of a focus, when it has one.
+ *
+ * A focus may name only a file - see `DiffFocus` - and the card wants the pair
+ * or nothing. Written once here rather than as the same conditional at the
+ * three places that need it.
+ */
+export function focusedLine(
+  focus: DiffFocus | null | undefined
+): { side: DiffSide; line: number } | undefined {
+  if (!focus || focus.side === undefined || focus.line === undefined) return undefined
+  return { side: focus.side, line: focus.line }
+}
+
+/**
  * Scroll to the line the URL asked for, and mark it while the reader finds it.
  *
  * The target may not be in the DOM yet - the diff is still rendering, or the
  * file card is collapsed and about to open - so this retries for a few frames
  * rather than firing once and missing. A line that never appears (the comment
- * was on code this diff does not contain) falls back to the file's card, which
- * is where such a thread is listed.
+ * was on code this diff does not contain, or the link named no line at all)
+ * falls back to the file's card, which is where such a thread is listed.
  */
 function useFocusScroll(focus: DiffFocus | undefined, ready: boolean): DiffFocus | null {
   const [marked, setMarked] = useState<DiffFocus | null>(null)
@@ -282,7 +297,8 @@ function useFocusScroll(focus: DiffFocus | undefined, ready: boolean): DiffFocus
     let clear = 0
 
     const find = (): void => {
-      const line = document.getElementById(lineDomId(focus.filePath, focus.side, focus.line))
+      const at = focusedLine(focus)
+      const line = at ? document.getElementById(lineDomId(focus.filePath, at.side, at.line)) : null
       const target = line ?? document.getElementById(fileDomId(focus.filePath))
 
       if (target) {
@@ -381,6 +397,9 @@ function useFilesLayout(): {
 export function ReviewFilesTab({ review, focus }: { review: Review; focus?: DiffFocus }) {
   const api = useApi()
   const host = useHost()
+  // Every link out of this tab has to carry the host, or a reviewer three
+  // clicks into another machine's review is walked back to their own.
+  const scope = useHostScope()
   const [changes, setChanges] = useState<DiffChanges>(DEFAULT_DIFF_CHANGES)
   const [editorId, setEditorId] = useStoredPreference('editor', null)
   const [openError, setOpenError] = useState<unknown>(null)
@@ -892,30 +911,57 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
         </p>
       )}
 
-      {/* Threads whose file has left the diff entirely - it was reverted, or
-          the base ref moved on and absorbed the change. Nothing below would
-          render them, and a discussion that silently disappears because the
+      {/* Threads on a file this diff does not contain. Two different stories
+          end up here and the card does not pretend to tell them apart, because
+          the useful response is the same for both: a file that left the diff -
+          reverted, or absorbed when the base ref moved on - and a file the
+          branch never touched, which since the browse tab is an ordinary place
+          to leave a comment.
+
+          What changed is that they are no longer a dead end. Browse reads the
+          file straight from the head, so it can show these threads against the
+          code they are about instead of stranding them at the top of a diff
+          they are not in. A discussion that silently disappears because the
           code moved is exactly the failure this app should not have. */}
       {orphanedFiles.length > 0 && (
         <Card className="flex flex-col gap-2 border-warning/40 p-3">
           <p className="text-xs text-muted-foreground">
             {plural(orphanedFiles.length, 'file')} with comments{' '}
-            {orphanedFiles.length === 1 ? 'is' : 'are'} no longer in this diff.
+            {orphanedFiles.length === 1 ? 'is' : 'are'} not part of this diff. Open{' '}
+            {orphanedFiles.length === 1 ? 'it' : 'them'} in Browse files to read the code.
           </p>
           {orphanedFiles.map(([path, fileThreads]) => (
             <div key={path} className="flex flex-col gap-3">
               {fileThreads.map((thread) => {
-                // No file to read the code from, so this is the stored snapshot
-                // or nothing at all.
+                // No file to read the code from *here* - this tab has only the
+                // diff - so this is the stored snapshot or nothing at all.
                 const snippet = threadSnippet(thread, thread.anchor, undefined)
                 const hasSnippet = snippet !== null && snippet.lines.length > 0
+                const openInBrowse = (): void =>
+                  replace({
+                    name: 'review',
+                    reviewId: review.id,
+                    tab: 'browse',
+                    focus:
+                      thread.line === null || thread.side === null
+                        ? { filePath: path }
+                        : { filePath: path, side: thread.side, line: thread.line },
+                    ...scope
+                  })
 
                 return (
                   <div key={thread.id} className="flex flex-col gap-2">
                     {hasSnippet ? (
-                      <DiffSnippet {...snippet} />
+                      <DiffSnippet {...snippet} onOpen={openInBrowse} openLabel="Browse files" />
                     ) : (
-                      <p className="font-mono text-xs text-muted-foreground">{path}</p>
+                      <button
+                        type="button"
+                        onClick={openInBrowse}
+                        title={`Open ${path} in Browse files`}
+                        className="self-start rounded font-mono text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                      >
+                        {path}
+                      </button>
                     )}
                     <CommentThreadCard
                       thread={thread}
@@ -1026,7 +1072,7 @@ export function ReviewFilesTab({ review, focus }: { review: Review; focus?: Diff
                   // arriving link cannot light up the same number in every file.
                   focus={focus?.filePath === file.path ? focus : undefined}
                   search={find.searchFor(file.path)}
-                  marked={marked?.filePath === file.path ? marked : undefined}
+                  marked={marked?.filePath === file.path ? focusedLine(marked) : undefined}
                   reviewed={{
                     isReviewed: reviewedPaths.has(file.path),
                     hasChangedSince: changedSincePaths.has(file.path),

--- a/src/renderer/src/features/reviews/use-reviews.ts
+++ b/src/renderer/src/features/reviews/use-reviews.ts
@@ -25,7 +25,8 @@ import type {
   FileImage,
   RepositoryRefs,
   ReviewCommits,
-  ReviewDiff
+  ReviewDiff,
+  ReviewTree
 } from '@shared/git'
 import type {
   CommentThread,
@@ -151,6 +152,31 @@ export function useReviewDiff(reviewId: number, changes: DiffChanges): ListState
     useSWR<ReviewDiff, unknown>(
       CACHE_KEYS.reviewDiff(reviewId, changes, host),
       () => api.reviews.diff({ id: reviewId, changes }),
+      LIVE_READ_OPTIONS
+    )
+  )
+}
+
+/**
+ * Every file in the repository at this review's head - what the browse tab
+ * folds into a tree.
+ *
+ * Keyed by `changes` like the diff and read on the same terms as it, which is
+ * what keeps the two tabs describing the same head: a file created on this
+ * branch and not committed yet is in the listing when the reviewer is looking
+ * at uncommitted work, and not when they have narrowed to the commits.
+ *
+ * Read on mount rather than on demand, unlike `useReviewFile`. There is exactly
+ * one of these per review and the tab is unusable without it, so deferring it
+ * would only mean the tree arrives a round trip after the screen does.
+ */
+export function useReviewTree(reviewId: number, changes: DiffChanges): ListState<ReviewTree> {
+  const api = useApi()
+  const host = useHost()
+  return toState(
+    useSWR<ReviewTree, unknown>(
+      CACHE_KEYS.reviewTree(reviewId, changes, host),
+      () => api.reviews.tree({ id: reviewId, changes }),
       LIVE_READ_OPTIONS
     )
   )

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -193,6 +193,7 @@ function buildApi(host: string | undefined): GitWarrenApi {
       remove: (input) => ask('reviews.remove', input, host),
       commits: (input) => ask('reviews.commits', input, host),
       diff: (input) => ask('reviews.diff', input, host),
+      tree: (input) => ask('reviews.tree', input, host),
       file: (input) => ask('reviews.file', input, host),
       image: (input) => ask('reviews.image', input, host),
       reviewedFiles: (input) => ask('reviews.reviewedFiles', input, host),
@@ -337,6 +338,13 @@ export const CACHE_KEYS = {
   reviewDiff: (reviewId: number, changes: DiffChanges, host?: string) =>
     scoped(`review-diff:${reviewId}:${changes}`, host),
   /**
+   * The repository's file list, keyed by the same setting as the diff: it is
+   * what decides whether the head is a worktree or a commit, and therefore
+   * whether a file that exists only on disk is in the listing at all.
+   */
+  reviewTree: (reviewId: number, changes: DiffChanges, host?: string) =>
+    scoped(`review-tree:${reviewId}:${changes}`, host),
+  /**
    * Keyed by the same setting as the diff: expanded context read from another
    * version of the file would not line up with the hunks it sits between.
    */
@@ -386,6 +394,7 @@ export const CACHE_PREFIXES = {
   review: 'review:',
   reviewCommits: 'review-commits:',
   reviewDiff: 'review-diff:',
+  reviewTree: 'review-tree:',
   reviewFile: 'review-file:',
   reviewImage: 'review-image:'
 } as const

--- a/src/shared/__tests__/comment-anchors.test.ts
+++ b/src/shared/__tests__/comment-anchors.test.ts
@@ -364,3 +364,51 @@ test('a file that could not be read is outdated rather than a crash', () => {
 
   assert.deepEqual(resolved, { state: 'outdated', line: null, startLine: null })
 })
+
+/* -------------------------------------------------------------------------- */
+/* Line endings                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The Windows case, which is not an edge case: `core.autocrlf=true` is what Git
+ * for Windows installs by default, and under it `git diff` reports a line with
+ * no CR while the same line read off disk keeps one. A comment captured from
+ * either document has to be findable in the other, or every anchor that falls
+ * back from the diff to the file goes outdated on Windows and nowhere else.
+ */
+test('a CRLF file matches an anchor captured from a CR-less diff', () => {
+  const resolved = resolveAnchorInFile(['function work() {\r', '  const a = 1\r'], {
+    filePath: 'src/app.ts',
+    side: 'head',
+    line: 2,
+    anchorText: '  const a = 1'
+  })
+
+  assert.deepEqual(resolved, { state: 'anchored', line: 2, startLine: null })
+})
+
+test('a diff matches an anchor captured from a CRLF file', () => {
+  // The other direction, which is what happens to a comment left in the browse
+  // tab on a file that the branch later changes.
+  const resolved = resolveAnchor(file, {
+    filePath: 'src/app.ts',
+    side: 'head',
+    line: 2,
+    anchorText: 'const b = 2\r'
+  })
+
+  assert.deepEqual(resolved, { state: 'anchored', line: 2, startLine: null })
+})
+
+test('a carriage return inside a line is content, not a terminator', () => {
+  // Only the last one is a terminator. A CR in the middle of a line is a byte
+  // somebody committed, and two lines differing only there are two lines.
+  const resolved = resolveAnchorInFile(['a\rb'], {
+    filePath: 'src/app.ts',
+    side: 'head',
+    line: 1,
+    anchorText: 'ab'
+  })
+
+  assert.deepEqual(resolved, { state: 'outdated', line: null, startLine: null })
+})

--- a/src/shared/__tests__/comment-anchors.test.ts
+++ b/src/shared/__tests__/comment-anchors.test.ts
@@ -10,7 +10,12 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
 
-import { findAnchorFile, isInlineAnchor, resolveAnchor } from '../comment-anchors.js'
+import {
+  findAnchorFile,
+  isInlineAnchor,
+  resolveAnchor,
+  resolveAnchorInFile
+} from '../comment-anchors.js'
 import type { DiffLine, FileDiff } from '../git.js'
 
 /**
@@ -271,4 +276,91 @@ test('inline threads are told apart from review-level ones', () => {
   assert.equal(isInlineAnchor({ filePath: null, side: null, line: null }), false)
   // A half-filled anchor is not inline: all three columns are written together.
   assert.equal(isInlineAnchor({ filePath: 'a.ts', side: 'head', line: null }), false)
+})
+
+/* -------------------------------------------------------------------------- */
+/* Anchored in a file rather than in a diff                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The browse tab's case: a comment on a file the patch does not contain, which
+ * has to be re-found in the file's own text. The rules are the same ones proved
+ * above - that is the point of the shared search - so what these check is that
+ * the file entry point really does go through it, and the two places where a
+ * file differs from a diff: line 1 is index 0, and there is no base side.
+ */
+const source = ['function work() {', '  const a = 1', '  const b = 2', '}']
+
+test('a file line still holding its text is anchored', () => {
+  const resolved = resolveAnchorInFile(source, {
+    filePath: 'src/app.ts',
+    side: 'head',
+    line: 2,
+    anchorText: '  const a = 1'
+  })
+
+  assert.deepEqual(resolved, { state: 'anchored', line: 2, startLine: null })
+})
+
+test('a file line pushed down by an edit above follows its text', () => {
+  const withPreamble = ['// a note', ...source]
+
+  const resolved = resolveAnchorInFile(withPreamble, {
+    filePath: 'src/app.ts',
+    side: 'head',
+    line: 2,
+    anchorText: '  const a = 1'
+  })
+
+  assert.deepEqual(resolved, { state: 'moved', line: 3, startLine: null })
+})
+
+test('a range in a file keeps the length it was written at', () => {
+  const withPreamble = ['// a note', '// and another', ...source]
+
+  const resolved = resolveAnchorInFile(withPreamble, {
+    filePath: 'src/app.ts',
+    side: 'head',
+    line: 3,
+    startLine: 1,
+    anchorText: '  const b = 2'
+  })
+
+  assert.deepEqual(resolved, { state: 'moved', line: 5, startLine: 3 })
+})
+
+test('text the file no longer contains is outdated', () => {
+  const resolved = resolveAnchorInFile(source, {
+    filePath: 'src/app.ts',
+    side: 'head',
+    line: 2,
+    anchorText: '  const a = 99'
+  })
+
+  assert.deepEqual(resolved, { state: 'outdated', line: null, startLine: null })
+})
+
+test('a base-side anchor is never matched against the current file', () => {
+  // "Base" is the version the change started from. `  const a = 1` is sitting
+  // right there on line 2, and claiming it would pin a comment about removed
+  // code to code that is still present.
+  const resolved = resolveAnchorInFile(source, {
+    filePath: 'src/app.ts',
+    side: 'base',
+    line: 2,
+    anchorText: '  const a = 1'
+  })
+
+  assert.deepEqual(resolved, { state: 'outdated', line: null, startLine: null })
+})
+
+test('a file that could not be read is outdated rather than a crash', () => {
+  const resolved = resolveAnchorInFile(undefined, {
+    filePath: 'src/app.ts',
+    side: 'head',
+    line: 2,
+    anchorText: '  const a = 1'
+  })
+
+  assert.deepEqual(resolved, { state: 'outdated', line: null, startLine: null })
 })

--- a/src/shared/__tests__/routes.test.ts
+++ b/src/shared/__tests__/routes.test.ts
@@ -33,6 +33,55 @@ test('local hrefs are the same strings they always were', () => {
   )
 })
 
+test('a browsed file is a location, with or without a line', () => {
+  // The browse tab shows one file at a time, so which file is part of where you
+  // are - it survives a reload and can be pasted to somebody else.
+  const file: Route = {
+    name: 'review',
+    reviewId: 4,
+    tab: 'browse',
+    focus: { filePath: 'src/core/git.ts' }
+  }
+
+  assert.equal(hrefFor(file), '#/reviews/4/browse/src%2Fcore%2Fgit.ts')
+  assert.deepEqual(parseRoute(hrefFor(file)), file)
+
+  // And a line in it, for a link that comes from a comment.
+  const line: Route = {
+    name: 'review',
+    reviewId: 4,
+    tab: 'browse',
+    focus: { filePath: 'src/core/git.ts', side: 'head', line: 12 }
+  }
+
+  assert.equal(hrefFor(line), '#/reviews/4/browse/src%2Fcore%2Fgit.ts/head/12')
+  assert.deepEqual(parseRoute(hrefFor(line)), line)
+})
+
+test('half a focus is no focus', () => {
+  // A bare path is a whole destination, but segments that are present and wrong
+  // mean the link was built by something that got the grammar wrong - so the
+  // reader lands on the tab rather than somewhere approximate.
+  const onlyTheTab = { name: 'review', reviewId: 4, tab: 'browse' }
+
+  assert.deepEqual(parseRoute('#/reviews/4/browse/a.ts/sideways/9'), onlyTheTab)
+  assert.deepEqual(parseRoute('#/reviews/4/browse/a.ts/head/0'), onlyTheTab)
+  assert.deepEqual(parseRoute('#/reviews/4/browse/a.ts/head/oops'), onlyTheTab)
+})
+
+test('a focus path may not address its way out of the repository', () => {
+  // The real guard is in `core/git-compare.ts`, at the read. This one keeps a
+  // hash an agent wrote into a comment from becoming a location at all - and
+  // since browse, a focus path is a file the screen goes and asks for.
+  for (const hash of [
+    '#/reviews/4/browse/..%2F..%2Fetc%2Fpasswd',
+    '#/reviews/4/browse/%2Fetc%2Fpasswd',
+    '#/reviews/4/browse/C%3A%5CWindows'
+  ]) {
+    assert.deepEqual(parseRoute(hash), { name: 'review', reviewId: 4, tab: 'browse' }, hash)
+  }
+})
+
 test('a local route carries no host key at all', () => {
   // Not `host: undefined`: routes are compared for equality in the router and
   // in tests, and a key that is present but empty is not the same object.

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -17,7 +17,14 @@
  * The MCP server uses none of this - it talks to `core/services` directly - and
  * that is deliberate: this file is transport, not behaviour.
  */
-import type { FileContent, FileImage, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
+import type {
+  FileContent,
+  FileImage,
+  RepositoryRefs,
+  ReviewCommits,
+  ReviewDiff,
+  ReviewTree
+} from './git.js'
 import type { AttachmentIngestParams, BridgeCarrier, ReviewOpen, RpcMethod } from './rpc.js'
 import type {
   AddHostInput,
@@ -54,6 +61,7 @@ import type {
   Review,
   ReviewCommitsInput,
   ReviewDiffInput,
+  ReviewTreeInput,
   ReviewedFile,
   ReviewFileInput,
   ReviewImageInput,
@@ -395,6 +403,13 @@ export interface GitWarrenApi {
     commits(input: ReviewCommitsInput): Promise<ReviewCommits>
     /** The merge-base diff, uncommitted work folded in unless asked otherwise. */
     diff(input: ReviewDiffInput): Promise<ReviewDiff>
+    /**
+     * Every file in the repository at this review's head, changed or not - what
+     * the browse tab folds into a tree. `changes` decides whether the head is a
+     * worktree or a commit, so it must match the diff on screen for the same
+     * reason `file` must.
+     */
+    tree(input: ReviewTreeInput): Promise<ReviewTree>
     /**
      * One file's head-side text, whole. This is what lets the diff show the
      * lines between its hunks; `changes` must match the diff on screen so the

--- a/src/shared/comment-anchors.ts
+++ b/src/shared/comment-anchors.ts
@@ -13,10 +13,26 @@
  * number is a position in a document that keeps being rewritten; the text is
  * what the reviewer was actually looking at.
  *
+ * ## Two things a comment can be anchored in
+ *
+ * A diff, which is what this module did when the only readable thing in a
+ * review was its patch - and a *file*, since a comment may now be left on a
+ * file the branch never touched. The rule above is the same for both, and so is
+ * every case that makes it interesting (the text moved, the text is gone, the
+ * text appears five times), so the search is written once over a list of
+ * numbered lines and the two entry points differ only in where they get that
+ * list. A diff contributes the lines its hunks happen to print; a file
+ * contributes all of them.
+ *
+ * That equivalence is load-bearing rather than tidy. A comment on an unchanged
+ * file resolved by a diff-only rule would be `outdated` from the moment it was
+ * written - not because anything drifted, but because the reader was asking the
+ * wrong document.
+ *
  * This module is deliberately pure and dependency-free. The renderer runs it
- * against the diff it has already fetched, and the MCP server runs it against a
- * diff it reads itself, so both surfaces report the same anchor for the same
- * thread.
+ * against the diff or file it has already fetched, and the MCP server runs it
+ * against ones it reads itself, so both surfaces report the same anchor for the
+ * same thread.
  */
 import type { DiffLine, FileDiff } from './git.js'
 
@@ -73,6 +89,19 @@ function numberOn(line: DiffLine, side: DiffSide): number | null {
 }
 
 /**
+ * One line of whatever document the comment is being re-found in.
+ *
+ * The smallest thing the search below actually needs, which is why it is this
+ * and not `DiffLine`: a file has no sides and no insert/delete, and asking it
+ * to pretend otherwise would mean inventing an `oldNumber` for every line of
+ * every unchanged file just to throw it away one function later.
+ */
+interface NumberedLine {
+  number: number
+  content: string
+}
+
+/**
  * Find the file a thread belongs to.
  *
  * Renames are matched on either name: a thread left on `old/name.ts` before the
@@ -82,21 +111,18 @@ export function findAnchorFile(files: FileDiff[], filePath: string): FileDiff | 
   return files.find((file) => file.path === filePath || file.oldPath === filePath)
 }
 
-export function resolveAnchor(file: FileDiff | undefined, anchor: ThreadAnchor): ResolvedAnchor {
-  if (!file) return OUTDATED
-
+/**
+ * The search itself: the stored line if it still reads the same, else the
+ * nearest line that does, else nothing.
+ *
+ * Both entry points below come through here, so "how a comment follows its
+ * code" is one piece of behaviour with one set of tests rather than two
+ * implementations that agree until someone touches one of them.
+ */
+function resolveIn(lines: NumberedLine[], anchor: ThreadAnchor): ResolvedAnchor {
   // Nothing to verify against, so there is no honest way to claim the stored
   // line is still the right one. Report it as outdated rather than guess.
   if (anchor.anchorText === null) return OUTDATED
-
-  // Only lines that exist on the requested side can carry the anchor: an
-  // inserted line has no base number, a deleted line has no head number.
-  const lines: DiffLine[] = []
-  for (const hunk of file.hunks) {
-    for (const line of hunk.lines) {
-      if (numberOn(line, anchor.side) !== null) lines.push(line)
-    }
-  }
 
   /** Keep the range the length it was written at; see `ResolvedAnchor`. */
   const span = Math.max(anchor.line - (anchor.startLine ?? anchor.line), 0)
@@ -106,7 +132,7 @@ export function resolveAnchor(file: FileDiff | undefined, anchor: ThreadAnchor):
     startLine: span === 0 ? null : Math.max(line - span, 1)
   })
 
-  const atStoredLine = lines.find((line) => numberOn(line, anchor.side) === anchor.line)
+  const atStoredLine = lines.find((line) => line.number === anchor.line)
   if (atStoredLine?.content === anchor.anchorText) {
     return withRange('anchored', anchor.line)
   }
@@ -118,17 +144,56 @@ export function resolveAnchor(file: FileDiff | undefined, anchor: ThreadAnchor):
   let bestDistance = Number.POSITIVE_INFINITY
   for (const candidate of lines) {
     if (candidate.content !== anchor.anchorText) continue
-    const number = numberOn(candidate, anchor.side)
-    if (number === null) continue
-    const distance = Math.abs(number - anchor.line)
+    const distance = Math.abs(candidate.number - anchor.line)
     if (distance < bestDistance) {
-      bestLine = number
+      bestLine = candidate.number
       bestDistance = distance
     }
   }
 
   if (bestLine === null) return OUTDATED
   return withRange('moved', bestLine)
+}
+
+export function resolveAnchor(file: FileDiff | undefined, anchor: ThreadAnchor): ResolvedAnchor {
+  if (!file) return OUTDATED
+
+  // Only lines that exist on the requested side can carry the anchor: an
+  // inserted line has no base number, a deleted line has no head number.
+  const lines: NumberedLine[] = []
+  for (const hunk of file.hunks) {
+    for (const line of hunk.lines) {
+      const number = numberOn(line, anchor.side)
+      if (number !== null) lines.push({ number, content: line.content })
+    }
+  }
+
+  return resolveIn(lines, anchor)
+}
+
+/**
+ * The same question asked of a file's own text, for a comment on a file the
+ * diff does not contain.
+ *
+ * `lines` is the file as `FileContent` carries it: index 0 is line 1, which is
+ * the one place in this module where that conversion happens.
+ *
+ * Head side only, and that is not a limitation so much as what the words mean.
+ * "Base" and "head" are ends of a *comparison*; a file nobody changed has one
+ * version, and it is the one on screen. A base-side anchor arriving here is a
+ * thread about a line the change removed, which by definition is a line this
+ * file does not have - so it is outdated, and saying so is more honest than
+ * matching its text against the current file and claiming a hit.
+ */
+export function resolveAnchorInFile(
+  lines: string[] | undefined,
+  anchor: ThreadAnchor
+): ResolvedAnchor {
+  if (lines === undefined || anchor.side === 'base') return OUTDATED
+  return resolveIn(
+    lines.map((content, index) => ({ number: index + 1, content })),
+    anchor
+  )
 }
 
 /** True for a thread that is about a line rather than about the review overall. */

--- a/src/shared/comment-anchors.ts
+++ b/src/shared/comment-anchors.ts
@@ -102,6 +102,37 @@ interface NumberedLine {
 }
 
 /**
+ * A line's text without its terminator.
+ *
+ * Windows, and specifically the configuration Git for Windows installs by
+ * default. With `core.autocrlf=true` the blob holds LF and the working tree
+ * holds CRLF, and git resolves that difference in opposite directions for the
+ * two documents this module compares: `git diff` applies the clean filter, so
+ * its lines arrive with no CR, while a file read off disk keeps it. The same
+ * line is then `const a = 1` in one and `const a = 1\r` in the other.
+ *
+ * That was harmless while an anchor was only ever looked for in a diff. It
+ * stops being harmless the moment a comment can be captured from one document
+ * and re-found in the other, which is exactly what an anchor does now: every
+ * such comment would go outdated on Windows the first time the fallback ran,
+ * and nothing on screen would explain why.
+ *
+ * Normalising here, in the comparison, rather than where the lines are
+ * produced. Stripping at the source would mean rewriting what a `DiffLine`
+ * *contains*, which is the input to the reviewed-file digests
+ * (`shared/diff-digest.ts`) and to every `anchorText` already stored - so on a
+ * repository with CRLF genuinely committed it would silently lapse people's
+ * reviewed marks and strand their existing comments. Comparing without the
+ * terminator fixes the mismatch and leaves both of those alone; it also means
+ * an anchor stored before this change still matches.
+ *
+ * One CR, only at the end. A CR anywhere else in a line is content.
+ */
+function withoutTerminator(content: string): string {
+  return content.endsWith('\r') ? content.slice(0, -1) : content
+}
+
+/**
  * Find the file a thread belongs to.
  *
  * Renames are matched on either name: a thread left on `old/name.ts` before the
@@ -132,8 +163,10 @@ function resolveIn(lines: NumberedLine[], anchor: ThreadAnchor): ResolvedAnchor 
     startLine: span === 0 ? null : Math.max(line - span, 1)
   })
 
+  const wanted = withoutTerminator(anchor.anchorText)
+
   const atStoredLine = lines.find((line) => line.number === anchor.line)
-  if (atStoredLine?.content === anchor.anchorText) {
+  if (atStoredLine !== undefined && withoutTerminator(atStoredLine.content) === wanted) {
     return withRange('anchored', anchor.line)
   }
 
@@ -143,7 +176,7 @@ function resolveIn(lines: NumberedLine[], anchor: ThreadAnchor): ResolvedAnchor 
   let bestLine: number | null = null
   let bestDistance = Number.POSITIVE_INFINITY
   for (const candidate of lines) {
-    if (candidate.content !== anchor.anchorText) continue
+    if (withoutTerminator(candidate.content) !== wanted) continue
     const distance = Math.abs(candidate.number - anchor.line)
     if (distance < bestDistance) {
       bestLine = candidate.number

--- a/src/shared/comment-snippets.ts
+++ b/src/shared/comment-snippets.ts
@@ -71,6 +71,43 @@ export function snippetAt(
 }
 
 /**
+ * The same few lines, taken from a file rather than from a patch.
+ *
+ * For a comment on a file the diff does not contain - which since the browse
+ * tab is an ordinary thing to write - there is no hunk to slice, only the file
+ * itself. `lines` is as `FileContent` carries it, index 0 being line 1.
+ *
+ * Head side only, and there is no parameter for it: a file has one version, and
+ * the numbers in it are head-side numbers. The caller decides whether a
+ * base-side anchor should reach here at all, and none of them let it.
+ *
+ * `clipped` means the same thing it does above - there is more file above the
+ * snippet - which for a file is true whenever the lead-in did not reach line 1.
+ */
+export function snippetInFile(
+  lines: string[],
+  line: number,
+  context = SNIPPET_CONTEXT_LINES
+): AnchorSnippet | null {
+  const content = lines[line - 1]
+  if (content === undefined) return null
+
+  const start = Math.max(1, line - context)
+  return {
+    lines: Array.from({ length: line - start + 1 }, (_, offset) => ({
+      type: 'context' as const,
+      content: lines[start + offset - 1] as string,
+      // Unchanged code has the same number on both sides of the comparison, and
+      // saying so is what lets a stored snapshot render through the same
+      // component as one taken from a diff.
+      oldNumber: start + offset,
+      newNumber: start + offset
+    })),
+    clipped: start > 1
+  }
+}
+
+/**
  * Choosing which code to show above a line comment.
  *
  * There are two candidates and the order between them is the whole point:

--- a/src/shared/deep-link.ts
+++ b/src/shared/deep-link.ts
@@ -76,7 +76,8 @@ export function deepLinkPathFor(route: ReviewRoute): string {
   if (!route.focus) return base
 
   const { filePath, side, line } = route.focus
-  return `${base}/${encodeURIComponent(filePath)}/${side}/${line}`
+  const at = side === undefined || line === undefined ? '' : `/${side}/${line}`
+  return `${base}/${encodeURIComponent(filePath)}${at}`
 }
 
 /**

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -160,6 +160,39 @@ export interface FileContent {
 }
 
 /**
+ * Every file in the repository at the review's head - what the branch changed
+ * and, far more of it, what it did not.
+ *
+ * Paths only. A tree read exists so a reviewer can *find* a file and then ask
+ * for it by name, and the two things a listing is otherwise tempted to carry -
+ * size and mode - are a `stat` per entry over what may be an `ssh` pipe, for
+ * columns nobody reads. The file itself arrives through `FileContent`, which is
+ * the same call the diff's expanders already make.
+ *
+ * Flat rather than nested, and that is deliberate too. The screen folds these
+ * into a tree with the code `changed-files-tree.tsx` has always used, so a
+ * nested response would be the same information in a shape only one consumer
+ * could use - and a shape that costs an object per directory on the wire.
+ */
+export interface ReviewTree {
+  /** Repository-relative, `/`-separated, sorted. */
+  paths: string[]
+  /**
+   * Where the listing came from - the worktree on disk (so it includes
+   * uncommitted and untracked files), or the head commit's tree.
+   *
+   * Worth carrying for the same reason `FileContent.source` is: it is the
+   * difference between "this repository has no such file" and "the commit you
+   * are reading does not have it yet".
+   */
+  source: 'worktree' | 'commit'
+  /** True when the repository has more files than one listing will carry. */
+  truncated: boolean
+  /** Set when the tree could not be read at all; `paths` is then empty. */
+  error: string | null
+}
+
+/**
  * Image formats a diff previews rather than writing off as "binary".
  *
  * Raster only, and deliberately so. SVG is text, so it already gets a real line

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -12,22 +12,33 @@
  */
 import { isInstanceId } from './instance-id.js'
 
-export const REVIEW_TABS = ['conversation', 'commits', 'files'] as const
+export const REVIEW_TABS = ['conversation', 'commits', 'files', 'browse'] as const
 export type ReviewTab = (typeof REVIEW_TABS)[number]
 
 /**
- * A line of the diff to scroll to and mark on arrival.
+ * Where in a tab full of code the reader is being sent.
  *
  * In the hash rather than in a module variable so that the jump from a
  * conversation thread to its code is a *location*: it survives a reload, it can
- * be gone back to, and the files tab does not have to be told about it by
- * whoever happened to render it.
+ * be gone back to, and the tab does not have to be told about it by whoever
+ * happened to render it.
+ *
+ * The line is optional, and that is what the browse tab writes: "open
+ * `src/app.ts`" is a perfectly good destination on a screen that shows one file
+ * at a time, and `#/reviews/4/browse/src%2Fapp.ts` is how a person would expect
+ * to be able to say it. A path without a line already had a meaning in Files
+ * changed too - scroll to that file's card - which is exactly what arriving
+ * with a line the diff does not contain has always fallen back to.
+ *
+ * `side` travels with the line rather than on its own. On its own it would be
+ * an assertion about a file with no line to make it about, and the two are
+ * written and read as one pair everywhere they appear.
  */
 export interface DiffFocus {
   filePath: string
-  side: 'base' | 'head'
-  /** Line on that side, already resolved against the diff being shown. */
-  line: number
+  side?: 'base' | 'head'
+  /** Line on that side, already resolved against the code being shown. */
+  line?: number
 }
 
 /**
@@ -129,7 +140,8 @@ export function hrefFor(route: Route): string {
       if (!route.focus) return base
       // The path is encoded whole, slashes included, so it stays one segment.
       const { filePath, side, line } = route.focus
-      return `${base}/${encodeURIComponent(filePath)}/${side}/${line}`
+      const at = side === undefined || line === undefined ? '' : `/${side}/${line}`
+      return `${base}/${encodeURIComponent(filePath)}${at}`
     }
   }
 }
@@ -138,21 +150,61 @@ function isReviewTab(value: string | undefined): value is ReviewTab {
   return REVIEW_TABS.includes(value as ReviewTab)
 }
 
-/** `<encoded path>/<side>/<line>`, or nothing if any of it is missing or wrong. */
+/**
+ * Is this a path inside the repository, as a link is allowed to name one?
+ *
+ * The same rule as `isSafeRelativePath` in `core/git-compare.ts`, applied a
+ * long way earlier. That one is the real defence - it guards the actual file
+ * read, and it is the one that must never be removed - but a hash is hostile
+ * input that can arrive from a deep link an agent wrote into a comment, and
+ * this parser's standing promise is that it never produces a location the app
+ * could not already express. `../../etc/passwd` is not one of those, so it does
+ * not become a `Route` in the first place.
+ *
+ * Checked here rather than left to the reader because since the browse tab a
+ * focus path is not only a scroll target: it is the file the screen goes and
+ * asks for.
+ */
+function isLinkablePath(path: string): boolean {
+  if (path === '' || path.startsWith('/') || path.startsWith('\\')) return false
+  if (/^[a-zA-Z]:/.test(path)) return false
+  return !path.split(/[\\/]/).includes('..')
+}
+
+/**
+ * `<encoded path>`, or `<encoded path>/<side>/<line>`.
+ *
+ * All or nothing, and deliberately so. A bare path is a complete destination -
+ * the browse tab's "open this file", and in Files changed the scroll-to-card
+ * that arriving with an unfindable line has always fallen back to. But segments
+ * that are *present and wrong* - `a.ts/sideways/9`, `a.ts/head/oops` - mean the
+ * link was built by something that got the grammar wrong, and the honest
+ * response to half a location is none of it. The tab itself is still perfectly
+ * openable, which is where such a link lands.
+ */
 function parseFocus(segments: string[]): DiffFocus | undefined {
   const [encoded, side, rawLine] = segments
-  if (!encoded || (side !== 'base' && side !== 'head')) return undefined
+  if (!encoded) return undefined
+
+  let filePath: string
+  try {
+    filePath = decodeURIComponent(encoded)
+  } catch {
+    // A hand-mangled hash with a stray `%`.
+    return undefined
+  }
+
+  if (!isLinkablePath(filePath)) return undefined
+
+  // Nothing after the path: the file is the destination.
+  if (side === undefined && rawLine === undefined) return { filePath }
+
+  if (side !== 'base' && side !== 'head') return undefined
 
   const line = Number(rawLine)
   if (!Number.isInteger(line) || line <= 0) return undefined
 
-  try {
-    return { filePath: decodeURIComponent(encoded), side, line }
-  } catch {
-    // A hand-mangled hash with a stray `%`. Losing the focus is the right
-    // failure - the tab itself is still perfectly openable.
-    return undefined
-  }
+  return { filePath, side, line }
 }
 
 /**

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -20,7 +20,14 @@
  */
 import { AppError, deserializeAppError, type SerializedAppError } from './errors.js'
 import type { McpLaunchInfo } from './api.js'
-import type { FileContent, FileImage, RepositoryRefs, ReviewCommits, ReviewDiff } from './git.js'
+import type {
+  FileContent,
+  FileImage,
+  RepositoryRefs,
+  ReviewCommits,
+  ReviewDiff,
+  ReviewTree
+} from './git.js'
 import type {
   AddHostInput,
   AddRepositoryInput,
@@ -58,6 +65,7 @@ import type {
   Review,
   ReviewCommitsInput,
   ReviewDiffInput,
+  ReviewTreeInput,
   ReviewedFile,
   ReviewFileInput,
   ReviewImageInput,
@@ -404,6 +412,7 @@ export interface RpcMethods {
   'reviews.remove': { params: RemoveReviewInput; result: { id: number } }
   'reviews.commits': { params: ReviewCommitsInput; result: ReviewCommits }
   'reviews.diff': { params: ReviewDiffInput; result: ReviewDiff }
+  'reviews.tree': { params: ReviewTreeInput; result: ReviewTree }
   'reviews.file': { params: ReviewFileInput; result: FileContent }
   'reviews.image': { params: ReviewImageInput; result: FileImage }
   /**
@@ -524,6 +533,7 @@ export const READ_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   'reviews.get',
   'reviews.commits',
   'reviews.diff',
+  'reviews.tree',
   'reviews.file',
   'reviews.image',
   'reviews.filePath',

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -481,6 +481,19 @@ export const reviewDiffInputSchema = z.object({
 })
 
 /**
+ * Every file in the repository at the review's head.
+ *
+ * The same two fields as the diff, and `changes` means the same thing here for
+ * the same reason: it decides whether the head is a commit or a worktree, and
+ * therefore whether a file created on this branch but not committed yet is part
+ * of the repository a reviewer can open.
+ */
+export const reviewTreeInputSchema = z.object({
+  id: reviewIdSchema,
+  changes: diffChangesSchema
+})
+
+/**
  * One file of a review, read whole so the diff can be expanded past its hunks.
  * `changes` has to match the diff on screen, or the expanded context would come
  * from a different version of the file than the hunks around it.
@@ -537,6 +550,7 @@ export type GetReviewInput = z.input<typeof getReviewInputSchema>
 export type RemoveReviewInput = z.input<typeof removeReviewInputSchema>
 export type ReviewCommitsInput = z.input<typeof reviewCommitsInputSchema>
 export type ReviewDiffInput = z.input<typeof reviewDiffInputSchema>
+export type ReviewTreeInput = z.input<typeof reviewTreeInputSchema>
 export type ReviewFileInput = z.input<typeof reviewFileInputSchema>
 export type ReviewImageInput = z.input<typeof reviewImageInputSchema>
 export type OpenReviewFileInput = z.input<typeof openReviewFileInputSchema>


### PR DESCRIPTION
A review has only ever shown what the branch changed. But reviewing a change is mostly reading code the change *did not* touch — the caller of the edited function, the test nobody updated, the interface a new field should have gone on — and until now that meant leaving the app, which also meant anything you noticed over there had nowhere to be written down.

## What this adds

**A Browse files tab.** Every file in the repository at the review's head, folded into a tree with a fuzzy filter over it, one file on screen at a time with the same comment gutter the diff has. Which file is part of the location — `#/reviews/4/browse/src%2Fapp.ts` — so it survives a reload and can be pasted to a colleague or written into a comment by an agent.

**`reviews.tree`**, the git read behind it: `ls-files` from the worktree when one holds the head branch (so uncommitted and untracked files are browsable), `ls-tree` from the head commit otherwise. `.gitignore` applies, so build output stays out.

## The part that actually made it work

Not the tab — the anchoring.

A comment has always been re-found by its stored *text* rather than its line number, because a review follows refs and the code keeps moving under it. But that search only ever ran over a diff. A line the patch does not print had no anchor at all, so it was reported `outdated` from the second it was written — not because anything had drifted, but because nobody had looked in the document it was about.

That silently covered two real cases already: an agent commenting on unchanged code, and anyone commenting on a line unfolded out of a diff's own expanders. Both are fixed here as a side effect.

The search is now written once over a list of numbered lines, with two entry points differing only in where the lines come from — a diff's hunks, or a file's own text. `captureAnchor` falls back from one to the other, and so does `listAnchored`, so agents over MCP see the same honest anchor the screen does.

Base-side anchors deliberately never match against the current file: "base" is the version the change started from, and claiming a hit there would pin a comment about removed code to code that is still present.

## Three consequences worth reviewing

- Threads the Files-changed tab used to strand in its orphan list now **link into Browse**, which can show them against the code they are about.
- The conversation tab sends a thread to whichever tab can display it — and now **carries the host** while doing so. It was dropping it, so clicking a snippet on another machine's review walked you to your own.
- A focus path in a hash is now a file the screen **goes and asks for**, not just a scroll target, so `parseRoute` rejects one that addresses its way out of the repository rather than leaving it to the read. (The read still checks too; that guard is untouched.)

## Shared rather than copied

`path-tree.ts` — both file trees fold directories the same way — and `line-selection.ts`. The touch-drag handling in the latter came from c78026b and was arrived at on a real phone; a second copy would have been a copy without it.

## A Windows defect this turned up

CI went red on Windows only. The surface cause was a test of mine asserting `['*.log']` against a file git *checks out* rather than one the test writes, so with the default `core.autocrlf` it came back `['*.log\r']`. The underlying cause was worth more.

With `core.autocrlf=true` — what Git for Windows installs by default — the blob holds LF and the working tree holds CRLF, and git resolves that in opposite directions for the two documents an anchor is now compared against. Verified in a scratch repo:

| config | diff body | file on disk |
| --- | --- | --- |
| `autocrlf` unset, CRLF committed | has CR | has CR — agree |
| `autocrlf=true` (default on Windows) | **no CR** | has CR — **disagree** |

So the same line is `const a = 1` in the diff and `const a = 1\r` in the file, and every comment falling back from one to the other would have gone outdated on Windows alone, with nothing on screen to explain it. Harmless before this branch, when an anchor was only ever looked for in a diff.

Fixed in the **comparison**, not at the source. Stripping the CR where lines are produced would change what a `DiffLine` contains — the input to the reviewed-file digests and to every `anchorText` already stored — so on a repository with CRLF genuinely committed it would have quietly lapsed reviewed marks and stranded existing comments. Comparing without the terminator fixes the mismatch, leaves both alone, and keeps anchors stored before this change matching. One CR, only at the end: a CR mid-line is content somebody committed.

## Verification

603 unit tests pass; lint and typecheck clean. Driven against the real app over CDP: the tree read over IPC, an unchanged file opened and rendered, a comment left on line 5 of it coming back anchored to that line's text with a snapshot, and the round trip from the conversation tab back into Browse.

Based on `worktree-mcp-comment-test` rather than `main`: the extracted touch handling comes from that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GuXTaHX3Lq4G7qCV9kh1d
