### PR TITLE
Give the CLI formula the description everything else now has

### DIFF
--- a/packaging/homebrew/gitwarren-cli.rb
+++ b/packaging/homebrew/gitwarren-cli.rb
@@ -21,7 +21,7 @@
 # calls it. A user types `brew install klarluft/tap/gitwarren-cli` once and then
 # never sees the suffix again.
 class GitwarrenCli < Formula
-  desc "Local-only code review for your git repositories, served on loopback"
+  desc "Code review for your own machines and your own agents, served on loopback"
   homepage "https://github.com/klarluft/gitwarren-app"
   version "__VERSION__"
   license "GPL-3.0-or-later"
@@ -99,7 +99,7 @@ class GitwarrenCli < Formula
     # framed request, so a single round trip exercises all of it.
     output = pipe_output(
       "#{bin}/gitwarren serve --stdio",
-      "{\"id\":1,\"method\":\"repositories.list\"}\n"
+      "{\"id\":1,\"method\":\"repositories.list\"}\n",
     )
     assert_match "\"id\":1", output
   end


### PR DESCRIPTION
`brew info klarluft/tap/gitwarren-cli` still announces:

> Local-only code review for your git repositories, served on loopback

That is the wording retired everywhere else when the across-hosts work shipped — `package.json`, the npm package, the electron-builder synopsis, the README, the site and the GitHub repo description all moved. `packaging/homebrew/gitwarren-cli.rb` was the one slogan surface missed, and it is the first thing a person sees after typing the install command the site now prints in three places.

"Local-only" is also the half that had stopped being true in the way it reads: the daemon this formula installs exists precisely so a machine you are *not* sitting at can be reviewed from one you are. Still loopback-only by default, which is the part worth keeping — hence "served on loopback" staying.

Also adds the trailing comma `brew style` asks for. That lint reads the whole tap, formula included, so the generated 0.1.7 formula would fail the tap's bump job now that a formula actually lives there — see klarluft/homebrew-tap#5, which turns that check on and needs this to stay clean from the next release onward.

The redundant-`version` audit warning is left alone deliberately: there is no top-level `url` for Homebrew to scan a version from, only the four inside `on_macos`/`on_linux` blocks, so the explicit `version` is what makes the formula resolve at all.

## Verified

Ran the generator against four stub tarballs at a fake version: substitutes cleanly, no `__PLACEHOLDER__` left, `ruby -c` passes. With the comma fix committed to the tap, `brew style klarluft/tap` reports *3 files inspected, no offenses detected*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrAiMERPdnvN6LAPgvtExi