### PR TITLE
Cut v0.1.8-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitwarren",
-  "version": "0.1.7",
+  "version": "0.1.8-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitwarren",
-      "version": "0.1.7",
+      "version": "0.1.8-beta.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitwarren",
   "productName": "GitWarren",
-  "version": "0.1.7",
+  "version": "0.1.8-beta.1",
   "description": "Code review for your own machines and your own agents",
   "author": {
     "name": "Klarluft B.V.",


### PR DESCRIPTION
Version bump only — `0.1.7` → `0.1.8-beta.1`.

A prerelease to prove Windows code signing end to end. Six commits have landed since `v0.1.7`, the last being #69, which wires the Windows build up to Azure Artifact Signing. No build has produced a signed `.exe` yet, so this beta is the first one to exercise the credentials and the certificate profile on a real runner.

The tag carries a prerelease component, so the draft is created `--prerelease` and GitHub's `/releases/latest` keeps it away from every stable install.

Once this is merged I'll tag `v0.1.8-beta.1` on the merge commit, push the tag to trigger the release build, and verify the signature on the resulting `.exe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a6YQKoLCsL7LzD2K3k3mQ
