### PR TITLE
Make the command line say which command you want, and reach Linux without Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ instead of an Electron window — for a machine that will not have the app on it
 or one with no screen at all:
 
 ```bash
-npx gitwarren serve                       # anywhere Node is
-brew install klarluft/tap/gitwarren-cli   # macOS and Linux, brings its own Node
+brew install klarluft/tap/gitwarren-cli               # macOS and Linux, brings its own Node
+curl -fsSL https://gitwarren.com/install.sh | sh      # macOS and Linux, no Homebrew needed
+npx gitwarren serve                                   # anywhere Node 22+ is, including Windows
 ```
 
-See [The `gitwarren` command line](#the-gitwarren-command-line).
+Then `gitwarren serve --open`. See
+[The `gitwarren` command line](#the-gitwarren-command-line).
 
 Code review for your own git repositories, on your own machines. Your machines,
 your agents, no one else's server — and no account.
@@ -1024,17 +1026,23 @@ same database independently, and an agent gets a working `guiUrl` either way.
 
 ## The `gitwarren` command line
 
-The same GitWarren, with a browser tab for a shell. One binary, four
+The same GitWarren, with a browser tab for a shell. One binary, a handful of
 subcommands, and no Electron anywhere in it.
 
 ```bash
-gitwarren serve                 # serve the web view on 127.0.0.1 and print its URL
-gitwarren serve --stdio         # answer GitWarren's protocol on stdin/stdout
-gitwarren open [link]           # open this machine's GitWarren in a browser
-gitwarren service install       # write the launchers, and start at login
-gitwarren service uninstall     # remove the login item
-gitwarren service status        # what is registered, and what is running
-gitwarren agent-setup           # print the sentence that points an agent here
+# Run it now
+gitwarren serve [--open]        # run GitWarren in this terminal and print its URL; Ctrl-C stops it
+gitwarren open [link]           # open the running GitWarren in your browser
+
+# Keep it running
+gitwarren service install       # run GitWarren in the background, from now and at every login
+gitwarren service uninstall     # stop that, and remove the login item
+gitwarren service status        # what is running, and where the data is
+
+# Let a coding agent in
+gitwarren agent-setup           # print the one sentence to give an agent so it can reach this GitWarren
+
+gitwarren serve --stdio         # answer GitWarren's protocol on stdin/stdout (what another machine spawns)
 ```
 
 It exists for two audiences that the app cannot serve. Someone who will not
@@ -1043,17 +1051,46 @@ shared, the shell is not. And a machine with no screen at all — a VPS, a WSL
 distro, a box an agent works on — gets the daemon and the MCP server, which is
 what [Your other machines](#your-other-machines) is built on.
 
-### Three ways to install it
+### Which command you want
+
+Three things a person wants from it, and one command for each. They are
+independent: none of them requires another to have been run first.
+
+- **Use it now.** `gitwarren serve` runs GitWarren in the terminal until Ctrl-C,
+  and prints the URL. `--open` opens it as well; `gitwarren open` in another
+  terminal does the same later.
+- **Have it always there.** `gitwarren service install` registers a login item
+  — a LaunchAgent on macOS, a `systemd --user` unit on Linux, an at-logon task
+  on Windows — and starts it now, so `gitwarren open` and the links an agent
+  hands you always have something to open. `gitwarren service uninstall` undoes
+  it.
+- **Let an agent in.** `gitwarren agent-setup` prints the sentence to paste into
+  Claude Code, Codex or any other MCP client. The MCP server is part of every
+  install and reads the same SQLite file the browser view does, so an agent can
+  open and comment on reviews whether or not GitWarren is being served — what
+  serving adds is that the `guiUrl` an agent hands back opens in a browser.
+
+All three write the same two files, `~/.gitwarren/bin/gitwarren` and
+`~/.gitwarren/bin/gitwarren-mcp`, the first time they run; see
+[`service install`](#service-install) for what they are.
+
+### Four ways to install it
 
 | | |
 | --- | --- |
-| `npx gitwarren` | Uses the Node you already have; `better-sqlite3` arrives as an ordinary dependency. The Windows answer, and about 700 KB. |
-| `brew install klarluft/tap/gitwarren-cli` | Pours the self-contained tarball. Brings its own Node, so nothing on the machine can upgrade out from under the native addon. |
-| The release tarball | `gitwarren-daemon-<v>-<target>.tar.gz`, unpacked anywhere. What GitWarren sends to a remote host over SSH. |
+| `brew install klarluft/tap/gitwarren-cli` | Pours the self-contained tarball. Brings its own Node, so nothing on the machine can upgrade out from under the native addon. macOS and Linux. |
+| `curl -fsSL https://gitwarren.com/install.sh \| sh` | The same tarball, without Homebrew — for a Linux box or a Mac with nothing on it. Unpacks into `~/.gitwarren/daemon/<version>/` and writes `~/.gitwarren/bin/gitwarren`, which is the layout the app itself produces when it installs onto a host over SSH, so either can upgrade what the other installed. Add `~/.gitwarren/bin` to `PATH`. `packaging/install.sh` is the script; `GITWARREN_VERSION` pins a release. |
+| `npx gitwarren` | Uses the Node you already have (22 or newer); `better-sqlite3` arrives as an ordinary dependency. The Windows answer, and about 700 KB. |
+| The release tarball | `gitwarren-daemon-<v>-<target>.tar.gz`, unpacked anywhere and run as `bin/gitwarren`. What the two rows above and the SSH installer all use. |
 
 The formula is `gitwarren-cli` and the cask stays `gitwarren`. The tokens differ
 so `brew install klarluft/tap/gitwarren` keeps meaning the app; the *binary* is
-called `gitwarren` in all three.
+called `gitwarren` in all four.
+
+To remove a Homebrew install, `brew uninstall gitwarren-cli`; a script install,
+`rm -rf ~/.gitwarren`. Run `gitwarren service uninstall` first if a login item
+was registered. Neither touches the reviews, which live in the data directory
+`gitwarren service status` prints.
 
 ### The token, and why nothing is copied
 
@@ -1078,11 +1115,15 @@ Two things, and only the second is about logging in:
    at the paths the rest of GitWarren already names — the Agent Access page
    prints the second as a command to paste, and the app spawns the first over ssh as
    `~/.gitwarren/bin/gitwarren serve --stdio`. Rerunning after an update points
-   them at the install that ran last.
+   them at the install that ran last. `gitwarren serve` and `gitwarren
+   agent-setup` write the same two files when they are missing, the way the app
+   writes the MCP one on every launch, so nobody has to ask for a login item to
+   get an agent working.
 2. **The login item.** A LaunchAgent on macOS, a `systemd --user` unit on Linux,
    an at-logon Scheduled Task on Windows — each running `gitwarren serve
-   --listen`. `--no-login-item` writes the launchers and stops, which is what a
-   headless host wants.
+   --listen`, and each started right away as well as at the next login.
+   `--no-login-item` writes the launchers and stops, which is what a headless
+   host wants and what the SSH installer and `install.sh` ask for.
 
 Nothing restarts a dead daemon, deliberately. `serve --listen` has a refusal it
 is *meant* to exit on — a data directory has one owner, so it stands aside when

--- a/docs/across-hosts.md
+++ b/docs/across-hosts.md
@@ -1307,6 +1307,34 @@ path is written and typed but has only been exercised on macOS and Linux;
 shape as the Windows launcher-banner bug M2 shipped, so it should be run on the
 PC before the milestone is called done.
 
+**M3.3 revisited on 12 September, after the first install on a Linux box.**
+The formula's caveats listed `serve`, `open` and `service install` and said
+nothing about which one a person wanted, `uninstall` was missing from every
+place a newcomer looked, and the model underneath was the confusing part: the
+MCP launcher was written by `service install` alone, so `gitwarren serve`
+followed by a look at the Agent Access page ended in an instruction to
+register a login item — a command about logging in, to a person who wanted an
+agent. Three changes. `gitwarren serve` now writes both launchers once it is
+up, the way the app writes the MCP one on every launch, and `agent-setup`
+writes the one it names rather than pointing elsewhere; `service install` is
+one thing again, *keep it running*, and says so — "running in the background,
+and will start again when you log in" — with the Scheduled Task started on the
+spot like the other two. Every usage block, caveat and README is now ordered
+by what a person wants: run it now, keep it running, let an agent in, and each
+says the MCP server reads the same SQLite file whether or not anything is
+serving. And Linux without Homebrew got a way in: `packaging/install.sh`,
+served as `https://gitwarren.com/install.sh` by a Cloudflare redirect, fetches
+the release tarball, checks it against the sha256 the release's own formula
+names, and lays it out exactly as `core/hosts/install.ts` does over ssh —
+`~/.gitwarren/daemon/<version>/` and the stable launcher — so the app and the
+script can upgrade each other's install. Verified in a bare `ubuntu:24.04`
+container with the worktree's own linux-x64 tarball: `serve` wrote the
+launchers and printed the new sentences, a second `serve` refused with the
+first one's URL, the MCP server answered `initialize` through the launcher,
+and the script installed v0.1.8 from GitHub with curl and again with only
+wget. `service install` on a real systemd was not re-exercised — the only
+change there is wording.
+
 **M3.4, done on the Mac, 10 September.** The screen that hands GitWarren to an
 agent. Most of the words were already right — M2 wrote the sentence and put it
 above the snippet — so this change is mostly about where they live and who they

--- a/packaging/homebrew/gitwarren-cli.rb
+++ b/packaging/homebrew/gitwarren-cli.rb
@@ -72,16 +72,30 @@ class GitwarrenCli < Formula
     bin.install_symlink libexec/"bin/gitwarren-mcp"
   end
 
+  # Read once, at the moment someone has just installed this and does not yet
+  # know what it is. So it answers the three questions that moment has - how
+  # do I start it, how do I keep it running, how does my agent get in - in
+  # that order, and says what each command does to the machine rather than
+  # what it is called. The desktop app is last because a person who wanted it
+  # has probably typed the wrong formula.
   def caveats
     <<~EOS
-      GitWarren serves its web view on 127.0.0.1 only:
+      To run GitWarren in this terminal and open it in your browser:
 
-        gitwarren serve         start it, and print a URL carrying this launch's token
-        gitwarren open          open that URL in your browser
-        gitwarren service install   start it at login, and write the agent launcher
+        gitwarren serve --open
 
-      `service install` also writes ~/.gitwarren/bin/gitwarren-mcp, which is the
-      one command to point an agent at. The desktop app is a separate package:
+      That serves on 127.0.0.1 only and stops when you press Ctrl-C. To keep
+      GitWarren running in the background instead, starting now and again at
+      every login:
+
+        gitwarren service install       (undo with: gitwarren service uninstall)
+
+      Either one also writes ~/.gitwarren/bin/gitwarren-mcp, the command a coding
+      agent starts GitWarren's MCP server with. `gitwarren agent-setup` prints the
+      sentence to give the agent. Reviews live in one SQLite file, and the MCP
+      server reads it whether or not GitWarren is being served.
+
+      `gitwarren --help` lists everything. The desktop app is a separate package:
 
         brew install --cask klarluft/tap/gitwarren
     EOS

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# GitWarren's command line, installed from a release tarball.
+#
+#   curl -fsSL https://gitwarren.com/install.sh | sh
+#
+# For a Linux or macOS machine with no Homebrew and no Node: the tarball brings
+# its own Node, so nothing has to be on the machine but a shell, `tar` and
+# `curl` (or `wget`). Windows is not served here - `npx gitwarren` is the
+# answer there, and a `.tar.gz` is not how anything is installed on it.
+#
+# ## It lays the files out exactly as the app does
+#
+# When the desktop app installs GitWarren onto another machine over ssh
+# (`src/core/hosts/install.ts`), the tarball goes into
+# `~/.gitwarren/daemon/<version>/` and the stable `~/.gitwarren/bin/gitwarren`
+# points into it. This script produces the same layout by the same steps,
+# down to the unpack-then-rename and the final `gitwarren service install
+# --no-login-item`, which is what writes the launchers. So a machine set up by
+# this script is one the app already knows how to upgrade, and a machine the
+# app set up is one this script can bring forward - there is one layout, not
+# two.
+#
+# Set GITWARREN_VERSION to install a specific release instead of the latest.
+#
+# Uninstall: `gitwarren service uninstall`, then `rm -rf ~/.gitwarren`. Reviews
+# live elsewhere (`gitwarren service status` prints where) and are not touched
+# by either.
+set -eu
+
+repo="klarluft/gitwarren-app"
+root="$HOME/.gitwarren"
+
+say() { printf '%s\n' "$*" >&2; }
+die() { say "install.sh: $*"; exit 1; }
+
+# 1. Which tarball. The same mapping as `targetFromUname` in
+#    src/core/hosts/release.ts: Linux says aarch64 where macOS says arm64.
+kernel="$(uname -s)"
+machine="$(uname -m)"
+case "$machine" in
+  x86_64 | amd64) arch="x64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *) die "no GitWarren build for $kernel/$machine. Linux and macOS on x86-64 or arm64 are what the release builds." ;;
+esac
+case "$kernel" in
+  Linux) target="linux-$arch" ;;
+  Darwin) target="darwin-$arch" ;;
+  *) die "no GitWarren build for $kernel/$machine. Linux and macOS on x86-64 or arm64 are what the release builds." ;;
+esac
+
+# 2. How to fetch. curl first because it is what the one-liner names; wget
+#    because a minimal Debian has that and not curl.
+if command -v curl >/dev/null 2>&1; then
+  fetch() { curl -fsSL "$1" -o "$2"; }
+  latest_tag() { curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/$repo/releases/latest"; }
+elif command -v wget >/dev/null 2>&1; then
+  fetch() { wget -qO "$2" "$1"; }
+  latest_tag() { wget -qO /dev/null --max-redirect=5 -S "https://github.com/$repo/releases/latest" 2>&1 | sed -n 's/^ *Location: *//p' | tail -1; }
+else
+  die "neither curl nor wget is installed, and one of them is needed to download GitWarren."
+fi
+
+# 3. Which version. `releases/latest` on github.com, not the API: it answers
+#    with a redirect to the newest stable release, and it has no rate limit to
+#    run into. Prereleases are skipped by it, which is right for a one-liner.
+version="${GITWARREN_VERSION:-}"
+if [ -z "$version" ]; then
+  version="$(latest_tag | sed -n 's|.*/tag/v\{0,1\}\([^/]*\)$|\1|p')"
+  [ -n "$version" ] || die "could not work out the latest release from https://github.com/$repo/releases/latest"
+fi
+version="${version#v}"
+
+dest="$root/daemon/$version"
+launcher="$root/bin/gitwarren"
+
+if [ -x "$launcher" ] && [ "$("$launcher" --version 2>/dev/null || true)" = "$version" ]; then
+  say "GitWarren $version is already installed at $dest."
+  say "Run \`gitwarren serve\` to start it."
+  exit 0
+fi
+
+asset="gitwarren-daemon-$version-$target.tar.gz"
+url="https://github.com/$repo/releases/download/v$version/$asset"
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/gitwarren-install.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+say "Downloading GitWarren $version for $target..."
+fetch "$url" "$work/$asset" || die "could not download $url"
+
+# 4. The checksum, from the same release. The Homebrew formula attached to
+#    every release names the sha256 of each tarball, and was written by the run
+#    that built them - so it is the release's own statement of what the bytes
+#    should be, and checking against it costs one small download.
+if command -v sha256sum >/dev/null 2>&1; then
+  sum() { sha256sum "$1" | cut -d' ' -f1; }
+elif command -v shasum >/dev/null 2>&1; then
+  sum() { shasum -a 256 "$1" | cut -d' ' -f1; }
+else
+  sum() { :; }
+fi
+if fetch "https://github.com/$repo/releases/download/v$version/gitwarren-cli.rb" "$work/formula.rb" 2>/dev/null; then
+  expected="$(grep -A1 -F "/$asset\"" "$work/formula.rb" | sed -n 's/.*sha256 "\([0-9a-f]*\)".*/\1/p' | head -1)"
+  actual="$(sum "$work/$asset")"
+  if [ -n "$expected" ] && [ -n "$actual" ] && [ "$expected" != "$actual" ]; then
+    die "the download did not match the checksum the release published for $asset. Not installing it."
+  fi
+fi
+
+# 5. Unpack beside the destination and rename into place, so an interrupted
+#    unpack can never leave a directory that exists, looks installed, and
+#    cannot run. Same as the app's installer.
+mkdir -p "$root/daemon" "$root/bin"
+stage="$root/daemon/.install-$$"
+rm -rf "$stage"
+mkdir -p "$stage"
+tar xzf "$work/$asset" -C "$stage"
+chmod +x "$stage/gitwarren-daemon/bin/"* 2>/dev/null || true
+[ -x "$stage/gitwarren-daemon/bin/gitwarren" ] || { rm -rf "$stage"; die "the tarball did not contain bin/gitwarren"; }
+if [ -e "$dest" ]; then mv "$dest" "$stage/.previous"; fi
+mv "$stage/gitwarren-daemon" "$dest"
+rm -rf "$stage"
+
+# 6. The launchers, written by the binary just unpacked - which is also the
+#    proof that it runs on this machine. `~/.gitwarren/bin/gitwarren` is the
+#    command to put on PATH; `gitwarren-mcp` beside it is what an agent starts.
+if ! "$dest/bin/gitwarren" service install --no-login-item >/dev/null; then
+  die "GitWarren unpacked into $dest but could not run. The $target build may be the wrong one for this machine."
+fi
+
+say ""
+say "GitWarren $version is installed."
+say ""
+case ":$PATH:" in
+  *":$root/bin:"*) ;;
+  *)
+    say "Add its bin directory to your PATH - for example, in your shell's rc file:"
+    say ""
+    say "    export PATH=\"\$HOME/.gitwarren/bin:\$PATH\""
+    say ""
+    ;;
+esac
+say "Then:"
+say ""
+say "    gitwarren serve              run it now, in this terminal"
+say "    gitwarren service install    or keep it running in the background, from now and at every login"
+say "    gitwarren agent-setup        the sentence to give a coding agent so it can use GitWarren"

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -8,33 +8,58 @@ This package is the command line. There is also a desktop app; see
 [gitwarren-app](https://github.com/klarluft/gitwarren-app).
 
 ```
-npx gitwarren serve
+npx gitwarren serve --open
 ```
 
-That serves the review UI on `127.0.0.1:41427` and prints a URL carrying a
-token minted for that launch. Open it, add a repository, pick two refs, and
-review the diff.
+That serves the review UI on `127.0.0.1:41427`, prints a URL carrying a token
+minted for that launch, and opens it. Add a repository, pick two refs, and
+review the diff. Ctrl-C stops it. Needs Node 22 or newer; on a machine without
+Node, the Homebrew formula and the install script in the
+[app repository](https://github.com/klarluft/gitwarren-app#the-gitwarren-command-line)
+bring their own.
 
 ## Commands
 
+**Run it now**
+
 | | |
 | --- | --- |
-| `gitwarren serve` | serve the web view on loopback and print its URL |
-| `gitwarren serve --stdio` | answer GitWarren's protocol on stdin/stdout |
-| `gitwarren open [link]` | open this machine's GitWarren in a browser, carrying the token |
-| `gitwarren service install` | write the agent launcher, and start at login |
-| `gitwarren service uninstall` | remove the login item |
-| `gitwarren service status` | what is registered, and what is running |
+| `gitwarren serve [--open]` | run GitWarren in this terminal and print its URL; `--open` opens it too |
+| `gitwarren open [link]` | open the running GitWarren in your browser, carrying the token |
+
+**Keep it running**
+
+| | |
+| --- | --- |
+| `gitwarren service install` | run GitWarren in the background, from now and at every login |
+| `gitwarren service uninstall` | stop that, and remove the login item |
+| `gitwarren service status` | what is running, and where the data is |
+
+**Let a coding agent in**
+
+| | |
+| --- | --- |
+| `gitwarren agent-setup` | print the one sentence to give an agent so it can reach GitWarren over MCP |
+
+`gitwarren serve --stdio` answers GitWarren's protocol on stdin and stdout; it
+is what a GitWarren on another machine spawns, and nothing a person needs to
+type.
 
 `gitwarren open` takes a `gitwarren://` deep link or the `http://127.0.0.1`
 URL an agent hands out, and lands on that review rather than the home screen.
 
 ## Letting an agent in
 
-`gitwarren service install` writes `~/.gitwarren/bin/gitwarren-mcp`, which is a
-GitWarren MCP server your coding agent can start. Point the agent at that one
-path — it is the same on every machine, and GitWarren keeps it pointing at
-whichever install ran last.
+Every install carries GitWarren's MCP server. What an agent needs is one
+stable command to start it with, and that is `~/.gitwarren/bin/gitwarren-mcp` —
+the same path on every machine, written by `gitwarren serve`, `gitwarren
+agent-setup` and `gitwarren service install` alike, and kept pointing at
+whichever install ran last. `gitwarren agent-setup` prints the sentence to
+paste into the agent.
+
+The MCP server reads the same SQLite file the browser view does, so an agent
+can open and comment on reviews whether or not GitWarren is being served. What
+serving adds is that the links an agent hands you have something to open.
 
 ## Where your data is
 

--- a/src/cli/__tests__/agent-setup.test.ts
+++ b/src/cli/__tests__/agent-setup.test.ts
@@ -8,6 +8,9 @@
  * warning into an agent.
  */
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, test } from 'node:test'
 import { getMcpLauncherPath } from '../../core/mcp-launcher.js'
 import { agentConfigSnippets, agentSetupPrompt } from '../../shared/agent-setup.js'
@@ -44,15 +47,30 @@ test('stdout is the prompt and only the prompt', () => {
 })
 
 test('a missing launcher is a line on stderr, not a failure', () => {
-  const { ok, out, err } = capture([])
+  // A home directory with nothing in it, so the launcher is missing on every
+  // machine this runs on rather than only on CI - the developer's own Mac has
+  // one, written by the app, and the first version of this test passed there
+  // while failing everywhere else. `homedir()` reads HOME on POSIX and
+  // USERPROFILE on Windows, so both are pointed at it.
+  const home = mkdtempSync(join(tmpdir(), 'gitwarren-agent-setup-'))
+  const saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE }
+  process.env.HOME = home
+  process.env.USERPROFILE = home
+  try {
+    const { ok, out, err } = capture([])
 
-  // Whether the launcher exists depends on the machine running the test, so the
-  // assertion is on the pairing rather than on either half: the note appears
-  // exactly when the command it names would be the right thing to type, it says
-  // so on stderr, and it never makes the command fail.
-  assert.equal(ok, true)
-  assert.ok(!out.includes('service install'))
-  assert.equal(err.includes('service install'), err !== '')
+    // Under tsx there is no file a shell could run again, so the command cannot
+    // write the launcher it names - and that is a sentence on stderr naming the
+    // path, never a failure, and never a word on stdout.
+    assert.equal(ok, true)
+    assert.equal(out.trim(), agentSetupPrompt({ command: getMcpLauncherPath() }))
+    assert.ok(err.includes(getMcpLauncherPath()), 'stderr should name the missing launcher')
+    assert.match(err, /could not write one: .*source checkout/)
+  } finally {
+    process.env.HOME = saved.HOME
+    process.env.USERPROFILE = saved.USERPROFILE
+    rmSync(home, { recursive: true, force: true })
+  }
 })
 
 test('--manual prints every by-hand format, verbatim', () => {

--- a/src/cli/__tests__/router.test.ts
+++ b/src/cli/__tests__/router.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The words a person reads first, and the side effect `serve` grew.
+ *
+ * The usage block is the only documentation most people will read, so the
+ * assertions here are about what it says rather than that it exists: every
+ * subcommand is in it, including `uninstall`, which the first version left out
+ * of every place a newcomer looked, and the three things a person wants are
+ * named as headings so the list reads as choices rather than as an inventory.
+ *
+ * `ensureLaunchers` is tested for the one property `serve` depends on: under
+ * tsx there is no file a login shell could run again, and that has to come
+ * back as a sentence, not a throw - a `serve` from a checkout still has a page
+ * to serve.
+ */
+import assert from 'node:assert/strict'
+import { afterEach, test } from 'node:test'
+import { ensureLaunchers } from '../launchers.js'
+import { runCli } from '../router.js'
+
+const realLog = console.log
+const realError = console.error
+
+afterEach(() => {
+  console.log = realLog
+  console.error = realError
+})
+
+function capture(argv: readonly string[]): { ok: boolean; out: string; err: string } {
+  let out = ''
+  let err = ''
+  console.log = (line: string) => {
+    out += `${line}\n`
+  }
+  console.error = (line: string) => {
+    err += `${line}\n`
+  }
+  const ok = runCli(argv)
+  return { ok, out, err }
+}
+
+test('--help names every subcommand, uninstall included, grouped by what a person wants', () => {
+  const { ok, out } = capture(['--help'])
+
+  assert.equal(ok, true)
+  for (const command of [
+    'gitwarren serve',
+    'gitwarren serve --stdio',
+    'gitwarren open',
+    'gitwarren service install',
+    'gitwarren service uninstall',
+    'gitwarren service status',
+    'gitwarren agent-setup',
+    'gitwarren --version'
+  ]) {
+    assert.ok(out.includes(command), `usage should mention \`${command}\``)
+  }
+  for (const heading of ['Run it now', 'Keep it running', 'Let a coding agent in']) {
+    assert.ok(out.includes(heading), `usage should have the heading "${heading}"`)
+  }
+})
+
+test('an unknown command is the usage on stderr and a false, not a throw', () => {
+  const { ok, out, err } = capture(['frobnicate'])
+
+  assert.equal(ok, false)
+  assert.equal(out, '')
+  assert.ok(err.includes('gitwarren serve'))
+})
+
+test('serve --help is its own usage, and does not start a server', () => {
+  const { ok, out } = capture(['serve', '--help'])
+
+  assert.equal(ok, true)
+  assert.ok(out.includes('--open'))
+  assert.ok(out.includes('--stdio'))
+  assert.ok(out.includes('gitwarren-mcp'))
+})
+
+test('a checkout cannot have launchers written, and says so instead of throwing', () => {
+  // This test runs under tsx, so `argv[1]` is a .ts file: exactly the case
+  // `serve` must survive.
+  const result = ensureLaunchers()
+
+  assert.deepEqual(result.created, [])
+  assert.match(result.refused ?? '', /source checkout/)
+})

--- a/src/cli/agent-setup.ts
+++ b/src/cli/agent-setup.ts
@@ -12,16 +12,22 @@
  * cannot: whether the launcher is actually on this machine yet, and what to
  * type if it is not.
  *
- * ## It does not install anything
+ * ## It writes the launcher it names
  *
- * `service install` writes the launcher; this prints where it is. Keeping them
- * apart is the same rule `open` follows - a command that reports is not a
- * command that changes the machine, and a user who typed "agent-setup" to read
- * a sentence has not asked for a login item.
+ * The first version of this printed the path and, when nothing was there,
+ * pointed at `gitwarren service install` - on the principle that a command
+ * that reports should not change the machine. That principle sent a person
+ * who had asked "how does my agent reach this" to a command about logging in,
+ * and the sentence it printed named a file that did not exist. Somebody who
+ * runs `agent-setup` wants the agent to work; the launcher is a two-line
+ * script at a path they can read, and the app writes the same file on every
+ * launch without asking. So this writes it too, says so once on stderr when
+ * it did, and still asks for no login item.
  */
 import { existsSync } from 'node:fs'
 import { getMcpLauncherPath } from '../core/mcp-launcher.js'
 import { agentConfigSnippets, agentSetupPrompt } from '../shared/agent-setup.js'
+import { ensureLaunchers } from './launchers.js'
 
 const USAGE = `gitwarren agent-setup [--manual]
 
@@ -62,12 +68,18 @@ export function runAgentSetup(argv: readonly string[]): boolean {
     }
   }
 
-  if (!existsSync(command)) {
+  // Written after the prompt rather than before it, so the sentence on stdout
+  // is the same whether or not this run had anything to write.
+  const launchers = ensureLaunchers()
+  if (launchers.created.includes(command)) {
+    console.error(`\n[gitwarren] wrote ${command}, which the sentence above names.`)
+  } else if (!existsSync(command)) {
     // Not an error: the prompt above is still the right prompt, and it will be
     // true the moment the launcher exists. Worth a line on stderr all the same
     // - an agent handed this today would report a command that is not there.
     console.error(
-      `\n[gitwarren] no launcher at ${command} yet. \`gitwarren service install\` writes it.`
+      `\n[gitwarren] no launcher at ${command} yet, and this run could not write one` +
+        (launchers.refused ? `: ${launchers.refused}` : '.')
     )
   }
 

