### PR TITLE
Take the Actions workflows off the Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,14 @@ jobs:
             name: macOS
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # .nvmrc is the single source of truth, shared with local development
       # through `fnm env --use-on-cd`. Pinning the version in one file rather
       # than three keeps CI from drifting away from the machines that write
       # package-lock.json. `engines` in package.json states the floor and
       # .npmrc makes it an error rather than a warning.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,6 +23,11 @@ jobs:
        github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
       github.event_name == 'pull_request_target'
     steps:
+      # Already the newest release there is: v2.6.1 is from 2024 and still
+      # declares `node20`, so Actions warns that the runner is forcing it onto
+      # Node 24. Nothing to bump until upstream ships a `node24` release, and
+      # this is the one action here that could actually break when that
+      # compatibility shim goes away.
       - uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # Both repositories are public, so the default token is enough here.
       - name: Check out the site
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: klarluft/gitwarren-site
           ref: main
@@ -49,7 +49,7 @@ jobs:
       # The checkout above is the *site*, so this reads gitwarren-site's own
       # .nvmrc — that repository declares the Node its lockfile is written
       # with, and this job simply obeys it. Nothing to keep in sync by hand.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     name: Create draft release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Create the draft if it does not exist
         env:
@@ -73,14 +73,14 @@ jobs:
             name: Linux (x64 + arm64)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
       # From .nvmrc, like ci.yml. Host toolchain only — the Node that ships
       # inside the app is Electron's, and install-app-deps rebuilds native
       # modules against Electron's headers rather than this one.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -294,7 +294,7 @@ jobs:
       # installers are still retrievable from the run itself.
       - name: Upload installers as a workflow artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: installers-${{ runner.os }}
           path: |
@@ -339,11 +339,11 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -402,7 +402,7 @@ jobs:
       # setup-node deliberately: doing it up front also writes an auth
       # placeholder into .npmrc, and `npm ci` then fails against a variable
       # nothing sets.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version-file: .nvmrc
           registry-url: 'https://registry.npmjs.org'
@@ -432,7 +432,7 @@ jobs:
 
       - name: Upload as a workflow artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: daemon-tarballs
           path: |

--- a/src/renderer/src/features/repositories/repository-detail.tsx
+++ b/src/renderer/src/features/repositories/repository-detail.tsx
@@ -90,7 +90,7 @@ export function RepositoryDetail({ repositoryId }: { repositoryId: number }) {
       // it arrives a frame late on a host: the host list has to load before this
       // machine knows whether it can name that file. Without it the `o` key
       // would keep the value from the render where the answer was still null.
-      [api, host, repository, revealPath]
+      [api, repository, revealPath]
     )
   )
 


### PR DESCRIPTION
Every job in the Actions tab was raising the same deprecation warning: `actions/checkout`, `actions/setup-node` and `actions/upload-artifact` all still declare `node20`, so the runner forces them onto Node 24 and says so. Nothing was failing — the warning is the notice that the compatibility shim goes away — so all three move to v7, which declares `node24` natively.

### The major-version jumps are no-ops here

I read the release notes for every major in between:

- **setup-node v6** limited automatic caching to npm. Every call in this repo already asks for `cache: npm`.
- **checkout v7** blocks fork checkouts under `pull_request_target`. The only workflow on that trigger, the CLA one, never checks out the code.
- **upload-artifact v7** only adds an opt-in unzipped single-file upload mode.

One change is an improvement rather than a wash. **setup-node v7** stopped exporting a dummy `NODE_AUTH_TOKEN` when no token is given, which is exactly what the npm publish job wants now that it authenticates over OIDC rather than with a credential.

### The CLA action keeps its warning

`contributor-assistant/github-action@v2.6.1` is already its newest release and dates from 2024, so no bump exists. It gains a comment saying so, since it is the one action here that could actually break when the shim is retired rather than just warn.

### The other warning on every CI run

ESLint was flagging an unnecessary `host` dependency on the command-registry memo in `repository-detail.tsx`. The memo body never reads it, and `repository` and `revealPath` already change when the host does.

### Checks

`npm run lint` and `npm run typecheck` both clean, with no warnings left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6NbJLc2ewoNAumtKkvrtb
