### PR TITLE
Let the update restart actually restart

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -45,21 +45,12 @@ import { registerIpcHandlers } from './ipc.js'
 import { startLinkServer, stopLinkServer } from './link-server.js'
 import { wasOpenedAtLogin } from './login-item.js'
 import { ensureMcpLauncher } from './mcp-launch.js'
+import { isQuitting, markQuitting } from './quitting.js'
 import { shouldStartHidden } from './start-hidden.js'
 import { createTray, destroyTray } from './tray.js'
 import { disposeUpdater, initialiseUpdater } from './updater.js'
 
 const isDev = !app.isPackaged
-
-/**
- * Set on `before-quit` so the window's `close` handler knows the difference
- * between "the user is putting this away" and "the app is going".
- *
- * A module-level flag rather than a property of the window, because the window
- * it applies to may not be the window that exists when the flag is set: the
- * user can close and reopen several times in one run.
- */
-let quitting = false
 
 // Before `app.whenReady()`: privileged scheme registration is only accepted
 // this early. See `attachment-protocol.ts` for why the scheme exists at all.
@@ -126,7 +117,7 @@ function createWindow(): BrowserWindow {
    * makes and the one the milestone is asking for.
    */
   window.on('close', (event) => {
-    if (quitting) return
+    if (isQuitting()) return
     event.preventDefault()
     window.hide()
   })
@@ -322,7 +313,7 @@ if (process.argv.includes('--serve')) {
   })
 
   app.on('before-quit', () => {
-    quitting = true
+    markQuitting()
     stopForwardingEvents()
     disposeUpdater()
     destroyTray()

--- a/src/main/quitting.ts
+++ b/src/main/quitting.ts
@@ -1,0 +1,39 @@
+/**
+ * Whether the app is on its way out.
+ *
+ * The window's `close` handler hides instead of closing, because since M2
+ * closing a window puts GitWarren away rather than ending it - see
+ * `index.ts`. That behaviour has to have an exception, or the app could never
+ * quit at all: the exception is this flag, set once when a real shutdown
+ * begins, and read by the handler to tell "the user is putting this away" from
+ * "the app is going".
+ *
+ * It lives in its own module rather than as a local in `index.ts` because two
+ * different things start a shutdown and only one of them is `before-quit`.
+ *
+ * The other is the updater, and it is the reason this file exists. Electron's
+ * `autoUpdater.quitAndInstall()` does not call `app.quit()` and then close the
+ * windows; it closes every window *first* and calls `app.quit()` only once
+ * they are all gone. So on the update path `before-quit` fires after the
+ * windows have closed - which means a flag set there arrives too late to let
+ * them close. The window would refuse the close, `app.quit()` would never be
+ * reached, and the app would sit there hidden, still on the old version, with
+ * the installer waiting for a quit that never comes. `updater.ts` marks the
+ * shutdown before it hands over, which is exactly what this module is for.
+ */
+
+let quitting = false
+
+/** True once a real shutdown has begun, so a window close may proceed. */
+export function isQuitting(): boolean {
+  return quitting
+}
+
+/**
+ * Declare that the app is shutting down. Idempotent: `before-quit` still fires
+ * on the update path, after the windows are closed, and calling this twice is
+ * the normal case rather than a mistake.
+ */
+export function markQuitting(): void {
+  quitting = true
+}

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -13,6 +13,7 @@
 import { app, BrowserWindow } from 'electron'
 import electronUpdater from 'electron-updater'
 import { IPC_CHANNELS, type UpdateStatus } from '../shared/api.js'
+import { markQuitting } from './quitting.js'
 import { requestHiddenRelaunch } from './start-hidden.js'
 
 // electron-updater is CommonJS, so the named export has to come off the default.
@@ -109,7 +110,18 @@ export function quitAndInstall(): void {
     requestHiddenRelaunch()
   }
 
+  // Before handing over, and this line is the whole reason the update ever
+  // applies. `quitAndInstall` closes every window first and calls `app.quit()`
+  // only once they are all gone - so on this path `before-quit`, where the
+  // shutdown is normally declared, fires *after* the closes it would have
+  // authorised. Without this the window hides itself as it does on any other
+  // close, the last window never goes, `app.quit()` is never reached, and the
+  // app sits there on the old version with the restart button still showing.
+  markQuitting()
+
   // isSilent: true, isForceRunAfter: true - no installer UI, app comes back up.
+  // macOS ignores both: Squirrel does its own install, and the relaunch is
+  // governed by `autoRunAppAfterInstall`, which defaults to true.
   autoUpdater.quitAndInstall(true, true)
 }
 


### PR DESCRIPTION
## The bug

On macOS, clicking **Restart to update** hid the window and left the app running on the old version. Bringing it back showed the same window with the same restart button. Only quitting by hand and launching again picked up the new build.

That last part is the tell: `autoInstallOnAppQuit` is on, so any real quit applies the staged update. The install was fine. The quit never happened.

## Why

The two halves of the app disagreed about what closing a window means.

Since M2, closing a window hides it. `createWindow`'s `close` handler calls `preventDefault()` unless a module-level `quitting` flag is set, and that flag was set on `before-quit`.

But Electron's `autoUpdater.quitAndInstall()` does not call `app.quit()` and then close the windows. From Electron's own docs:

> Under the hood calling `autoUpdater.quitAndInstall()` will close all application windows first, and automatically call `app.quit()` after all windows have been closed.

and, on `app`'s `before-quit`:

> If application quit was initiated by `autoUpdater.quitAndInstall()`, then `before-quit` is emitted _after_ emitting `close` event on all windows and closing them.

So the flag was waiting on a quit that was waiting on the flag. The window hid itself as it does on any other close, no window ever closed, `app.quit()` was never reached, and Squirrel sat waiting for a termination that never came. The app stayed up, on the old version, still showing the button.

Windows and Linux were unaffected. `BaseUpdater.quitAndInstall` runs the installer and then calls `app.quit()` itself, so `before-quit` fires first and sets the flag in time.

## The fix

The flag moves out of `index.ts` into `src/main/quitting.ts`, because it now has two writers rather than one, and `updater.ts` marks the shutdown before handing over to `quitAndInstall`.

## Checks

- `npm run typecheck` clean
- `npm run lint` clean apart from one pre-existing warning in `repository-detail.tsx`
- `npm test` 603 passing, 0 failing
- `npm run build` succeeds

End-to-end verification needs a signed packaged build with a real update to fetch, so it is worth watching the next release actually restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBNstj1QhdxwKMNFmzqEmx