### PR TITLE
Publish to npm without a credential to lose

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,6 +285,13 @@ jobs:
     # Same reasoning as the matrix: a failure here should not throw away
     # installers that already uploaded to the draft.
     continue-on-error: true
+    # A job-level block *replaces* the workflow's `contents: write` rather than
+    # adding to it, so that has to be repeated here or `gh release upload`
+    # above loses the permission it needs. `id-token: write` is what lets this
+    # job ask GitHub for the OIDC token npm trades for a publish credential.
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -332,29 +339,42 @@ jobs:
           gh release upload "$TAG" out/daemon-tarball/*.tar.gz --clobber
           gh release upload "$TAG" out/daemon-tarball/gitwarren-cli.rb --clobber
 
-      # Skipped rather than failed without a token, like homebrew-tap.yml: a
-      # release that produced every asset and did not publish to npm is a
-      # `npm publish out/npm` away from being finished, and failing the job
-      # would suggest the artifacts are suspect when they are not.
+      # Published by trusted publishing: npm trades the OIDC token GitHub mints
+      # for this workflow for a credential that lives minutes, so there is no
+      # NPM_TOKEN here and none in the repository secrets. Nothing long-lived
+      # exists to leak, and npm generates a provenance attestation from the
+      # same exchange — which the token era never produced.
       #
-      # `--provenance` needs the `id-token: write` permission on this job, which
-      # is deliberately not granted: this workflow already has `contents: write`
-      # at the top, and widening a release workflow's token to sign statements
-      # about itself is a decision to take on its own rather than as a footnote
-      # to packaging. Without it npm publishes the tarball unattested, which is
-      # what every release before this one did too.
+      # The trust lives on the package at npmjs.com, matched against the owner,
+      # the repository, and this workflow's *filename*. Renaming this file, or
+      # moving the publish into a workflow of another name, breaks the publish
+      # until the publisher is updated to match; the failure reads as an
+      # authentication error rather than as a name mismatch, so change the two
+      # together.
+      #
+      # The registry-url step is what points npm at the registry the publisher
+      # was configured on. It runs here rather than on the job's first
+      # setup-node deliberately: doing it up front also writes an auth
+      # placeholder into .npmrc, and `npm ci` then fails against a variable
+      # nothing sets.
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "NPM_TOKEN is not set; skipping. Publish by hand with: npm publish ./out/npm"
-            exit 0
-          fi
-          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > ~/.npmrc
+          # Trusted publishing needs npm 11.5.1 or newer, and the npm bundled
+          # with a Node release is whatever shipped with it. package.json's
+          # engines field already asks for a newer npm than that, so this
+          # agrees with the project rather than only with the registry.
+          npm install -g npm@latest
+          npm --version
+
           # A prerelease tag must not become `npm install gitwarren`'s default.
-          # `0.1.7-beta.1` goes out as `next`; a plain `v0.1.7` as `latest`.
+          # `0.1.8-beta.1` goes out as `next`; a plain `v0.1.8` as `latest`.
           #
           # `./out/npm`, never `out/npm`: npm reads a bare `<a>/<b>` as a GitHub
           # shorthand and tries to clone a repository of that name, reporting it

--- a/README.md
+++ b/README.md
@@ -1264,7 +1264,7 @@ npm run package:dir    # unpacked app only, much faster
 | Linux | `-x86_64.AppImage`, `-arm64.AppImage`, `latest-linux.yml`, `latest-linux-arm64.yml` |
 | Any host | `gitwarren-daemon-<v>-{linux,darwin}-{x64,arm64}.tar.gz` |
 | Homebrew | `gitwarren-cli.rb`, the formula with this release's four checksums |
-| npm | `gitwarren@<v>`, published from `out/npm` when `NPM_TOKEN` is set |
+| npm | `gitwarren@<v>`, published from `out/npm` by trusted publishing |
 
 The `.blockmap` files are what make updates differential: electron-updater
 compares block hashes with the installed version and downloads only the changed
@@ -1291,6 +1291,19 @@ remote host runs `uname -sm` there, maps the answer to one of the four targets,
 and fetches `gitwarren-daemon-<version>-<target>.tar.gz` from the release by URL
 — one request, no listing and no search. The Homebrew formula names the same
 URLs. Renaming them breaks both.
+
+The **npm package** carries no credential to publish it. The `daemon` job asks
+GitHub for an OIDC token, npm trades that for a credential good for minutes, and
+the exchange also produces a provenance attestation — so there is no `NPM_TOKEN`
+in this repository's secrets and there is not meant to be one. The trust is
+configured on the package at npmjs.com against this repository and the
+*filename* `release.yml`, which is the one thing to remember: renaming that
+workflow breaks publishing, and it fails as an authentication error rather than
+as a name mismatch.
+
+`gitwarren@0.1.7` was published by hand, because a trusted publisher can only be
+configured on a package that already exists and npm has no pre-registration for
+one that does not. Nothing else will be.
 
 The **Homebrew formula** is rendered by `scripts/build-homebrew-formula.mjs`
 from `packaging/homebrew/gitwarren-cli.rb` in the same job that builds the


### PR DESCRIPTION
`gitwarren@0.1.7` is on the registry, which unblocks this: a trusted publisher can only be configured on a package that already exists, and npm has no pre-registration for one that does not. That first publish was by hand; nothing else needs to be.

The `daemon` job now asks GitHub for an OIDC token and npm trades it for a credential that lives minutes. `NPM_TOKEN` is gone from the workflow, was never in this repository's secrets, and is not meant to be — nothing long-lived exists here to leak, rotate or forget. The exchange also produces a provenance attestation, which the token path never did.

### Three details worth reviewing

- **The `permissions` block repeats `contents: write`.** A job-level block *replaces* the workflow's top-level permissions rather than adding to them, so omitting it would take the permission away from `gh release upload` two steps earlier.
- **`registry-url` is set by a second `setup-node` immediately before the publish**, not on the job's first one. Setting it up front also writes an auth placeholder into `.npmrc`, and `npm ci` then fails against a variable nothing sets — a self-inflicted `ENEEDAUTH` minutes before the step that cares.
- **npm is upgraded first.** Trusted publishing needs 11.5.1+, and the npm bundled with a Node release is whatever shipped with it. `package.json`'s `engines` already asks for newer, so this agrees with the project rather than only with the registry.

### Before merging

The trusted publisher must exist on the package first, or the next release's npm step fails (the job is `continue-on-error`, so the release itself would still complete). On npmjs.com → `gitwarren` → Settings → Trusted Publisher → GitHub Actions:

| Field | Value |
| --- | --- |
| Organization or user | `klarluft` |
| Repository | `gitwarren-app` |
| Workflow filename | `release.yml` |
| Environment name | *(blank)* |

Fields are case-sensitive. `package.json`'s `repository.url` already matches the repository exactly, which npm requires.

The trust is matched on the workflow *filename*, so renaming `release.yml` breaks publishing — and it fails as an authentication error rather than a name mismatch. The comment in the workflow says to change the two together.

### Verified

`actionlint` is clean on this change — the single SC2046 warning it reports is at line 165 on `main` too, in the keychain step. The parsed workflow has the permissions on the `daemon` job, the `registry-url` step immediately before the publish, and no reference to `NPM_TOKEN` anywhere.

README updated to match: the artifacts table no longer says "when `NPM_TOKEN` is set", and there's a short section on why the package carries no credential and why 0.1.7 was the one manual publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKRYVY7fHyAtJkZd3JFTjm