### PR TITLE
Release 0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitwarren",
-  "version": "0.1.7-beta.4",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitwarren",
-      "version": "0.1.7-beta.4",
+      "version": "0.1.7",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitwarren",
   "productName": "GitWarren",
-  "version": "0.1.7-beta.4",
+  "version": "0.1.7",
   "description": "Code review for your own machines and your own agents",
   "author": {
     "name": "Klarluft B.V.",


### PR DESCRIPTION
Bumps the version to `0.1.7` — the first stable release since `v0.1.6`.

**This is the same code as `v0.1.7-beta.4`.** Nothing has merged into `main` since that tag, so the build you exercised is the build that ships.

### Before merging

`NPM_TOKEN` is still unset in this repository's secrets. Per the plan made while 0.1.7 was in beta, it was deliberately held back so the *first ever* publish of `gitwarren` would take `latest` rather than landing as `gitwarren@next` — and this is that release. Create a **classic automation** token on npmjs.com (granular tokens cannot be scoped to a package that does not exist yet) and `gh secret set NPM_TOKEN` before the tag is pushed.

If it is not set, the release still succeeds and everything else publishes — the `daemon` job skips npm and says so. It can be recovered by re-running that job, or by `npm publish ./out/npm` from the built output.

### What publishing this does, that a beta did not

- `deploy-site.yml` rebuilds gitwarren.com so every download button points at these assets
- `homebrew-tap.yml` moves the cask to this version and its checksums (`HOMEBREW_TAP_TOKEN` is not set, so the tap picks it up on its own schedule within a few hours rather than immediately)
- Every 0.1.6 install takes it on its next six-hourly check
- `npm publish` runs without `--tag`, setting `latest`

Verified on the branch: `npm run lint` (0 errors, the one pre-existing `exhaustive-deps` warning) and `npm test` (607 tests, 603 pass, 0 fail, 4 skipped on darwin by design).

After merge: tag `v0.1.7` on main, let `release.yml` build, then publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKRYVY7fHyAtJkZd3JFTjm