--- a/src/cli/browser.ts
+++ b/src/cli/browser.ts
@@ -1,0 +1,38 @@
+/**
+ * Hand a URL to the desktop's browser.
+ *
+ * Two commands need this and neither should own it: `gitwarren open` is the
+ * one it was written for, and `gitwarren serve --open` hands over the URL it
+ * has just printed. One implementation, because the rules below are the kind
+ * that are easy to get right once and easy to lose in a copy.
+ *
+ * `execFile`, never a shell: the URL carries a token and a fragment, and the
+ * one thing that must not happen to a string like that is word splitting by
+ * something that also understands `;`. Windows is the exception in shape rather
+ * than in rule - `start` is a `cmd` builtin and cannot be executed directly -
+ * and its empty `""` is the window *title*, which has to be there or `cmd`
+ * reads the quoted URL as one.
+ *
+ * Detached and unreferenced, because `open` and `xdg-open` on some desktops do
+ * not return until the browser they started exits, and the caller has nothing
+ * left to say once the URL is handed over.
+ *
+ * Failure is reported through `onError` rather than thrown: the browser
+ * launcher answers later, from a callback, and by then the command that asked
+ * may be a server that must not die because `xdg-open` is missing on a VPS.
+ */
+import { execFile } from 'node:child_process'
+
+export function openInBrowser(url: string, onError: (message: string) => void): void {
+  const [command, args]: [string, string[]] =
+    process.platform === 'darwin'
+      ? ['open', [url]]
+      : process.platform === 'win32'
+        ? ['cmd', ['/c', 'start', '', url]]
+        : ['xdg-open', [url]]
+
+  const child = execFile(command, args, { windowsHide: true }, (error) => {
+    if (error) onError(`could not ask ${command} to open a browser (${error.message})`)
+  })
+  child.unref()
+}

