### PR TITLE
Release 0.1.7-beta.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitwarren",
-  "version": "0.1.7-beta.3",
+  "version": "0.1.7-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitwarren",
-      "version": "0.1.7-beta.3",
+      "version": "0.1.7-beta.4",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitwarren",
   "productName": "GitWarren",
-  "version": "0.1.7-beta.3",
+  "version": "0.1.7-beta.4",
   "description": "Code review for your own machines and your own agents",
   "author": {
     "name": "Klarluft B.V.",


### PR DESCRIPTION
Bumps the version to `0.1.7-beta.4` so everything merged since beta.3 can be installed and exercised in a real build.

Since `v0.1.7-beta.3`:

- **Browse files** (#64) — every file at the review's head in a filterable tree, with the diff's comment gutter, and the file in the location so the view survives a reload.
- **Anchoring past the diff** (#64) — a comment's text search now runs over a file's own lines too, so comments on untouched code anchor and follow the code instead of being born outdated.
- **Four things reported from use** (#62) — a newly added host no longer claims GitWarren is missing before it has been asked, the copied tick is visible on the filled button, a line comment can be started with a finger, and a multi-line selection can be dragged on a touchscreen.
- **CRLF** (#64) — anchors compare without the line terminator, so Windows comments stop going outdated over one byte.
- **Smaller** (#61) — `serve`'s refusal prints the running owner's URL; an unknown file size draws a dash rather than `NaN B`; large file counts are grouped.
- **Words** (#63) — README and CONTRIBUTING no longer call this a single-machine app.

Verified on the branch: `npm run lint` (0 errors, the one pre-existing `exhaustive-deps` warning) and `npm test` (603 passing, 4 skipped on darwin by design).

After merge: tag `v0.1.7-beta.4` on main, let `release.yml` build, then publish with

```
gh release edit v0.1.7-beta.4 --draft=false --prerelease --latest=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKRYVY7fHyAtJkZd3JFTjm