### PR TITLE
Cut v0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitwarren",
-  "version": "0.1.8-beta.1",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitwarren",
-      "version": "0.1.8-beta.1",
+      "version": "0.1.8",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gitwarren",
   "productName": "GitWarren",
-  "version": "0.1.8-beta.1",
+  "version": "0.1.8",
   "description": "Code review for your own machines and your own agents",
   "author": {
     "name": "Klarluft B.V.",


### PR DESCRIPTION
Version bump only — `0.1.8-beta.1` → `0.1.8`.

The first stable release with a signed Windows build. `v0.1.8-beta.1` proved the signing path end to end: every Windows binary was Authenticode-signed as `CN=Klarluft B.V.` through Azure Artifact Signing, verified on a real Windows machine as chain-valid to the Microsoft Identity Verification root and correctly timestamped. This promotes that to stable with no code change beyond the version.

Carries the six commits that landed after `v0.1.7`: npm trusted publishing (#67), the CLI formula description (#68), and the Windows signing work (#69).

## After merge

I'll tag `v0.1.8` and push it, which produces a **draft** release. Publishing that draft is a separate, manual step — and on a stable release it is the consequential one: it rebuilds gitwarren.com, moves the Homebrew cask, publishes to npm, and starts every existing install updating within six hours. That click stays with you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011a6YQKoLCsL7LzD2K3k3mQ