--- a/src/cli/launchers.ts
+++ b/src/cli/launchers.ts
@@ -1,6 +1,12 @@
 /**
  * The two generated files in `~/.gitwarren/bin`, written by the CLI.
  *
+ * Three commands write them: `service install`, whose job it is; and `serve`
+ * and `agent-setup`, for which they are a side effect (see `ensureLaunchers`
+ * at the bottom). The app writes the MCP one on every launch, and the CLI
+ * used to write it only when a login item was asked for - which sent a person
+ * who wanted an agent, and not a service, to a command about logging in.
+ *
  * `main/mcp-launch.ts` does the same job for the app, and the duplication is
  * deliberate rather than missed: what the two write is genuinely different -
  * the app names its own Electron binary in Node mode, the CLI names a real
@@ -23,12 +29,12 @@
 import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { getCliLauncherPath, getLauncherDirectory, getMcpLauncherPath } from '../core/mcp-launcher.js'
 import { cmdQuote, shellQuote } from '../core/shell-quote.js'
-import type { SelfDescription } from './install.js'
+import { describeSelf, type SelfDescription } from './install.js'
 
 const BANNER = (what: string): string[] => [
-  `GitWarren ${what}. Written by \`gitwarren service install\`, so a config or a`,
+  `GitWarren ${what}. Written by the gitwarren command line, so a config or a`,
   'login item that names this path keeps working when the install moves.',
-  'Generated file - run the command again, do not edit this.'
+  'Generated file - rerun `gitwarren service install` to refresh it, do not edit this.'
 ]
 
 /**
@@ -83,7 +89,8 @@ function windowsLauncher(what: string, self: SelfDescription, script: string): s
 }
 
 /**
- * Write one launcher if its contents would change.
+ * Write one launcher if its contents would change. True when the file did not
+ * exist before - the one case worth a sentence to the user.
  *
  * Compared before writing for the reason `ensureMcpLauncher` gives: this is a
  * file in the user's home directory, and churning its mtime for an identical
@@ -94,7 +101,7 @@ function windowsLauncher(what: string, self: SelfDescription, script: string): s
  * its executable bit, and a login item pointing at a non-executable file fails
  * in a way that names neither.
  */
-function write(path: string, contents: string): void {
+function write(path: string, contents: string): boolean {
   let current: string | null = null
   try {
     current = readFileSync(path, 'utf8')
@@ -107,12 +114,15 @@ function write(path: string, contents: string): void {
     writeFileSync(path, contents, 'utf8')
   }
   if (process.platform !== 'win32') chmodSync(path, 0o755)
+  return current === null
 }
 
 export interface WrittenLaunchers {
   cli: string
   /** Null when this install ships no MCP server - see `install.ts`. */
   mcp: string | null
+  /** The launchers that did not exist before this call. */
+  created: string[]
 }
 
 /**
@@ -133,14 +143,48 @@ export function writeLaunchers(self: SelfDescription): WrittenLaunchers {
   }
 
   const posix = process.platform !== 'win32'
+  const created: string[] = []
   const cli = getCliLauncherPath()
-  write(cli, (posix ? posixLauncher : windowsLauncher)('CLI', self, self.script))
+  if (write(cli, (posix ? posixLauncher : windowsLauncher)('CLI', self, self.script))) created.push(cli)
 
   let mcp: string | null = null
   if (self.mcpServer !== null) {
     mcp = getMcpLauncherPath()
-    write(mcp, (posix ? posixLauncher : windowsLauncher)('MCP server', self, self.mcpServer))
+    if (write(mcp, (posix ? posixLauncher : windowsLauncher)('MCP server', self, self.mcpServer)))
+      created.push(mcp)
   }
 
-  return { cli, mcp }
+  return { cli, mcp, created }
+}
+
+/**
+ * The launchers, as a side effect rather than as the point.
+ *
+ * `service install` is the command whose whole job is to write these, and it
+ * throws when it cannot. `gitwarren serve` and `gitwarren agent-setup` write
+ * them the way the app does on every launch - because a person who has just
+ * started GitWarren, or just asked how to point an agent at it, has said all
+ * they need to for `~/.gitwarren/bin/gitwarren-mcp` to exist - and neither of
+ * those may fail over it. A `serve` from a source checkout still has a page to
+ * serve; what it cannot do is name a file a login shell could run again, and
+ * that is a sentence on stderr, not a reason to stop.
+ *
+ * `describeSelf` is called here rather than by the caller so that the throw it
+ * can raise - no migrations folder to name - is caught in the same place as
+ * the checkout refusal. Both mean the same thing to the person reading it.
+ */
+export interface EnsuredLaunchers {
+  /** What was written for the first time, to be said once and not again. */
+  created: string[]
+  /** Why nothing was written, when nothing was. Null on success. */
+  refused: string | null
+}
+
+export function ensureLaunchers(): EnsuredLaunchers {
+  try {
+    const { created } = writeLaunchers(describeSelf())
+    return { created, refused: null }
+  } catch (error) {
+    return { created: [], refused: error instanceof Error ? error.message : String(error) }
+  }
 }

--- a/src/cli/open.ts
+++ b/src/cli/open.ts
@@ -19,8 +19,8 @@
  * for wanting one permanently, which is `gitwarren service install`. The
  * refusal names both.
  */
-import { execFile } from 'node:child_process'
 import { readFileSync } from 'node:fs'
+import { openInBrowser } from './browser.js'
 import { readLiveDaemonRuntime } from '../core/daemon-runtime.js'
 import { getWebTokenPath } from '../core/web/token.js'
 import { webUrlFor } from './target.js'
@@ -36,40 +36,6 @@ token so the tab is authenticated without anything being copied.
            piping somewhere.
 `
 
-/**
- * Hand a URL to the desktop.
- *
- * `execFile`, never a shell: the URL carries a token and a fragment, and the
- * one thing that must not happen to a string like that is word splitting by
- * something that also understands `;`. Windows is the exception in shape rather
- * than in rule - `start` is a `cmd` builtin and cannot be executed directly -
- * and its empty `""` is the window *title*, which has to be there or `cmd`
- * reads the quoted URL as one.
- *
- * Detached and unreferenced, because `open` and `xdg-open` on some desktops do
- * not return until the browser they started exits, and this command has nothing
- * left to say once the URL is handed over.
- */
-function openInBrowser(url: string): void {
-  const [command, args]: [string, string[]] =
-    process.platform === 'darwin'
-      ? ['open', [url]]
-      : process.platform === 'win32'
-        ? ['cmd', ['/c', 'start', '', url]]
-        : ['xdg-open', [url]]
-
-  const child = execFile(command, args, { windowsHide: true }, (error) => {
-    if (error) {
-      console.error(
-        `[gitwarren] could not ask ${command} to open a browser (${error.message}). ` +
-          `The URL is:\n\n    ${url}\n`
-      )
-      process.exitCode = 1
-    }
-  })
-  child.unref()
-}
-
 export function runOpen(argv: readonly string[]): boolean {
   const print = argv.includes('--print')
   const rest = argv.filter((argument) => argument !== '--print')
@@ -82,8 +48,9 @@ export function runOpen(argv: readonly string[]): boolean {
   const owner = readLiveDaemonRuntime()
   if (owner === null) {
     console.error(
-      '[gitwarren] nothing is serving this machine. Start it with `gitwarren serve`, or ' +
-        '`gitwarren service install` to have it start at login.'
+      '[gitwarren] GitWarren is not running on this machine, so there is nothing to open. ' +
+        '`gitwarren serve` runs it in a terminal; `gitwarren service install` keeps it ' +
+        'running in the background.'
     )
     process.exitCode = 1
     return true
@@ -126,7 +93,11 @@ export function runOpen(argv: readonly string[]): boolean {
   // and substituted, and a URL on stderr is the one thing that would make it
   // useless for that.
   if (print) console.log(url)
-  else openInBrowser(url)
+  else
+    openInBrowser(url, (message) => {
+      console.error(`[gitwarren] ${message}. The URL is:\n\n    ${url}\n`)
+      process.exitCode = 1
+    })
 
   return true
 }

--- a/src/cli/router.ts
+++ b/src/cli/router.ts
@@ -25,6 +25,8 @@
  */
 import { runDaemon } from '../daemon/daemon.js'
 import { runAgentSetup } from './agent-setup.js'
+import { openInBrowser } from './browser.js'
+import { ensureLaunchers } from './launchers.js'
 import { runOpen } from './open.js'
 import { runService } from './service.js'
 
@@ -33,22 +35,85 @@ declare const __APP_VERSION__: string
 
 const VERSION = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : '0.0.0-dev'
 
-const USAGE = `gitwarren - local-only code review, from the command line
+/**
+ * The usage block is the only documentation most people will read, so it is
+ * ordered by what a person wants rather than by what the code has: run it now,
+ * open it, keep it running, let an agent in. The pipe carrier is last and
+ * labelled as something a program asks for, because it is.
+ */
+const USAGE = `gitwarren - code review for your own git repositories, in a browser tab
 
-  gitwarren serve                serve the web view on loopback and print its URL
-  gitwarren serve --stdio        answer GitWarren's protocol on stdin/stdout
-  gitwarren open [link]          open this machine's GitWarren in a browser
-  gitwarren service install      write the launchers and start at login
-  gitwarren service uninstall    remove the login item
-  gitwarren service status       what is registered, and what is running
-  gitwarren agent-setup          print the sentence that points an agent here
+Run it now
+  gitwarren serve                run GitWarren in this terminal and print its URL
+                                 (--open also opens the browser; Ctrl-C stops it)
+  gitwarren open [link]          open the running GitWarren in your browser
+
+Keep it running
+  gitwarren service install      run GitWarren in the background, from now and at
+                                 every login
+  gitwarren service uninstall    stop that, and remove the login item
+  gitwarren service status       what is running, and where the data is
+
+Let a coding agent in
+  gitwarren agent-setup          print the one sentence to give an agent so it can
+                                 reach this GitWarren over MCP
+
+  gitwarren serve --stdio        answer GitWarren's protocol on stdin/stdout (this
+                                 is what another machine's GitWarren spawns)
   gitwarren --version
 
-Run a subcommand with no valid arguments to see its own usage.
+Run a subcommand with --help to see its own usage.
 
-The web view is served on 127.0.0.1 only, behind a token minted per launch.
-\`gitwarren open\` carries that token for you; see docs/across-hosts.md.
+GitWarren serves on 127.0.0.1 only, behind a token minted per launch, and
+\`gitwarren open\` carries that token for you. Reviews live in one SQLite file
+on this machine - serving, the background service and the MCP server all read
+the same one, so an agent can use GitWarren whether or not it is being served.
 `
+
+const SERVE_USAGE = `gitwarren serve [--open]
+gitwarren serve --stdio
+
+Runs GitWarren in this terminal, serving the review UI on 127.0.0.1 and printing
+a URL that carries this launch's token. Ctrl-C stops it.
+
+  --open    also open that URL in your browser
+  --stdio   answer GitWarren's protocol on stdin/stdout instead. This is what a
+            GitWarren on another machine spawns over ssh or wsl.exe; by hand it
+            is a way to see what the protocol says.
+
+Serving also writes ~/.gitwarren/bin/gitwarren-mcp, the command a coding agent
+starts the MCP server with - see \`gitwarren agent-setup\`.
+`
+
+/**
+ * What a person's `gitwarren serve` does once it is up, that a program's would
+ * not: it writes the launchers, the way the app does on every launch, and it
+ * opens the browser when asked to.
+ *
+ * The launchers come first and unconditionally. Until this, `gitwarren serve`
+ * followed by a look at the Agent Access page ended in an instruction to run
+ * `service install` - a command about logging in, to a person who wanted an
+ * agent. Serving is enough of a statement of intent, and what gets written is
+ * two files the person can read.
+ *
+ * Only what was *created* is announced. Every later `serve` finds them there
+ * and says nothing, which is the same silence the app keeps.
+ */
+function afterListening(url: string, open: boolean): void {
+  const launchers = ensureLaunchers()
+  if (launchers.refused) {
+    console.error(
+      `\n[gitwarren] no launcher was written to ~/.gitwarren/bin, so an agent has nothing to ` +
+        `start yet: ${launchers.refused}`
+    )
+  } else if (launchers.created.length > 0) {
+    console.error(`\n[gitwarren] wrote ${launchers.created.join(' and ')}`)
+  }
+
+  if (open) {
+    openInBrowser(url, (message) => console.error(`[gitwarren] ${message}. The URL is above.`))
+  }
+}
 
 /**
  * Run one command. False means "argv asked for something that is not a
@@ -60,11 +125,15 @@ export function runCli(argv: readonly string[]): boolean {
   const [command, ...rest] = argv
 
   switch (command) {
-    case 'serve':
+    case 'serve': {
+      if (rest.includes('--help') || rest.includes('-h')) {
+        console.log(SERVE_USAGE)
+        return true
+      }
       // Neither carrier named: the person in front of it meant the web view.
-      return runDaemon(
-        rest.includes('--stdio') || rest.includes('--listen') ? rest : [...rest, '--listen']
-      )
+      const argv = rest.includes('--stdio') || rest.includes('--listen') ? rest : [...rest, '--listen']
+      return runDaemon(argv, { onListening: (url) => afterListening(url, rest.includes('--open')) })
+    }
 
     case 'open':
       return runOpen(rest)

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -35,7 +35,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { readLiveDaemonRuntime } from '../core/daemon-runtime.js'
-import { getCliLauncherPath } from '../core/mcp-launcher.js'
+import { getCliLauncherPath, getMcpLauncherPath } from '../core/mcp-launcher.js'
 import { getDataDirectory } from '../core/paths.js'
 import { describeSelf } from './install.js'
 import { writeLaunchers } from './launchers.js'
@@ -52,11 +52,18 @@ const USAGE = `gitwarren service install [--no-login-item]
 gitwarren service uninstall
 gitwarren service status
 
-install   writes ~/.gitwarren/bin/gitwarren and gitwarren-mcp, and registers a
-          login item that runs \`gitwarren serve --listen\`.
-uninstall removes the login item. The launchers stay: an agent config may name
-          one, and removing a login item is not a request to break that.
-status    says what is registered and what is running.
+install    keeps GitWarren running in the background: it starts now, and again
+           at every login, so \`gitwarren open\` and the links an agent hands
+           you always have something to open. Registers a LaunchAgent on
+           macOS, a systemd user unit on Linux, an at-logon task on Windows.
+           Also writes ~/.gitwarren/bin/gitwarren and gitwarren-mcp, the
+           stable paths the app and an agent start this install by.
+           --no-login-item writes those two files and registers nothing,
+           for a machine that is only ever reached from another one.
+uninstall  stops the background GitWarren and removes the login item. The two
+           files in ~/.gitwarren/bin stay, because an agent config may name
+           one; delete that directory by hand to remove them.
+status     what is registered, what is running, and where the data is.
 `
 
 /** `~/Library/Logs/GitWarren/daemon.log`. macOS only - see `units.ts`. */
@@ -141,6 +148,11 @@ function registerLoginItem(launcher: string): string {
       'ONLOGON',
       '/F'
     ])
+    // Started now as well as at logon, for the reason the systemd branch gives
+    // `--now`: the command a user just typed should have a visible effect, and
+    // "log out and back in" is not one. `ask` rather than `must` because a
+    // task that refuses to run this instant is still registered.
+    ask('schtasks', ['/Run', '/TN', WINDOWS_TASK])
     return `Scheduled Task "${WINDOWS_TASK}"`
   }
 
@@ -225,22 +237,38 @@ function install(argv: readonly string[]): boolean {
   }
 
   if (argv.includes('--no-login-item')) {
-    console.log('--no-login-item: nothing was registered to start at login.')
+    console.log('Nothing was registered to start at login (--no-login-item).')
     return true
   }
 
-  console.log(registerLoginItem(cli) + ' will run `gitwarren serve --listen` at login.')
+  // Whoever holds the data directory *before* the item is registered, because
+  // registering starts the daemon, and a moment later the answer would be
+  // "the daemon" whether or not it is about to stand aside.
+  const owner = readLiveDaemonRuntime()
+
+  console.log(`registered ${registerLoginItem(cli)}`)
 
   // Said after the fact rather than as a refusal. The user asked for a login
   // item and now has one; what they also have is an app that will win the race
   // for the port every time, and finding that out in three weeks by wondering
   // why the daemon is never up is worse than a sentence now.
-  const owner = readLiveDaemonRuntime()
   if (owner?.owner === 'gui') {
     console.log(
-      '\nGitWarren.app is running and owns this data directory. A data directory has one ' +
-        'owner, so the daemon will stand aside whenever the app is up - which is fine, and ' +
-        'means the login item only does something on the logins where you do not open it.'
+      '\nThe desktop app is running and owns this data directory, so the background ' +
+        'GitWarren has stood aside for now. Only one can serve at a time; the login item ' +
+        'does its job on the logins where you do not open the app.'
+    )
+  } else if (owner !== null) {
+    console.log(
+      '\nA `gitwarren serve` is already running in a terminal, so the background GitWarren ' +
+        'has stood aside for now. Stop that one and it takes over at the next login, or ' +
+        'straight away if you run `gitwarren service install` again.'
+    )
+  } else {
+    console.log(
+      '\nGitWarren is now running in the background, and will start again when you log in. ' +
+        '`gitwarren open` opens it in your browser; `gitwarren service uninstall` undoes ' +
+        'all of this.'
     )
   }
 
@@ -259,23 +287,26 @@ export function runService(argv: readonly string[]): boolean {
       case 'uninstall':
         console.log(`removed ${removeLoginItem()}`)
         console.log(
-          'The launchers in ~/.gitwarren/bin were left alone. Delete them by hand if an ' +
-            'agent no longer needs to reach this machine.'
+          'GitWarren no longer runs in the background or starts at login. `gitwarren serve` ' +
+            'still runs it in a terminal. The two files in ~/.gitwarren/bin were left alone, ' +
+            'because an agent config may name one; delete that directory to remove them.'
         )
         return true
 
       case 'status': {
         const owner = readLiveDaemonRuntime()
-        console.log(`Login item:  ${loginItemState()}`)
-        console.log(`Launcher:    ${existsSync(getCliLauncherPath()) ? getCliLauncherPath() : 'not written'}`)
+        const mcp = getMcpLauncherPath()
+        console.log(`Login item:    ${loginItemState()}`)
+        console.log(`CLI launcher:  ${existsSync(getCliLauncherPath()) ? getCliLauncherPath() : 'not written'}`)
+        console.log(`MCP launcher:  ${existsSync(mcp) ? mcp : 'not written - `gitwarren agent-setup` writes it'}`)
         console.log(
-          `Serving now: ${
+          `Running now:   ${
             owner === null
-              ? 'nothing'
-              : `${owner.owner === 'gui' ? 'GitWarren.app' : 'gitwarren serve'} (pid ${owner.pid})`
+              ? 'nothing - `gitwarren serve` runs it in this terminal'
+              : `${owner.owner === 'gui' ? 'the desktop app' : 'gitwarren serve'} (pid ${owner.pid})`
           }`
         )
-        console.log(`Data:        ${getDataDirectory()}`)
+        console.log(`Data:          ${getDataDirectory()}`)
         return true
       }
 

--- a/src/core/mcp-launcher.ts
+++ b/src/core/mcp-launcher.ts
@@ -33,7 +33,8 @@ export function getMcpLauncherPath(): string {
 }
 
 /**
- * The CLI's own stable path, written by `gitwarren service install`.
+ * The CLI's own stable path, written by `gitwarren service install` and, since
+ * the launchers became a side effect of serving, by `gitwarren serve` too.
  *
  * `.cmd` on Windows for the same reason the MCP launcher takes it: a file the
  * Task Scheduler and a user's own shell both have to be able to run has to be
@@ -77,6 +78,6 @@ export function describeMcpLaunch(): McpLaunchInfo {
     direct: { command: launcher, args: [], env: {} },
     note: available
       ? undefined
-      : 'No MCP launcher on this machine yet. `gitwarren service install` writes it.'
+      : 'No MCP launcher on this machine yet. `gitwarren agent-setup` writes it, and so does `gitwarren serve`.'
   }
 }

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -45,7 +45,7 @@ import { getInstanceId } from '../core/instance.js'
 import { getDatabasePath } from '../core/paths.js'
 import { serveStdio } from '../core/rpc/stdio.js'
 import { DAEMON_READY_PREFIX, RPC_PROTOCOL_VERSION } from '../shared/rpc.js'
-import { runListen } from './listen.js'
+import { runListen, type ListenHooks } from './listen.js'
 
 const USAGE = `gitwarren serve --stdio
 gitwarren serve --listen
@@ -58,20 +58,26 @@ hand it is a way to see what the protocol says:
 
 --listen serves the web view on loopback and prints a URL carrying this
 launch's token. It claims this machine's data directory, so it refuses to
-start while the app is running - see daemon/listen.ts.
+start while the app is running - see daemon/listen.ts. \`gitwarren serve\` with
+no flag means this one.
 `
 
 /**
  * Start the daemon. Returns false when argv asked for something that is not a
  * carrier, so the caller can decide whether that is a usage error or a
  * different mode of its own - `main/index.ts` reuses this for `--serve`.
+ *
+ * `hooks` belong to `--listen` alone and are what the CLI does once a human's
+ * server is up - write the launchers, open a browser. They are passed through
+ * rather than done here because this file must stay free of anything a
+ * `--stdio` daemon spawned over ssh would not want.
  */
-export function runDaemon(argv: readonly string[]): boolean {
+export function runDaemon(argv: readonly string[], hooks: ListenHooks = {}): boolean {
   // Checked before `--stdio` only because it is the mode that can *refuse*, and
   // its refusals are sentences rather than a usage block. The two are exclusive:
   // one binds a port and owns the machine, the other answers a pipe and owns
   // nothing.
-  if (argv.includes('--listen')) return runListen()
+  if (argv.includes('--listen')) return runListen(hooks)
 
   if (!argv.includes('--stdio')) {
     console.error(USAGE)

--- a/src/daemon/listen.ts
+++ b/src/daemon/listen.ts
@@ -175,6 +175,18 @@ function whereTheOwnerIs(owner: DaemonRuntime): string {
 }
 
 /**
+ * What the CLI wants done once the server is up, and not before.
+ *
+ * Both are things a person - never a spawning program - asked for by typing
+ * `gitwarren serve`, and both belong after the bind rather than before it: a
+ * refusal to start should write nothing and open nothing.
+ */
+export interface ListenHooks {
+  /** Called once, with the URL that was just printed. */
+  onListening?: (url: string) => void
+}
+
+/**
  * Bind, publish, and print the one URL that works.
  *
  * Returns false when it could not start, so the CLI entry can exit with something
@@ -182,13 +194,21 @@ function whereTheOwnerIs(owner: DaemonRuntime): string {
  * it: this is a command someone typed, and an exit code on its own is not an
  * answer.
  */
-export function runListen(): boolean {
+export function runListen(hooks: ListenHooks = {}): boolean {
   const owner = readLiveDaemonRuntime()
   if (owner) {
+    // The background service is the likeliest "another gitwarren serve" on a
+    // machine where someone has just typed this, and it is the one the person
+    // cannot see in a terminal - so it gets named, and so does the way to stop
+    // it.
+    const who =
+      owner.owner === 'gui'
+        ? 'the desktop app'
+        : 'another `gitwarren serve`, in a terminal or as the background service ' +
+          '(which `gitwarren service uninstall` stops)'
     console.error(
-      `[gitwarren-serve] this machine's GitWarren is already being served by ` +
-        `${owner.owner === 'gui' ? 'the app' : 'another gitwarren serve'} (pid ${owner.pid}). ` +
-        `A data directory has one owner. Quit that first, or use the one that is running` +
+      `[gitwarren] GitWarren is already running on this machine (pid ${owner.pid}), as ${who}. ` +
+        `Only one can serve a data directory at a time. Quit that first, or use the one that is running` +
         whereTheOwnerIs(owner)
     )
     process.exitCode = 1
@@ -198,7 +218,7 @@ export function runListen(): boolean {
   const webRoot = resolveWebRoot()
   if (!webRoot) {
     console.error(
-      '[gitwarren-serve] no web build found. Run `npm run build:web`, or set ' +
+      '[gitwarren] no web build found. Run `npm run build:web`, or set ' +
         'GITWARREN_WEB_ROOT to the directory holding its index.html.'
     )
     process.exitCode = 1
@@ -237,12 +257,12 @@ export function runListen(): boolean {
   server.on('error', (error: NodeJS.ErrnoException) => {
     if (error.code === 'EADDRINUSE') {
       console.error(
-        `[gitwarren-serve] port ${LINK_SERVER_PORT} is already in use. That port is the one ` +
+        `[gitwarren] port ${LINK_SERVER_PORT} is already in use. That port is the one ` +
           `every GitWarren link names, so serving on a different one would mean serving where ` +
           `nobody is looking. Free it and start again.`
       )
     } else {
-      console.error('[gitwarren-serve] the server failed', error)
+      console.error('[gitwarren] the server failed', error)
     }
     shutdownListen()
     process.exitCode = 1
@@ -260,12 +280,21 @@ export function runListen(): boolean {
     // stderr, like every other diagnostic here: stdout belongs to the protocol
     // in the other carrier and there is no reason for the two to disagree about
     // which stream a human message goes on.
+    //
+    // The three sentences after the URL are the whole of what a person who has
+    // just typed `gitwarren serve` for the first time needs: why the URL looks
+    // like that, how to stop this, and that there is a way not to have to run
+    // it by hand. Each was a question in somebody's first ten minutes.
+    const url = `http://${LINK_SERVER_HOST}:${LINK_SERVER_PORT}/?${TOKEN_PARAM}=${token}`
     console.error(
-      `[gitwarren-serve] GitWarren is at\n\n` +
-        `    http://${LINK_SERVER_HOST}:${LINK_SERVER_PORT}/?${TOKEN_PARAM}=${token}\n\n` +
-        `The token is new each time this starts, and is exchanged for a session cookie the ` +
-        `first time the URL is opened.`
+      `[gitwarren] GitWarren is running at\n\n` +
+        `    ${url}\n\n` +
+        `Open that URL, or run \`gitwarren open\` in another terminal. The token in it is ` +
+        `minted for this launch and becomes a cookie the first time the page loads.\n` +
+        `Press Ctrl-C to stop. To keep GitWarren running in the background instead, ` +
+        `from now and at every login, use \`gitwarren service install\`.`
     )
+    hooks.onListening?.(url)
   })
 
   closeOnExit = () => {


### PR DESCRIPTION
## Why

The first install on a Linux box read the formula's caveats — `serve`, `open`, `service install` — and could not tell which one it wanted; `uninstall` was missing from every place a newcomer looked. Underneath the wording was a model worth fixing: the MCP launcher at `~/.gitwarren/bin/gitwarren-mcp` was written by `service install` alone, so `gitwarren serve` followed by a look at the Agent Access page ended in an instruction to register a login item.

## What changed

**CLI**
- `gitwarren serve` writes both launchers once it is listening (the way the app writes the MCP one on every launch), announces only what it created, and never fails over it — a checkout gets a sentence on stderr. New `--open` flag. New success message: the URL, how to open it, Ctrl-C, and that `service install` exists.
- `gitwarren agent-setup` writes the launcher it names instead of pointing at `service install`.
- `gitwarren service install` reports the outcome in plain words ("running in the background, and will start again when you log in"), names what happens when the app or a terminal `serve` already holds the directory, and on Windows runs the task right away as the other two platforms already did. `uninstall` and `status` reworded; `status` shows the MCP launcher.
- `--help` grouped by intent: run it now / keep it running / let a coding agent in; `serve --help` added; the refusal when something already serves names the background service and how to stop it; `open`'s refusal reworded.
- `openInBrowser` moved to `src/cli/browser.ts`, shared by `open` and `serve --open`. `runDaemon` takes optional listen hooks; `--stdio` is untouched.

**Distribution**
- `packaging/install.sh`: `curl -fsSL https://gitwarren.com/install.sh | sh` for Linux and macOS without Homebrew. Same layout as the SSH installer (`~/.gitwarren/daemon/<version>/` + the stable launcher), sha256 checked against the release's own `gitwarren-cli.rb`, `GITWARREN_VERSION` pins a release, wget fallback. The site PR adds the redirect.
- Homebrew caveats rewritten around the three intents; npm README and the app README likewise. Design log entry added.

## Verified

- `npm run typecheck`, `npm run lint` (one pre-existing warning in `repository-detail.tsx`), `npm test` 607 pass / 0 fail, plus a new `router.test.ts`.
- Bare `ubuntu:24.04` container with this worktree's linux-x64 tarball: `serve` wrote the launchers and printed the new sentences; `open` reported the missing xdg-open with the URL; a second `serve` refused with the first one's URL; `status` before/during/after; `initialize` answered through `~/.gitwarren/bin/gitwarren-mcp`; `service install --no-login-item`; `agent-setup`.
- `install.sh` against v0.1.8 on this Mac (darwin-arm64, rerun detection, pinned version) and in the container with curl, then with wget only.
- Not re-exercised: `service install` on a real systemd/launchd/schtasks — only wording changed there, plus the Windows `/Run`.

Companion PRs: klarluft/gitwarren-site#16 (docs, redirect), klarluft/homebrew-tap (README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3kxaiF5vBXuCvY65hbiTa
